### PR TITLE
feat(android): optimize BLE scan/advertise frequency with hybrid mode

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -122,6 +122,11 @@ internal class BarnardController(
 
     private val knownPeers: MutableMap<String, KnownPeer> = mutableMapOf()
 
+    // Hybrid scan: start with LOW_LATENCY, transition to BALANCED after delay
+    private val scanModeTransitionDelayMs: Long = 15_000
+    private var scanModeTransitionRunnable: Runnable? = null
+    private var currentScanMode: Int = ScanSettings.SCAN_MODE_LOW_LATENCY
+
     // MARK: - Storage
 
     private val prefs: SharedPreferences =
@@ -402,33 +407,33 @@ internal class BarnardController(
             }
         }
 
-        val settings = ScanSettings.Builder()
-            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
-            .setReportDelay(0)
-            .build()
-
-        // Create fresh callback
-        val cb = createScanCallback()
-        scanCallback = cb
-
-        // Filter by Barnard service UUID for efficiency
-        val filter = ScanFilter.Builder()
-            .setServiceUuid(ParcelUuid(serviceUuid))
-            .build()
-
-        Log.i(TAG, "Starting BLE scan with scanner: $s, callback: $cb, filter: $serviceUuid")
-        s.startScan(listOf(filter), settings, cb)
+        // Start with LOW_LATENCY for fast initial discovery
+        currentScanMode = ScanSettings.SCAN_MODE_LOW_LATENCY
+        startScanWithMode(s, currentScanMode)
         isScanning = true
 
-        // Flush any pending results
-        s.flushPendingScanResults(cb)
-        Log.i(TAG, "BLE scan started (LOW_LATENCY, service UUID filter)")
         emitState("scan_start")
-        emitDebug("info", "scan_start", mapOf("allowDuplicates" to allowDuplicates))
+        emitDebug("info", "scan_start", mapOf(
+            "allowDuplicates" to allowDuplicates,
+            "scanMode" to "LOW_LATENCY",
+            "transitionDelayMs" to scanModeTransitionDelayMs
+        ))
+
+        // Schedule transition to BALANCED mode after delay
+        scanModeTransitionRunnable = Runnable {
+            if (isScanning) {
+                transitionToBalancedScan()
+            }
+        }
+        mainHandler.postDelayed(scanModeTransitionRunnable!!, scanModeTransitionDelayMs)
     }
 
     private fun stopScan() {
         if (!isScanning) return
+        // Cancel pending scan mode transition
+        scanModeTransitionRunnable?.let { mainHandler.removeCallbacks(it) }
+        scanModeTransitionRunnable = null
+
         scanCallback?.let { cb ->
             if (hasScanPermission()) {
                 adapter?.bluetoothLeScanner?.stopScan(cb)
@@ -450,6 +455,53 @@ internal class BarnardController(
 
         emitState("scan_stop")
         emitDebug("info", "scan_stop", null)
+    }
+
+    private fun startScanWithMode(scanner: BluetoothLeScanner, scanMode: Int) {
+        val settings = ScanSettings.Builder()
+            .setScanMode(scanMode)
+            .setReportDelay(0)
+            .build()
+
+        val cb = createScanCallback()
+        scanCallback = cb
+
+        val filter = ScanFilter.Builder()
+            .setServiceUuid(ParcelUuid(serviceUuid))
+            .build()
+
+        val modeName = when (scanMode) {
+            ScanSettings.SCAN_MODE_LOW_LATENCY -> "LOW_LATENCY"
+            ScanSettings.SCAN_MODE_BALANCED -> "BALANCED"
+            ScanSettings.SCAN_MODE_LOW_POWER -> "LOW_POWER"
+            else -> "UNKNOWN"
+        }
+        Log.i(TAG, "Starting BLE scan with mode: $modeName")
+        scanner.startScan(listOf(filter), settings, cb)
+        scanner.flushPendingScanResults(cb)
+    }
+
+    private fun transitionToBalancedScan() {
+        val scanner = adapter?.bluetoothLeScanner ?: return
+        if (!hasScanPermission()) return
+
+        // Stop current scan
+        scanCallback?.let { cb ->
+            try {
+                scanner.stopScan(cb)
+            } catch (e: Exception) {
+                Log.w(TAG, "stopScan for transition failed: ${e.message}")
+            }
+        }
+
+        // Restart with BALANCED mode
+        currentScanMode = ScanSettings.SCAN_MODE_BALANCED
+        startScanWithMode(scanner, currentScanMode)
+
+        emitDebug("info", "scan_mode_transition", mapOf(
+            "from" to "LOW_LATENCY",
+            "to" to "BALANCED"
+        ))
     }
 
     // MARK: - Advertise Control
@@ -508,7 +560,7 @@ internal class BarnardController(
         }
 
         val settings = AdvertiseSettings.Builder()
-            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_BALANCED)
             .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
             .setConnectable(true)
             .build()


### PR DESCRIPTION
## Summary
- Implement hybrid scan: LOW_LATENCY (15s) → BALANCED (continuous)
- Change advertise mode from LOW_LATENCY to BALANCED
- Add debug events for scan mode transitions

## Rationale
Reduces battery consumption while maintaining fast initial discovery.

| Phase | Mode | Interval | Purpose |
|-------|------|----------|---------|
| Initial | LOW_LATENCY | ~100ms | Fast device discovery |
| Continuous | BALANCED | ~4-5s | Battery efficiency |

## UX Impact (after merge)

### Improvements
- **Battery drain reduced** during long sessions. The "phone gets warm / battery drops fast after 30 min scanning" symptom should be noticeably mitigated.
- **Advertising side also lighter**: broadcast interval relaxes from ~100ms to ~250ms, lowering radio on-time on the peripheral side.
- **Initial discovery unchanged**: first 15 seconds still scan at ~100ms — no regression in "app open → first peer shown" latency.

### Tradeoffs users will feel
- **After 15s, new-peer discovery latency increases** from ~100ms to ~4–5s. Someone walking into a venue after initial setup may be detected 2–4s later than today.
- **Known-peer RSSI update rate drops** (interacts with #37's `rssi_update` feature). While in BALANCED, proximity UI (distance readout, approach indicators) refreshes every ~4–5s instead of every ~100ms. Real-time proximity tracking is only "real-time" during the first 15s; after that, it is coarse-grained.
- **Peripheral visibility latency** rises a few hundred ms on average — scanners on the other side may see this device ~100–300ms later than today.

### Net effect for typical use cases
- **Crowd detection at an event**: fine — initial 15s gives fast headcount, BALANCED is sufficient for "still here" updates.
- **Close-range proximity game / greeting UX**: the first handshake remains snappy, but post-connection RSSI tracking becomes low-rate. If sub-second proximity is required, the app should trigger a fresh `startScan` cycle to regain the 15s LOW_LATENCY window.

### Observability
- Emits `scan_mode_transition` debug event on downgrade (LOW_LATENCY → BALANCED). Useful for QA to confirm the timing and for apps to key UI state off of it.

## Test plan
- [ ] Verify initial scan discovers devices quickly (<1s)
- [ ] Verify scan mode transitions after 15s (check debug events)
- [ ] Verify battery consumption is reduced in continuous operation

Closes #26