### PR TITLE
fix(ble): clear discovery state on stopScan for accurate device count

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -243,6 +243,12 @@ internal class BarnardController(
         connectQueue.clear()
         activeGatt?.close()
         activeGatt = null
+
+        // Clear discovery state for clean restart
+        discoveredRssi.clear()
+        discoveredAt.clear()
+        lastConnectAttemptAtMs.clear()
+
         emitState("scan_stop")
         emitDebug("info", "scan_stop", null)
     }

--- a/packages/dart/barnard/ios/Classes/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardBleController.swift
@@ -141,6 +141,13 @@ final class BarnardBleController: NSObject {
     isScanning = false
     connectQueue.removeAll()
     activePeripheral = nil
+
+    // Clear discovery state for clean restart
+    discoveredRssi.removeAll()
+    discoveredAt.removeAll()
+    peripheralsById.removeAll()
+    lastConnectAttemptAt.removeAll()
+
     emitState(reasonCode: "scan_stop")
     emitDebug(level: "info", name: "scan_stop", data: nil)
   }


### PR DESCRIPTION
## Summary

- BLEスキャン停止時に発見デバイスの状態をクリアするように修正
- Android: `discoveredRssi`, `discoveredAt`, `lastConnectAttemptAtMs` をクリア
- iOS: `discoveredRssi`, `discoveredAt`, `peripheralsById`, `lastConnectAttemptAt` をクリア

Fixes #28

## Test plan

- [x] exampleアプリをビルド・起動
- [x] BLEスキャンを開始し、デバイスが認識されることを確認
- [x] スキャンを停止
- [x] 再度スキャンを開始し、デバイス認識数が正確であることを確認
- [x] 上記を5-10回繰り返し、一貫した動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)