### PR TITLE
feat(flutter): implement GAEN-compatible resolvable ID

### DIFF
--- a/examples/flutter/barnard_poc/ios/Podfile
+++ b/examples/flutter/barnard_poc/ios/Podfile
@@ -1,5 +1,4 @@
-# Uncomment this line to define a global platform for your project
-# platform :ios, '13.0'
+platform :ios, '14.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/examples/flutter/barnard_poc/ios/Podfile.lock
+++ b/examples/flutter/barnard_poc/ios/Podfile.lock
@@ -24,11 +24,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
-  barnard: 10682d3027e78b5cd32ab70f5ccd5f9624b7634b
+  barnard: fe0cf3540273ece12718057a3adfbe6b01ef32b8
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
 
-PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+PODFILE CHECKSUM: d71a8f9d234bf288cee64b372c30c196c8075224
 
 COCOAPODS: 1.16.2

--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -21,6 +21,10 @@ class _MyAppState extends State<MyApp> {
   StreamSubscription<BarnardEvent>? _eventsSub;
   StreamSubscription<BarnardDebugEvent>? _debugSub;
 
+  final TextEditingController _eventCodeController = TextEditingController(
+    text: "BND",
+  );
+
   BarnardState _state = BarnardState.idle;
   final List<BarnardEvent> _events = <BarnardEvent>[];
   final List<BarnardDebugEvent> _debugEvents = <BarnardDebugEvent>[];
@@ -55,6 +59,7 @@ class _MyAppState extends State<MyApp> {
     _eventsSub?.cancel();
     _debugSub?.cancel();
     _client?.dispose();
+    _eventCodeController.dispose();
     _uiTicker?.cancel();
     super.dispose();
   }
@@ -76,7 +81,8 @@ class _MyAppState extends State<MyApp> {
       if (!mounted) return;
       setState(() {
         _debugEvents.add(e);
-        if (_debugEvents.length > 200) _debugEvents.removeRange(0, _debugEvents.length - 200);
+        if (_debugEvents.length > 200)
+          _debugEvents.removeRange(0, _debugEvents.length - 200);
         _updateSelfInfo(e);
       });
     });
@@ -84,6 +90,10 @@ class _MyAppState extends State<MyApp> {
     setState(() {
       _client = client;
       _state = client.state;
+      if (client.currentEventCode != null &&
+          client.currentEventCode!.isNotEmpty) {
+        _eventCodeController.text = client.currentEventCode!;
+      }
     });
   }
 
@@ -99,7 +109,9 @@ class _MyAppState extends State<MyApp> {
     await perms.request();
   }
 
-  Future<void> _run(Future<void> Function(BarnardBleClient client) action) async {
+  Future<void> _run(
+    Future<void> Function(BarnardBleClient client) action,
+  ) async {
     final BarnardBleClient? client = _client;
     if (client == null) return;
     if (_busy) return;
@@ -111,12 +123,26 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
+  Future<void> _ensureEventJoined(BarnardBleClient client) async {
+    if (client.currentMode == EventMode.event) return;
+    final String code = _eventCodeController.text.trim();
+    if (code.isEmpty) return;
+    await client.joinEvent(code);
+  }
+
   @override
   Widget build(BuildContext context) {
     final BarnardBleClient? client = _client;
     final int detections = _events.whereType<DetectionEvent>().length;
-    final int issues = _events.where((BarnardEvent e) => e is ConstraintEvent || e is ErrorEvent).length;
-    final int debugIssues = _debugEvents.where((BarnardDebugEvent e) => e.level == DebugLevel.warn || e.level == DebugLevel.error).length;
+    final int issues = _events
+        .where((BarnardEvent e) => e is ConstraintEvent || e is ErrorEvent)
+        .length;
+    final int debugIssues = _debugEvents
+        .where(
+          (BarnardDebugEvent e) =>
+              e.level == DebugLevel.warn || e.level == DebugLevel.error,
+        )
+        .length;
     final DateTime now = DateTime.now();
     final List<_SeenEntry> seen = _seenById.values.toList()
       ..sort((_SeenEntry a, _SeenEntry b) => b.lastSeen.compareTo(a.lastSeen));
@@ -124,220 +150,318 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(title: const Text("Barnard BLE PoC (GATT-first)")),
-        body:
-            client == null
-                ? const Center(child: CircularProgressIndicator())
-                : Column(
-                  children: <Widget>[
-                    Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: <Widget>[
-                          FilledButton(
-                            onPressed:
-                                _busy ? null : () => _run((c) => c.startScan(const ScanConfig(allowDuplicates: true))),
-                            child: const Text("Start Scan"),
+        body: client == null
+            ? const Center(child: CircularProgressIndicator())
+            : Column(
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: <Widget>[
+                        SizedBox(
+                          width: 240,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              TextField(
+                                controller: _eventCodeController,
+                                decoration: const InputDecoration(
+                                  labelText: "Event Code",
+                                  isDense: true,
+                                  border: OutlineInputBorder(),
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                "Auto-join on Start",
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: Colors.black54,
+                                ),
+                              ),
+                            ],
                           ),
-                          OutlinedButton(
-                            onPressed: _busy ? null : () => _run((c) => c.stopScan()),
-                            child: const Text("Stop Scan"),
-                          ),
-                          FilledButton(
-                            onPressed: _busy ? null : () => _run((c) => c.startAdvertise(const AdvertiseConfig())),
-                            child: const Text("Start Advertise"),
-                          ),
-                          OutlinedButton(
-                            onPressed: _busy ? null : () => _run((c) => c.stopAdvertise()),
-                            child: const Text("Stop Advertise"),
-                          ),
-                          FilledButton(
-                            onPressed: _busy ? null : () => _run((c) => c.startAuto(const AutoConfig())),
-                            child: const Text("Start Auto"),
-                          ),
-                          OutlinedButton(
-                            onPressed: _busy ? null : () => _run((c) => c.stopAuto()),
-                            child: const Text("Stop Auto"),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      child: Row(
-                        children: <Widget>[
-                          Expanded(child: Text("State: $_state")),
-                          Text("caps: ${client.capabilities.supportedTransports.map((e) => e.name).join(",")}"),
-                        ],
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                      child: Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: <Widget>[
-                          _StatChip(label: "events", value: _events.length),
-                          _StatChip(label: "detections", value: detections),
-                          _StatChip(label: "issues", value: issues),
-                          _StatChip(label: "debug", value: _debugEvents.length),
-                          _StatChip(label: "debug issues", value: debugIssues),
-                          TextButton(
-                            onPressed:
-                                _events.isEmpty
-                                    ? null
-                                    : () => setState(() => _events.clear()),
-                            child: const Text("Clear Events"),
-                          ),
-                          TextButton(
-                            onPressed:
-                                _debugEvents.isEmpty
-                                    ? null
-                                    : () => setState(() => _debugEvents.clear()),
-                            child: const Text("Clear Debug"),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                      child: Card(
-                        child: ExpansionTile(
-                          initiallyExpanded: _diagExpanded,
-                          onExpansionChanged: (bool v) => setState(() => _diagExpanded = v),
-                          title: const Text("Diagnostics"),
-                          subtitle: const Text("Self advertise + recently seen"),
-                          childrenPadding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
-                          children: <Widget>[
-                            _SelfAdvertiseCard(
-                              isAdvertising: _state.isAdvertising,
-                              serviceUuid: _selfInfo.serviceUuid ?? _serviceUuid,
-                              localName: _selfInfo.localName ?? _localName,
-                              formatVersion: _selfInfo.formatVersion ?? 1,
-                              lastDisplayId: _selfInfo.lastDisplayId,
-                              lastPayloadAt: _selfInfo.lastPayloadAt,
-                              staleAfter: _staleAfter,
-                              now: now,
-                            ),
-                            const SizedBox(height: 8),
-                            _SeenCard(
-                              seen: seen,
-                              now: now,
-                              staleAfter: _staleAfter,
-                            ),
-                          ],
                         ),
+                        FilledButton(
+                          onPressed: _busy
+                              ? null
+                              : () => _run((c) async {
+                                  await _ensureEventJoined(c);
+                                  await c.startScan(
+                                    const ScanConfig(allowDuplicates: true),
+                                  );
+                                }),
+                          child: const Text("Start Scan"),
+                        ),
+                        OutlinedButton(
+                          onPressed: _busy
+                              ? null
+                              : () => _run((c) => c.stopScan()),
+                          child: const Text("Stop Scan"),
+                        ),
+                        FilledButton(
+                          onPressed: _busy
+                              ? null
+                              : () => _run((c) async {
+                                  await _ensureEventJoined(c);
+                                  await c.startAdvertise(
+                                    const AdvertiseConfig(),
+                                  );
+                                }),
+                          child: const Text("Start Advertise"),
+                        ),
+                        OutlinedButton(
+                          onPressed: _busy
+                              ? null
+                              : () => _run((c) => c.stopAdvertise()),
+                          child: const Text("Stop Advertise"),
+                        ),
+                        FilledButton(
+                          onPressed: _busy
+                              ? null
+                              : () => _run((c) async {
+                                  await _ensureEventJoined(c);
+                                  await c.startAuto(const AutoConfig());
+                                }),
+                          child: const Text("Start Auto"),
+                        ),
+                        OutlinedButton(
+                          onPressed: _busy
+                              ? null
+                              : () => _run((c) => c.stopAuto()),
+                          child: const Text("Stop Auto"),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: Text(
+                            "State: $_state mode=${client.currentMode.name} event=${client.currentEventCode ?? "-"}",
+                          ),
+                        ),
+                        Text(
+                          "caps: ${client.capabilities.supportedTransports.map((e) => e.name).join(",")}",
+                        ),
+                        const SizedBox(width: 8),
+                        Text("debugName: ${_selfInfo.localName ?? _localName}"),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    child: Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: <Widget>[
+                        _StatChip(label: "events", value: _events.length),
+                        _StatChip(label: "detections", value: detections),
+                        _StatChip(label: "issues", value: issues),
+                        _StatChip(label: "debug", value: _debugEvents.length),
+                        _StatChip(label: "debug issues", value: debugIssues),
+                        TextButton(
+                          onPressed: _events.isEmpty
+                              ? null
+                              : () => setState(() => _events.clear()),
+                          child: const Text("Clear Events"),
+                        ),
+                        TextButton(
+                          onPressed: _debugEvents.isEmpty
+                              ? null
+                              : () => setState(() => _debugEvents.clear()),
+                          child: const Text("Clear Debug"),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
+                    child: Card(
+                      child: ExpansionTile(
+                        initiallyExpanded: _diagExpanded,
+                        onExpansionChanged: (bool v) =>
+                            setState(() => _diagExpanded = v),
+                        title: const Text("Diagnostics"),
+                        subtitle: const Text("Self advertise + recently seen"),
+                        childrenPadding: const EdgeInsets.fromLTRB(
+                          12,
+                          0,
+                          12,
+                          12,
+                        ),
+                        children: <Widget>[
+                          _SelfAdvertiseCard(
+                            isAdvertising: _state.isAdvertising,
+                            serviceUuid: _selfInfo.serviceUuid ?? _serviceUuid,
+                            localName: _selfInfo.localName ?? _localName,
+                            formatVersion: _selfInfo.formatVersion ?? 1,
+                            lastDisplayId: _selfInfo.lastDisplayId,
+                            lastPayloadAt: _selfInfo.lastPayloadAt,
+                            staleAfter: _staleAfter,
+                            now: now,
+                          ),
+                          const SizedBox(height: 8),
+                          _SeenCard(
+                            seen: seen,
+                            now: now,
+                            staleAfter: _staleAfter,
+                          ),
+                        ],
                       ),
                     ),
-                    const Divider(),
-                    Expanded(
-                      child: DefaultTabController(
-                        length: 2,
-                        child: Column(
-                          children: <Widget>[
-                            const TabBar(tabs: <Tab>[Tab(text: "Events"), Tab(text: "Debug")]),
-                            Expanded(
-                              child: TabBarView(
-                                children: <Widget>[
-                                  Column(
-                                    children: <Widget>[
-                                      Padding(
-                                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                                        child: Wrap(
-                                          spacing: 8,
-                                          runSpacing: 8,
-                                          children: <Widget>[
-                                            FilterChip(
-                                              label: const Text("Detections only"),
-                                              selected: _eventsOnlyDetections,
-                                              onSelected: (bool v) => setState(() => _eventsOnlyDetections = v),
-                                            ),
-                                            FilterChip(
-                                              label: const Text("Issues only"),
-                                              selected: _eventsOnlyIssues,
-                                              onSelected: (bool v) => setState(() => _eventsOnlyIssues = v),
-                                            ),
-                                          ],
-                                        ),
+                  ),
+                  const Divider(),
+                  Expanded(
+                    child: DefaultTabController(
+                      length: 2,
+                      child: Column(
+                        children: <Widget>[
+                          const TabBar(
+                            tabs: <Tab>[
+                              Tab(text: "Events"),
+                              Tab(text: "Debug"),
+                            ],
+                          ),
+                          Expanded(
+                            child: TabBarView(
+                              children: <Widget>[
+                                Column(
+                                  children: <Widget>[
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 12,
+                                        vertical: 8,
                                       ),
-                                      Expanded(
-                                        child: _EventList(
-                                          events: _events,
-                                          onlyDetections: _eventsOnlyDetections,
-                                          onlyIssues: _eventsOnlyIssues,
-                                          seenById: _seenById,
-                                        ),
+                                      child: Wrap(
+                                        spacing: 8,
+                                        runSpacing: 8,
+                                        children: <Widget>[
+                                          FilterChip(
+                                            label: const Text(
+                                              "Detections only",
+                                            ),
+                                            selected: _eventsOnlyDetections,
+                                            onSelected: (bool v) => setState(
+                                              () => _eventsOnlyDetections = v,
+                                            ),
+                                          ),
+                                          FilterChip(
+                                            label: const Text("Issues only"),
+                                            selected: _eventsOnlyIssues,
+                                            onSelected: (bool v) => setState(
+                                              () => _eventsOnlyIssues = v,
+                                            ),
+                                          ),
+                                        ],
                                       ),
-                                    ],
-                                  ),
-                                  Column(
-                                    children: <Widget>[
-                                      Padding(
-                                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                                        child: Wrap(
-                                          spacing: 8,
-                                          runSpacing: 8,
-                                          crossAxisAlignment: WrapCrossAlignment.center,
-                                          children: <Widget>[
-                                            FilterChip(
-                                              label: const Text("Issues only"),
-                                              selected: _debugOnlyIssues,
-                                              onSelected: (bool v) => setState(() => _debugOnlyIssues = v),
+                                    ),
+                                    Expanded(
+                                      child: _EventList(
+                                        events: _events,
+                                        onlyDetections: _eventsOnlyDetections,
+                                        onlyIssues: _eventsOnlyIssues,
+                                        seenById: _seenById,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Column(
+                                  children: <Widget>[
+                                    Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 12,
+                                        vertical: 8,
+                                      ),
+                                      child: Wrap(
+                                        spacing: 8,
+                                        runSpacing: 8,
+                                        crossAxisAlignment:
+                                            WrapCrossAlignment.center,
+                                        children: <Widget>[
+                                          FilterChip(
+                                            label: const Text("Issues only"),
+                                            selected: _debugOnlyIssues,
+                                            onSelected: (bool v) => setState(
+                                              () => _debugOnlyIssues = v,
                                             ),
-                                            FilterChip(
-                                              label: const Text("Hide trace"),
-                                              selected: _debugHideTrace,
-                                              onSelected: (bool v) => setState(() => _debugHideTrace = v),
+                                          ),
+                                          FilterChip(
+                                            label: const Text("Hide trace"),
+                                            selected: _debugHideTrace,
+                                            onSelected: (bool v) => setState(
+                                              () => _debugHideTrace = v,
                                             ),
-                                            SizedBox(
-                                              width: 220,
-                                              child: TextField(
-                                                decoration: const InputDecoration(
-                                                  labelText: "Filter name",
-                                                  isDense: true,
-                                                  border: OutlineInputBorder(),
-                                                ),
-                                                onChanged: (String v) => setState(() => _debugQuery = v.trim()),
+                                          ),
+                                          SizedBox(
+                                            width: 220,
+                                            child: TextField(
+                                              decoration: const InputDecoration(
+                                                labelText: "Filter name",
+                                                isDense: true,
+                                                border: OutlineInputBorder(),
+                                              ),
+                                              onChanged: (String v) => setState(
+                                                () => _debugQuery = v.trim(),
                                               ),
                                             ),
-                                          ],
-                                        ),
+                                          ),
+                                        ],
                                       ),
-                                      Expanded(
-                                        child: _DebugList(
-                                          events: _debugEvents,
-                                          onlyIssues: _debugOnlyIssues,
-                                          hideTrace: _debugHideTrace,
-                                          query: _debugQuery,
-                                        ),
+                                    ),
+                                    Expanded(
+                                      child: _DebugList(
+                                        events: _debugEvents,
+                                        onlyIssues: _debugOnlyIssues,
+                                        hideTrace: _debugHideTrace,
+                                        query: _debugQuery,
                                       ),
-                                    ],
-                                  ),
-                                ],
-                              ),
+                                    ),
+                                  ],
+                                ),
+                              ],
                             ),
-                          ],
-                        ),
+                          ),
+                        ],
                       ),
                     ),
-                  ],
-                ),
+                  ),
+                ],
+              ),
       ),
     );
   }
 
   void _updateSeen(DetectionEvent e) {
     final String key = base64UrlEncode(e.rpid);
-    final _SeenEntry existing = _seenById[key] ?? _SeenEntry(displayId: e.displayId);
+    final _SeenEntry existing =
+        _seenById[key] ?? _SeenEntry(displayId: e.displayId);
     existing.lastSeen = e.timestamp;
     existing.lastRssi = e.rssi;
-    existing.displayId = e.displayId.isNotEmpty ? e.displayId : existing.displayId;
+    existing.displayId = e.displayId.isNotEmpty
+        ? e.displayId
+        : existing.displayId;
+    if (e.debugLocalName != null && e.debugLocalName!.isNotEmpty) {
+      existing.debugLocalName = e.debugLocalName!;
+    }
     existing.count += 1;
     _seenById[key] = existing;
     if (_seenById.length > 50) {
-      final List<MapEntry<String, _SeenEntry>> entries = _seenById.entries.toList(growable: false)
-        ..sort((MapEntry<String, _SeenEntry> a, MapEntry<String, _SeenEntry> b) => a.value.lastSeen.compareTo(b.value.lastSeen));
+      final List<MapEntry<String, _SeenEntry>> entries =
+          _seenById.entries.toList(growable: false)..sort(
+            (MapEntry<String, _SeenEntry> a, MapEntry<String, _SeenEntry> b) =>
+                a.value.lastSeen.compareTo(b.value.lastSeen),
+          );
       final int removeCount = _seenById.length - 50;
       for (int i = 0; i < removeCount; i++) {
         _seenById.remove(entries[i].key);
@@ -349,12 +473,16 @@ class _MyAppState extends State<MyApp> {
     final Map<String, Object?>? data = e.data;
     if (data == null) return;
     if (e.name == "advertise_start") {
-      _selfInfo.formatVersion = _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
-      _selfInfo.serviceUuid = data["serviceUuid"] as String? ?? _selfInfo.serviceUuid;
+      _selfInfo.formatVersion =
+          _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
+      _selfInfo.serviceUuid =
+          data["serviceUuid"] as String? ?? _selfInfo.serviceUuid;
       _selfInfo.localName = data["localName"] as String? ?? _selfInfo.localName;
     } else if (e.name == "gatt_read_rpid") {
-      _selfInfo.lastDisplayId = data["displayId"] as String? ?? _selfInfo.lastDisplayId;
-      _selfInfo.formatVersion = _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
+      _selfInfo.lastDisplayId =
+          data["displayId"] as String? ?? _selfInfo.lastDisplayId;
+      _selfInfo.formatVersion =
+          _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
       _selfInfo.lastPayloadAt = e.timestamp;
     }
   }
@@ -383,11 +511,14 @@ class _EventList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final DateTime now = DateTime.now();
-    final List<BarnardEvent> filtered = events.where((BarnardEvent e) {
-      if (onlyDetections && e is! DetectionEvent) return false;
-      if (onlyIssues && e is! ConstraintEvent && e is! ErrorEvent) return false;
-      return true;
-    }).toList(growable: false);
+    final List<BarnardEvent> filtered = events
+        .where((BarnardEvent e) {
+          if (onlyDetections && e is! DetectionEvent) return false;
+          if (onlyIssues && e is! ConstraintEvent && e is! ErrorEvent)
+            return false;
+          return true;
+        })
+        .toList(growable: false);
     return ListView.builder(
       itemCount: filtered.length,
       itemBuilder: (BuildContext context, int index) {
@@ -397,28 +528,40 @@ class _EventList extends StatelessWidget {
           final bool isStale = age > _MyAppState._staleAfter;
           final String rpidKey = base64UrlEncode(e.rpid);
           final _SeenEntry? latest = seenById[rpidKey];
-          final bool isActive = latest != null && now.difference(latest.lastSeen) <= _MyAppState._staleAfter;
+          final bool isActive =
+              latest != null &&
+              now.difference(latest.lastSeen) <= _MyAppState._staleAfter;
           return ListTile(
             dense: true,
             leading: const Icon(Icons.wifi_tethering, size: 18),
             title: Text(
               "detection ${e.displayId} rssi=${e.rssi} age=${age.inSeconds}s${isStale ? " STALE" : ""}${isActive ? " ACTIVE" : ""}",
             ),
-            subtitle: Text("${e.timestamp.toIso8601String()} transport=${e.transport.name}"),
+            subtitle: Text(
+              "${e.timestamp.toIso8601String()} transport=${e.transport.name}",
+            ),
           );
         }
         if (e is StateEvent) {
           return ListTile(
             dense: true,
             leading: const Icon(Icons.tune, size: 18),
-            title: Text("state scan=${e.state.isScanning} adv=${e.state.isAdvertising}"),
-            subtitle: Text("${e.timestamp.toIso8601String()} reason=${e.reasonCode ?? "-"}"),
+            title: Text(
+              "state scan=${e.state.isScanning} adv=${e.state.isAdvertising}",
+            ),
+            subtitle: Text(
+              "${e.timestamp.toIso8601String()} reason=${e.reasonCode ?? "-"}",
+            ),
           );
         }
         if (e is ConstraintEvent) {
           return ListTile(
             dense: true,
-            leading: const Icon(Icons.warning_amber, size: 18, color: Colors.orange),
+            leading: const Icon(
+              Icons.warning_amber,
+              size: 18,
+              color: Colors.orange,
+            ),
             title: Text("constraint ${e.code}"),
             subtitle: Text(e.message ?? "-"),
           );
@@ -453,12 +596,17 @@ class _DebugList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final String needle = query.toLowerCase();
-    final List<BarnardDebugEvent> filtered = events.where((BarnardDebugEvent e) {
-      if (hideTrace && e.level == DebugLevel.trace) return false;
-      if (onlyIssues && e.level != DebugLevel.warn && e.level != DebugLevel.error) return false;
-      if (needle.isEmpty) return true;
-      return e.name.toLowerCase().contains(needle);
-    }).toList(growable: false);
+    final List<BarnardDebugEvent> filtered = events
+        .where((BarnardDebugEvent e) {
+          if (hideTrace && e.level == DebugLevel.trace) return false;
+          if (onlyIssues &&
+              e.level != DebugLevel.warn &&
+              e.level != DebugLevel.error)
+            return false;
+          if (needle.isEmpty) return true;
+          return e.name.toLowerCase().contains(needle);
+        })
+        .toList(growable: false);
     return ListView.builder(
       itemCount: filtered.length,
       itemBuilder: (BuildContext context, int index) {
@@ -480,7 +628,10 @@ class _DebugList extends StatelessWidget {
             size: 18,
             color: color,
           ),
-          title: Text("${e.level.name} ${e.name}", style: TextStyle(color: color)),
+          title: Text(
+            "${e.level.name} ${e.name}",
+            style: TextStyle(color: color),
+          ),
           subtitle: Text("${e.timestamp.toIso8601String()}$data"),
         );
       },
@@ -501,12 +652,11 @@ class _StatChip extends StatelessWidget {
 }
 
 class _SeenEntry {
-  _SeenEntry({
-    this.displayId = "",
-    DateTime? lastSeen,
-  }) : lastSeen = lastSeen ?? DateTime.fromMillisecondsSinceEpoch(0);
+  _SeenEntry({this.displayId = "", DateTime? lastSeen})
+    : lastSeen = lastSeen ?? DateTime.fromMillisecondsSinceEpoch(0);
 
   String displayId;
+  String? debugLocalName;
   DateTime lastSeen;
   int count = 0;
   int lastRssi = 0;
@@ -543,7 +693,10 @@ class _SelfAdvertiseCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool hasPayload = lastPayloadAt != null && lastDisplayId != null && lastDisplayId!.isNotEmpty;
+    final bool hasPayload =
+        lastPayloadAt != null &&
+        lastDisplayId != null &&
+        lastDisplayId!.isNotEmpty;
     final Duration? age = hasPayload ? now.difference(lastPayloadAt!) : null;
     final bool isStale = age != null && age > staleAfter;
     return Card(
@@ -552,7 +705,10 @@ class _SelfAdvertiseCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            const Text("Self Advertise", style: TextStyle(fontWeight: FontWeight.bold)),
+            const Text(
+              "Self Advertise",
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
             const SizedBox(height: 6),
             Text("Advertising: ${isAdvertising ? "ON" : "OFF"}"),
             Text("Service UUID: $serviceUuid"),
@@ -595,14 +751,21 @@ class _SeenCard extends StatelessWidget {
             const SizedBox(height: 6),
             if (top.isEmpty) const Text("No detections yet"),
             for (final _SeenEntry entry in top)
-              Builder(builder: (BuildContext context) {
-                final Duration age = now.difference(entry.lastSeen);
-                final bool isStale = age > staleAfter;
-                return Text(
-                  "${entry.displayId.isEmpty ? "-" : entry.displayId} age=${age.inSeconds}s rssi=${entry.lastRssi} count=${entry.count}${isStale ? " STALE" : " ACTIVE"}",
-                  style: TextStyle(color: isStale ? Colors.orange : Colors.green),
-                );
-              }),
+              Builder(
+                builder: (BuildContext context) {
+                  final Duration age = now.difference(entry.lastSeen);
+                  final bool isStale = age > staleAfter;
+                  final String nameLabel = entry.debugLocalName == null
+                      ? ""
+                      : " name=${entry.debugLocalName}";
+                  return Text(
+                    "${entry.displayId.isEmpty ? "-" : entry.displayId}$nameLabel age=${age.inSeconds}s rssi=${entry.lastRssi} count=${entry.count}${isStale ? " STALE" : " ACTIVE"}",
+                    style: TextStyle(
+                      color: isStale ? Colors.orange : Colors.green,
+                    ),
+                  );
+                },
+              ),
           ],
         ),
       ),

--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -21,9 +21,7 @@ class _MyAppState extends State<MyApp> {
   StreamSubscription<BarnardEvent>? _eventsSub;
   StreamSubscription<BarnardDebugEvent>? _debugSub;
 
-  final TextEditingController _eventCodeController = TextEditingController(
-    text: "BND",
-  );
+  final TextEditingController _eventCodeController = TextEditingController(text: "BND");
 
   BarnardState _state = BarnardState.idle;
   final List<BarnardEvent> _events = <BarnardEvent>[];
@@ -81,8 +79,7 @@ class _MyAppState extends State<MyApp> {
       if (!mounted) return;
       setState(() {
         _debugEvents.add(e);
-        if (_debugEvents.length > 200)
-          _debugEvents.removeRange(0, _debugEvents.length - 200);
+        if (_debugEvents.length > 200) _debugEvents.removeRange(0, _debugEvents.length - 200);
         _updateSelfInfo(e);
       });
     });
@@ -90,8 +87,7 @@ class _MyAppState extends State<MyApp> {
     setState(() {
       _client = client;
       _state = client.state;
-      if (client.currentEventCode != null &&
-          client.currentEventCode!.isNotEmpty) {
+      if (client.currentEventCode != null && client.currentEventCode!.isNotEmpty) {
         _eventCodeController.text = client.currentEventCode!;
       }
     });
@@ -109,9 +105,7 @@ class _MyAppState extends State<MyApp> {
     await perms.request();
   }
 
-  Future<void> _run(
-    Future<void> Function(BarnardBleClient client) action,
-  ) async {
+  Future<void> _run(Future<void> Function(BarnardBleClient client) action) async {
     final BarnardBleClient? client = _client;
     if (client == null) return;
     if (_busy) return;
@@ -134,334 +128,269 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     final BarnardBleClient? client = _client;
     final int detections = _events.whereType<DetectionEvent>().length;
-    final int issues = _events
-        .where((BarnardEvent e) => e is ConstraintEvent || e is ErrorEvent)
-        .length;
-    final int debugIssues = _debugEvents
-        .where(
-          (BarnardDebugEvent e) =>
-              e.level == DebugLevel.warn || e.level == DebugLevel.error,
-        )
-        .length;
+    final int issues = _events.where((BarnardEvent e) => e is ConstraintEvent || e is ErrorEvent).length;
+    final int debugIssues =
+        _debugEvents.where((BarnardDebugEvent e) => e.level == DebugLevel.warn || e.level == DebugLevel.error).length;
     final DateTime now = DateTime.now();
-    final List<_SeenEntry> seen = _seenById.values.toList()
-      ..sort((_SeenEntry a, _SeenEntry b) => b.lastSeen.compareTo(a.lastSeen));
+    final List<_SeenEntry> seen =
+        _seenById.values.toList()..sort((_SeenEntry a, _SeenEntry b) => b.lastSeen.compareTo(a.lastSeen));
 
     return MaterialApp(
       home: Scaffold(
         appBar: AppBar(title: const Text("Barnard BLE PoC (GATT-first)")),
-        body: client == null
-            ? const Center(child: CircularProgressIndicator())
-            : Column(
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: <Widget>[
-                        SizedBox(
-                          width: 240,
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              TextField(
-                                controller: _eventCodeController,
-                                decoration: const InputDecoration(
-                                  labelText: "Event Code",
-                                  isDense: true,
-                                  border: OutlineInputBorder(),
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                "Auto-join on Start",
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: Colors.black54,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        FilledButton(
-                          onPressed: _busy
-                              ? null
-                              : () => _run((c) async {
-                                  await _ensureEventJoined(c);
-                                  await c.startScan(
-                                    const ScanConfig(allowDuplicates: true),
-                                  );
-                                }),
-                          child: const Text("Start Scan"),
-                        ),
-                        OutlinedButton(
-                          onPressed: _busy
-                              ? null
-                              : () => _run((c) => c.stopScan()),
-                          child: const Text("Stop Scan"),
-                        ),
-                        FilledButton(
-                          onPressed: _busy
-                              ? null
-                              : () => _run((c) async {
-                                  await _ensureEventJoined(c);
-                                  await c.startAdvertise(
-                                    const AdvertiseConfig(),
-                                  );
-                                }),
-                          child: const Text("Start Advertise"),
-                        ),
-                        OutlinedButton(
-                          onPressed: _busy
-                              ? null
-                              : () => _run((c) => c.stopAdvertise()),
-                          child: const Text("Stop Advertise"),
-                        ),
-                        FilledButton(
-                          onPressed: _busy
-                              ? null
-                              : () => _run((c) async {
-                                  await _ensureEventJoined(c);
-                                  await c.startAuto(const AutoConfig());
-                                }),
-                          child: const Text("Start Auto"),
-                        ),
-                        OutlinedButton(
-                          onPressed: _busy
-                              ? null
-                              : () => _run((c) => c.stopAuto()),
-                          child: const Text("Stop Auto"),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    child: Row(
-                      children: <Widget>[
-                        Expanded(
-                          child: Text(
-                            "State: $_state mode=${client.currentMode.name} event=${client.currentEventCode ?? "-"}",
-                          ),
-                        ),
-                        Text(
-                          "caps: ${client.capabilities.supportedTransports.map((e) => e.name).join(",")}",
-                        ),
-                        const SizedBox(width: 8),
-                        Text("debugName: ${_selfInfo.localName ?? _localName}"),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 8,
-                    ),
-                    child: Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: <Widget>[
-                        _StatChip(label: "events", value: _events.length),
-                        _StatChip(label: "detections", value: detections),
-                        _StatChip(label: "issues", value: issues),
-                        _StatChip(label: "debug", value: _debugEvents.length),
-                        _StatChip(label: "debug issues", value: debugIssues),
-                        TextButton(
-                          onPressed: _events.isEmpty
-                              ? null
-                              : () => setState(() => _events.clear()),
-                          child: const Text("Clear Events"),
-                        ),
-                        TextButton(
-                          onPressed: _debugEvents.isEmpty
-                              ? null
-                              : () => setState(() => _debugEvents.clear()),
-                          child: const Text("Clear Debug"),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 8,
-                    ),
-                    child: Card(
-                      child: ExpansionTile(
-                        initiallyExpanded: _diagExpanded,
-                        onExpansionChanged: (bool v) =>
-                            setState(() => _diagExpanded = v),
-                        title: const Text("Diagnostics"),
-                        subtitle: const Text("Self advertise + recently seen"),
-                        childrenPadding: const EdgeInsets.fromLTRB(
-                          12,
-                          0,
-                          12,
-                          12,
-                        ),
+        body:
+            client == null
+                ? const Center(child: CircularProgressIndicator())
+                : Column(
+                  children: <Widget>[
+                    Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
                         children: <Widget>[
-                          _SelfAdvertiseCard(
-                            isAdvertising: _state.isAdvertising,
-                            serviceUuid: _selfInfo.serviceUuid ?? _serviceUuid,
-                            localName: _selfInfo.localName ?? _localName,
-                            formatVersion: _selfInfo.formatVersion ?? 1,
-                            lastDisplayId: _selfInfo.lastDisplayId,
-                            lastPayloadAt: _selfInfo.lastPayloadAt,
-                            staleAfter: _staleAfter,
-                            now: now,
-                          ),
-                          const SizedBox(height: 8),
-                          _SeenCard(
-                            seen: seen,
-                            now: now,
-                            staleAfter: _staleAfter,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  const Divider(),
-                  Expanded(
-                    child: DefaultTabController(
-                      length: 2,
-                      child: Column(
-                        children: <Widget>[
-                          const TabBar(
-                            tabs: <Tab>[
-                              Tab(text: "Events"),
-                              Tab(text: "Debug"),
-                            ],
-                          ),
-                          Expanded(
-                            child: TabBarView(
+                          SizedBox(
+                            width: 240,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
                               children: <Widget>[
-                                Column(
-                                  children: <Widget>[
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 12,
-                                        vertical: 8,
-                                      ),
-                                      child: Wrap(
-                                        spacing: 8,
-                                        runSpacing: 8,
-                                        children: <Widget>[
-                                          FilterChip(
-                                            label: const Text(
-                                              "Detections only",
-                                            ),
-                                            selected: _eventsOnlyDetections,
-                                            onSelected: (bool v) => setState(
-                                              () => _eventsOnlyDetections = v,
-                                            ),
-                                          ),
-                                          FilterChip(
-                                            label: const Text("Issues only"),
-                                            selected: _eventsOnlyIssues,
-                                            onSelected: (bool v) => setState(
-                                              () => _eventsOnlyIssues = v,
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                    Expanded(
-                                      child: _EventList(
-                                        events: _events,
-                                        onlyDetections: _eventsOnlyDetections,
-                                        onlyIssues: _eventsOnlyIssues,
-                                        seenById: _seenById,
-                                      ),
-                                    ),
-                                  ],
+                                TextField(
+                                  controller: _eventCodeController,
+                                  decoration: const InputDecoration(
+                                    labelText: "Event Code",
+                                    isDense: true,
+                                    border: OutlineInputBorder(),
+                                  ),
                                 ),
-                                Column(
-                                  children: <Widget>[
-                                    Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 12,
-                                        vertical: 8,
-                                      ),
-                                      child: Wrap(
-                                        spacing: 8,
-                                        runSpacing: 8,
-                                        crossAxisAlignment:
-                                            WrapCrossAlignment.center,
-                                        children: <Widget>[
-                                          FilterChip(
-                                            label: const Text("Issues only"),
-                                            selected: _debugOnlyIssues,
-                                            onSelected: (bool v) => setState(
-                                              () => _debugOnlyIssues = v,
-                                            ),
-                                          ),
-                                          FilterChip(
-                                            label: const Text("Hide trace"),
-                                            selected: _debugHideTrace,
-                                            onSelected: (bool v) => setState(
-                                              () => _debugHideTrace = v,
-                                            ),
-                                          ),
-                                          SizedBox(
-                                            width: 220,
-                                            child: TextField(
-                                              decoration: const InputDecoration(
-                                                labelText: "Filter name",
-                                                isDense: true,
-                                                border: OutlineInputBorder(),
-                                              ),
-                                              onChanged: (String v) => setState(
-                                                () => _debugQuery = v.trim(),
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                      ),
-                                    ),
-                                    Expanded(
-                                      child: _DebugList(
-                                        events: _debugEvents,
-                                        onlyIssues: _debugOnlyIssues,
-                                        hideTrace: _debugHideTrace,
-                                        query: _debugQuery,
-                                      ),
-                                    ),
-                                  ],
-                                ),
+                                const SizedBox(height: 4),
+                                Text("Auto-join on Start", style: TextStyle(fontSize: 12, color: Colors.black54)),
                               ],
                             ),
                           ),
+                          FilledButton(
+                            onPressed:
+                                _busy
+                                    ? null
+                                    : () => _run((c) async {
+                                      await _ensureEventJoined(c);
+                                      await c.startScan(const ScanConfig(allowDuplicates: true));
+                                    }),
+                            child: const Text("Start Scan"),
+                          ),
+                          OutlinedButton(
+                            onPressed: _busy ? null : () => _run((c) => c.stopScan()),
+                            child: const Text("Stop Scan"),
+                          ),
+                          FilledButton(
+                            onPressed:
+                                _busy
+                                    ? null
+                                    : () => _run((c) async {
+                                      await _ensureEventJoined(c);
+                                      await c.startAdvertise(const AdvertiseConfig());
+                                    }),
+                            child: const Text("Start Advertise"),
+                          ),
+                          OutlinedButton(
+                            onPressed: _busy ? null : () => _run((c) => c.stopAdvertise()),
+                            child: const Text("Stop Advertise"),
+                          ),
+                          FilledButton(
+                            onPressed:
+                                _busy
+                                    ? null
+                                    : () => _run((c) async {
+                                      await _ensureEventJoined(c);
+                                      await c.startAuto(const AutoConfig());
+                                    }),
+                            child: const Text("Start Auto"),
+                          ),
+                          OutlinedButton(
+                            onPressed: _busy ? null : () => _run((c) => c.stopAuto()),
+                            child: const Text("Stop Auto"),
+                          ),
                         ],
                       ),
                     ),
-                  ),
-                ],
-              ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      child: Row(
+                        children: <Widget>[
+                          Expanded(
+                            child: Text(
+                              "State: $_state mode=${client.currentMode.name} event=${client.currentEventCode ?? "-"}",
+                            ),
+                          ),
+                          Text("caps: ${client.capabilities.supportedTransports.map((e) => e.name).join(",")}"),
+                          const SizedBox(width: 8),
+                          Text("debugName: ${_selfInfo.localName ?? _localName}"),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      child: Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: <Widget>[
+                          _StatChip(label: "events", value: _events.length),
+                          _StatChip(label: "detections", value: detections),
+                          _StatChip(label: "issues", value: issues),
+                          _StatChip(label: "debug", value: _debugEvents.length),
+                          _StatChip(label: "debug issues", value: debugIssues),
+                          TextButton(
+                            onPressed: _events.isEmpty ? null : () => setState(() => _events.clear()),
+                            child: const Text("Clear Events"),
+                          ),
+                          TextButton(
+                            onPressed: _debugEvents.isEmpty ? null : () => setState(() => _debugEvents.clear()),
+                            child: const Text("Clear Debug"),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      child: Card(
+                        child: ExpansionTile(
+                          initiallyExpanded: _diagExpanded,
+                          onExpansionChanged: (bool v) => setState(() => _diagExpanded = v),
+                          title: const Text("Diagnostics"),
+                          subtitle: const Text("Self advertise + recently seen"),
+                          childrenPadding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                          children: <Widget>[
+                            _SelfAdvertiseCard(
+                              isAdvertising: _state.isAdvertising,
+                              serviceUuid: _selfInfo.serviceUuid ?? _serviceUuid,
+                              localName: _selfInfo.localName ?? _localName,
+                              formatVersion: _selfInfo.formatVersion ?? 1,
+                              lastDisplayId: _selfInfo.lastDisplayId,
+                              lastPayloadAt: _selfInfo.lastPayloadAt,
+                              staleAfter: _staleAfter,
+                              now: now,
+                            ),
+                            const SizedBox(height: 8),
+                            _SeenCard(seen: seen, now: now, staleAfter: _staleAfter),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const Divider(),
+                    Expanded(
+                      child: DefaultTabController(
+                        length: 2,
+                        child: Column(
+                          children: <Widget>[
+                            const TabBar(tabs: <Tab>[Tab(text: "Events"), Tab(text: "Debug")]),
+                            Expanded(
+                              child: TabBarView(
+                                children: <Widget>[
+                                  Column(
+                                    children: <Widget>[
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                        child: Wrap(
+                                          spacing: 8,
+                                          runSpacing: 8,
+                                          children: <Widget>[
+                                            FilterChip(
+                                              label: const Text("Detections only"),
+                                              selected: _eventsOnlyDetections,
+                                              onSelected: (bool v) => setState(() => _eventsOnlyDetections = v),
+                                            ),
+                                            FilterChip(
+                                              label: const Text("Issues only"),
+                                              selected: _eventsOnlyIssues,
+                                              onSelected: (bool v) => setState(() => _eventsOnlyIssues = v),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                      Expanded(
+                                        child: _EventList(
+                                          events: _events,
+                                          onlyDetections: _eventsOnlyDetections,
+                                          onlyIssues: _eventsOnlyIssues,
+                                          seenById: _seenById,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  Column(
+                                    children: <Widget>[
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                                        child: Wrap(
+                                          spacing: 8,
+                                          runSpacing: 8,
+                                          crossAxisAlignment: WrapCrossAlignment.center,
+                                          children: <Widget>[
+                                            FilterChip(
+                                              label: const Text("Issues only"),
+                                              selected: _debugOnlyIssues,
+                                              onSelected: (bool v) => setState(() => _debugOnlyIssues = v),
+                                            ),
+                                            FilterChip(
+                                              label: const Text("Hide trace"),
+                                              selected: _debugHideTrace,
+                                              onSelected: (bool v) => setState(() => _debugHideTrace = v),
+                                            ),
+                                            SizedBox(
+                                              width: 220,
+                                              child: TextField(
+                                                decoration: const InputDecoration(
+                                                  labelText: "Filter name",
+                                                  isDense: true,
+                                                  border: OutlineInputBorder(),
+                                                ),
+                                                onChanged: (String v) => setState(() => _debugQuery = v.trim()),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                      Expanded(
+                                        child: _DebugList(
+                                          events: _debugEvents,
+                                          onlyIssues: _debugOnlyIssues,
+                                          hideTrace: _debugHideTrace,
+                                          query: _debugQuery,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
       ),
     );
   }
 
   void _updateSeen(DetectionEvent e) {
     final String key = base64UrlEncode(e.rpid);
-    final _SeenEntry existing =
-        _seenById[key] ?? _SeenEntry(displayId: e.displayId);
+    final _SeenEntry existing = _seenById[key] ?? _SeenEntry(displayId: e.displayId);
     existing.lastSeen = e.timestamp;
     existing.lastRssi = e.rssi;
-    existing.displayId = e.displayId.isNotEmpty
-        ? e.displayId
-        : existing.displayId;
+    existing.displayId = e.displayId.isNotEmpty ? e.displayId : existing.displayId;
+    if (e.resolvedDisplayId != null && e.resolvedDisplayId!.isNotEmpty) {
+      existing.resolvedDisplayId = e.resolvedDisplayId;
+    }
     if (e.debugLocalName != null && e.debugLocalName!.isNotEmpty) {
       existing.debugLocalName = e.debugLocalName!;
     }
     existing.count += 1;
     _seenById[key] = existing;
     if (_seenById.length > 50) {
-      final List<MapEntry<String, _SeenEntry>> entries =
-          _seenById.entries.toList(growable: false)..sort(
-            (MapEntry<String, _SeenEntry> a, MapEntry<String, _SeenEntry> b) =>
-                a.value.lastSeen.compareTo(b.value.lastSeen),
-          );
+      final List<MapEntry<String, _SeenEntry>> entries = _seenById.entries.toList(growable: false)..sort(
+        (MapEntry<String, _SeenEntry> a, MapEntry<String, _SeenEntry> b) =>
+            a.value.lastSeen.compareTo(b.value.lastSeen),
+      );
       final int removeCount = _seenById.length - 50;
       for (int i = 0; i < removeCount; i++) {
         _seenById.remove(entries[i].key);
@@ -473,16 +402,12 @@ class _MyAppState extends State<MyApp> {
     final Map<String, Object?>? data = e.data;
     if (data == null) return;
     if (e.name == "advertise_start") {
-      _selfInfo.formatVersion =
-          _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
-      _selfInfo.serviceUuid =
-          data["serviceUuid"] as String? ?? _selfInfo.serviceUuid;
+      _selfInfo.formatVersion = _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
+      _selfInfo.serviceUuid = data["serviceUuid"] as String? ?? _selfInfo.serviceUuid;
       _selfInfo.localName = data["localName"] as String? ?? _selfInfo.localName;
     } else if (e.name == "gatt_read_rpid") {
-      _selfInfo.lastDisplayId =
-          data["displayId"] as String? ?? _selfInfo.lastDisplayId;
-      _selfInfo.formatVersion =
-          _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
+      _selfInfo.lastDisplayId = data["displayId"] as String? ?? _selfInfo.lastDisplayId;
+      _selfInfo.formatVersion = _asInt(data["formatVersion"]) ?? _selfInfo.formatVersion;
       _selfInfo.lastPayloadAt = e.timestamp;
     }
   }
@@ -514,8 +439,7 @@ class _EventList extends StatelessWidget {
     final List<BarnardEvent> filtered = events
         .where((BarnardEvent e) {
           if (onlyDetections && e is! DetectionEvent) return false;
-          if (onlyIssues && e is! ConstraintEvent && e is! ErrorEvent)
-            return false;
+          if (onlyIssues && e is! ConstraintEvent && e is! ErrorEvent) return false;
           return true;
         })
         .toList(growable: false);
@@ -528,40 +452,28 @@ class _EventList extends StatelessWidget {
           final bool isStale = age > _MyAppState._staleAfter;
           final String rpidKey = base64UrlEncode(e.rpid);
           final _SeenEntry? latest = seenById[rpidKey];
-          final bool isActive =
-              latest != null &&
-              now.difference(latest.lastSeen) <= _MyAppState._staleAfter;
+          final bool isActive = latest != null && now.difference(latest.lastSeen) <= _MyAppState._staleAfter;
           return ListTile(
             dense: true,
             leading: const Icon(Icons.wifi_tethering, size: 18),
             title: Text(
-              "detection ${e.displayId} rssi=${e.rssi} age=${age.inSeconds}s${isStale ? " STALE" : ""}${isActive ? " ACTIVE" : ""}",
+              "detection ${e.displayId}${e.resolvedDisplayId == null ? "" : " resolved=${e.resolvedDisplayId}"} rssi=${e.rssi} age=${age.inSeconds}s${isStale ? " STALE" : ""}${isActive ? " ACTIVE" : ""}",
             ),
-            subtitle: Text(
-              "${e.timestamp.toIso8601String()} transport=${e.transport.name}",
-            ),
+            subtitle: Text("${e.timestamp.toIso8601String()} transport=${e.transport.name}"),
           );
         }
         if (e is StateEvent) {
           return ListTile(
             dense: true,
             leading: const Icon(Icons.tune, size: 18),
-            title: Text(
-              "state scan=${e.state.isScanning} adv=${e.state.isAdvertising}",
-            ),
-            subtitle: Text(
-              "${e.timestamp.toIso8601String()} reason=${e.reasonCode ?? "-"}",
-            ),
+            title: Text("state scan=${e.state.isScanning} adv=${e.state.isAdvertising}"),
+            subtitle: Text("${e.timestamp.toIso8601String()} reason=${e.reasonCode ?? "-"}"),
           );
         }
         if (e is ConstraintEvent) {
           return ListTile(
             dense: true,
-            leading: const Icon(
-              Icons.warning_amber,
-              size: 18,
-              color: Colors.orange,
-            ),
+            leading: const Icon(Icons.warning_amber, size: 18, color: Colors.orange),
             title: Text("constraint ${e.code}"),
             subtitle: Text(e.message ?? "-"),
           );
@@ -581,12 +493,7 @@ class _EventList extends StatelessWidget {
 }
 
 class _DebugList extends StatelessWidget {
-  const _DebugList({
-    required this.events,
-    required this.onlyIssues,
-    required this.hideTrace,
-    required this.query,
-  });
+  const _DebugList({required this.events, required this.onlyIssues, required this.hideTrace, required this.query});
 
   final List<BarnardDebugEvent> events;
   final bool onlyIssues;
@@ -599,10 +506,7 @@ class _DebugList extends StatelessWidget {
     final List<BarnardDebugEvent> filtered = events
         .where((BarnardDebugEvent e) {
           if (hideTrace && e.level == DebugLevel.trace) return false;
-          if (onlyIssues &&
-              e.level != DebugLevel.warn &&
-              e.level != DebugLevel.error)
-            return false;
+          if (onlyIssues && e.level != DebugLevel.warn && e.level != DebugLevel.error) return false;
           if (needle.isEmpty) return true;
           return e.name.toLowerCase().contains(needle);
         })
@@ -628,10 +532,7 @@ class _DebugList extends StatelessWidget {
             size: 18,
             color: color,
           ),
-          title: Text(
-            "${e.level.name} ${e.name}",
-            style: TextStyle(color: color),
-          ),
+          title: Text("${e.level.name} ${e.name}", style: TextStyle(color: color)),
           subtitle: Text("${e.timestamp.toIso8601String()}$data"),
         );
       },
@@ -652,11 +553,11 @@ class _StatChip extends StatelessWidget {
 }
 
 class _SeenEntry {
-  _SeenEntry({this.displayId = "", DateTime? lastSeen})
-    : lastSeen = lastSeen ?? DateTime.fromMillisecondsSinceEpoch(0);
+  _SeenEntry({this.displayId = "", DateTime? lastSeen}) : lastSeen = lastSeen ?? DateTime.fromMillisecondsSinceEpoch(0);
 
   String displayId;
   String? debugLocalName;
+  String? resolvedDisplayId;
   DateTime lastSeen;
   int count = 0;
   int lastRssi = 0;
@@ -693,10 +594,7 @@ class _SelfAdvertiseCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool hasPayload =
-        lastPayloadAt != null &&
-        lastDisplayId != null &&
-        lastDisplayId!.isNotEmpty;
+    final bool hasPayload = lastPayloadAt != null && lastDisplayId != null && lastDisplayId!.isNotEmpty;
     final Duration? age = hasPayload ? now.difference(lastPayloadAt!) : null;
     final bool isStale = age != null && age > staleAfter;
     return Card(
@@ -705,10 +603,7 @@ class _SelfAdvertiseCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            const Text(
-              "Self Advertise",
-              style: TextStyle(fontWeight: FontWeight.bold),
-            ),
+            const Text("Self Advertise", style: TextStyle(fontWeight: FontWeight.bold)),
             const SizedBox(height: 6),
             Text("Advertising: ${isAdvertising ? "ON" : "OFF"}"),
             Text("Service UUID: $serviceUuid"),
@@ -725,11 +620,7 @@ class _SelfAdvertiseCard extends StatelessWidget {
 }
 
 class _SeenCard extends StatelessWidget {
-  const _SeenCard({
-    required this.seen,
-    required this.now,
-    required this.staleAfter,
-  });
+  const _SeenCard({required this.seen, required this.now, required this.staleAfter});
 
   final List<_SeenEntry> seen;
   final DateTime now;
@@ -755,14 +646,12 @@ class _SeenCard extends StatelessWidget {
                 builder: (BuildContext context) {
                   final Duration age = now.difference(entry.lastSeen);
                   final bool isStale = age > staleAfter;
-                  final String nameLabel = entry.debugLocalName == null
-                      ? ""
-                      : " name=${entry.debugLocalName}";
+                  final String nameLabel = entry.debugLocalName == null ? "" : " name=${entry.debugLocalName}";
+                  final String resolvedLabel =
+                      entry.resolvedDisplayId == null ? "" : " resolved=${entry.resolvedDisplayId}";
                   return Text(
-                    "${entry.displayId.isEmpty ? "-" : entry.displayId}$nameLabel age=${age.inSeconds}s rssi=${entry.lastRssi} count=${entry.count}${isStale ? " STALE" : " ACTIVE"}",
-                    style: TextStyle(
-                      color: isStale ? Colors.orange : Colors.green,
-                    ),
+                    "${entry.displayId.isEmpty ? "-" : entry.displayId}$resolvedLabel$nameLabel age=${age.inSeconds}s rssi=${entry.lastRssi} count=${entry.count}${isStale ? " STALE" : " ACTIVE"}",
+                    style: TextStyle(color: isStale ? Colors.orange : Colors.green),
                   );
                 },
               ),

--- a/packages/dart/barnard/android/build.gradle
+++ b/packages/dart/barnard/android/build.gradle
@@ -29,6 +29,10 @@ android {
 
     compileSdk = 36
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -243,6 +243,12 @@ internal class BarnardController(
         connectQueue.clear()
         activeGatt?.close()
         activeGatt = null
+
+        // Clear discovery state for clean restart
+        discoveredRssi.clear()
+        discoveredAt.clear()
+        lastConnectAttemptAtMs.clear()
+
         emitState("scan_stop")
         emitDebug("info", "scan_stop", null)
     }

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -1,3 +1,6 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
 package network.greeting.barnard
 
 import android.Manifest
@@ -15,8 +18,6 @@ import android.bluetooth.BluetoothProfile
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
-import android.bluetooth.le.BluetoothLeAdvertiser
-import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
@@ -29,16 +30,12 @@ import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
 import android.util.Base64
+import android.util.Log
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.util.UUID
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
-import android.util.Log
 
 private const val TAG = "BarnardBLE"
 
@@ -55,8 +52,14 @@ internal class BarnardController(
     private var eventSink: EventChannel.EventSink? = null
     private var debugEventSink: EventChannel.EventSink? = null
 
+    // MARK: - UUIDs
+
     private val serviceUuid: UUID = UUID.fromString("0000B001-0000-1000-8000-00805F9B34FB")
     private val rpidCharUuid: UUID = UUID.fromString("0000B002-0000-1000-8000-00805F9B34FB")
+    private val tekCharUuid: UUID = UUID.fromString("0000B003-0000-1000-8000-00805F9B34FB")
+    private val eventCodeHashCharUuid: UUID = UUID.fromString("0000B004-0000-1000-8000-00805F9B34FB")
+
+    // MARK: - Bluetooth
 
     private val bluetoothManager: BluetoothManager? =
         appContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
@@ -64,13 +67,26 @@ internal class BarnardController(
 
     private var gattServer: BluetoothGattServer? = null
 
+    // MARK: - State
+
     private var isScanning: Boolean = false
     private var isAdvertising: Boolean = false
     private var allowDuplicates: Boolean = true
     private var formatVersion: Int = 1
 
+    // MARK: - Event Mode
+
+    private var eventCode: String? = null
+    private var currentTek: ByteArray = ByteArray(16)
+
+    private val tekStorage: BarnardTekStorage by lazy { BarnardTekStorage(appContext) }
+
+    // MARK: - Discovery State
+
     private val discoveredRssi: MutableMap<String, Int> = mutableMapOf()
     private val discoveredAt: MutableMap<String, Long> = mutableMapOf()
+
+    // MARK: - Connection Queue
 
     private val connectQueue: ArrayDeque<BluetoothDevice> = ArrayDeque()
     private val lastConnectAttemptAtMs: MutableMap<String, Long> = mutableMapOf()
@@ -78,6 +94,18 @@ internal class BarnardController(
 
     private val maxConnectQueue: Int = 20
     private val cooldownPerPeerMs: Long = 10_000
+
+    // MARK: - Central GATT State
+
+    private data class GattReadValues(
+        var eventCodeHash: ByteArray? = null,
+        var rpid: ByteArray? = null,
+        var tek: ByteArray? = null
+    )
+
+    private val peripheralReadValues: MutableMap<String, GattReadValues> = mutableMapOf()
+
+    // MARK: - Storage
 
     private val prefs: SharedPreferences =
         appContext.getSharedPreferences("barnard", Context.MODE_PRIVATE)
@@ -104,6 +132,32 @@ internal class BarnardController(
                 debugEventSink = null
             }
         })
+
+        // Initialize TEK
+        initializeTek()
+    }
+
+    private fun initializeTek() {
+        // Load persisted event code
+        eventCode = prefs.getString("eventCode", null)
+
+        if (eventCode != null) {
+            // Event Mode: derive TEK from DeviceSecret + EventCode
+            val deviceSecret = getOrCreateDeviceSecret()
+            currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret, eventCode!!)
+        } else {
+            // Anonymous Mode: use stored random TEK or generate new one
+            val storedTek = prefs.getString("currentTek", null)
+            if (storedTek != null) {
+                val decoded = Base64.decode(storedTek, Base64.DEFAULT)
+                if (decoded.size == 16) {
+                    currentTek = decoded
+                    return
+                }
+            }
+            currentTek = BarnardCrypto.generateRandomTek()
+            prefs.edit().putString("currentTek", Base64.encodeToString(currentTek, Base64.NO_WRAP)).apply()
+        }
     }
 
     fun dispose() {
@@ -125,27 +179,40 @@ internal class BarnardController(
                     "supportsHighRateRssi" to false,
                 )
             )
-            "getState" -> result.success(mapOf("isScanning" to isScanning, "isAdvertising" to isAdvertising))
+
+            "getState" -> result.success(
+                mapOf(
+                    "isScanning" to isScanning,
+                    "isAdvertising" to isAdvertising,
+                    "eventMode" to if (eventCode != null) "event" else "anonymous",
+                    "eventCode" to eventCode
+                )
+            )
+
             "startScan" -> {
                 val args = call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()
                 allowDuplicates = args["allowDuplicates"] as? Boolean ?: true
                 startScan()
                 result.success(null)
             }
+
             "stopScan" -> {
                 stopScan()
                 result.success(null)
             }
+
             "startAdvertise" -> {
                 val args = call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()
                 formatVersion = (args["formatVersion"] as? Int) ?: 1
                 startAdvertise()
                 result.success(null)
             }
+
             "stopAdvertise" -> {
                 stopAdvertise()
                 result.success(null)
             }
+
             "startAuto" -> {
                 val args = call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()
                 val scan = args["scan"] as? Map<*, *>
@@ -165,18 +232,130 @@ internal class BarnardController(
                     )
                 )
             }
+
             "stopAuto" -> {
                 stopScan()
                 stopAdvertise()
                 result.success(null)
             }
+
             "dispose" -> {
                 dispose()
                 result.success(null)
             }
+
+            // MARK: Event Mode APIs
+
+            "joinEvent" -> {
+                val args = call.arguments as? Map<*, *>
+                val code = args?.get("eventCode") as? String
+                if (code == null) {
+                    result.error("INVALID_ARGUMENT", "eventCode required", null)
+                    return
+                }
+                joinEvent(code)
+                result.success(null)
+            }
+
+            "leaveEvent" -> {
+                leaveEvent()
+                result.success(null)
+            }
+
+            "getExchangedTeks" -> {
+                val args = call.arguments as? Map<*, *>
+                val code = args?.get("eventCode") as? String
+                if (code == null) {
+                    result.error("INVALID_ARGUMENT", "eventCode required", null)
+                    return
+                }
+                val eventCodeHash = BarnardCrypto.computeEventCodeHash(code)
+                val entries = tekStorage.getEntries(eventCodeHash)
+                result.success(entries.map { it.toMap() })
+            }
+
+            "clearTeksForEvent" -> {
+                val args = call.arguments as? Map<*, *>
+                val code = args?.get("eventCode") as? String
+                if (code == null) {
+                    result.error("INVALID_ARGUMENT", "eventCode required", null)
+                    return
+                }
+                val eventCodeHash = BarnardCrypto.computeEventCodeHash(code)
+                val count = tekStorage.clear(eventCodeHash)
+                emitDebug("info", "clear_teks_for_event", mapOf("eventCode" to code, "count" to count))
+                result.success(count)
+            }
+
+            "clearAllTeks" -> {
+                val count = tekStorage.clearAll()
+                emitDebug("info", "clear_all_teks", mapOf("count" to count))
+                result.success(count)
+            }
+
             else -> result.notImplemented()
         }
     }
+
+    // MARK: - Event Mode Control
+
+    private fun joinEvent(code: String) {
+        eventCode = code
+        prefs.edit().putString("eventCode", code).apply()
+
+        // Derive TEK from DeviceSecret + EventCode
+        val deviceSecret = getOrCreateDeviceSecret()
+        currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret, code)
+        prefs.edit().remove("currentTek").apply() // Event-derived TEK can be recomputed
+
+        // Rebuild GATT server
+        rebuildGattServerIfNeeded()
+
+        emitState("join_event")
+        emitDebug("info", "join_event", mapOf(
+            "eventCode" to code,
+            "displayId" to BarnardCrypto.displayId(currentTek)
+        ))
+    }
+
+    private fun leaveEvent() {
+        eventCode = null
+        prefs.edit().remove("eventCode").apply()
+
+        // Generate new random TEK
+        currentTek = BarnardCrypto.generateRandomTek()
+        prefs.edit().putString("currentTek", Base64.encodeToString(currentTek, Base64.NO_WRAP)).apply()
+
+        // Rebuild GATT server
+        rebuildGattServerIfNeeded()
+
+        emitState("leave_event")
+        emitDebug("info", "leave_event", null)
+    }
+
+    private val isEventMode: Boolean
+        get() = eventCode != null
+
+    private fun getEventCodeHash(): ByteArray {
+        val code = eventCode ?: return ByteArray(0)
+        return BarnardCrypto.computeEventCodeHash(code)
+    }
+
+    // MARK: - DeviceSecret Management
+
+    private fun getOrCreateDeviceSecret(): ByteArray {
+        val key = "rpidSeed"
+        val existing = prefs.getString(key, null)
+        if (existing != null) {
+            val bytes = Base64.decode(existing, Base64.DEFAULT)
+            if (bytes.size >= 32) return bytes
+        }
+        val bytes = BarnardCrypto.generateRandomBytes(32)
+        prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
+        return bytes
+    }
+
+    // MARK: - Scan Control
 
     private fun startScan() {
         val a = adapter ?: run {
@@ -248,10 +427,13 @@ internal class BarnardController(
         discoveredRssi.clear()
         discoveredAt.clear()
         lastConnectAttemptAtMs.clear()
+        peripheralReadValues.clear()
 
         emitState("scan_stop")
         emitDebug("info", "scan_stop", null)
     }
+
+    // MARK: - Advertise Control
 
     private fun startAdvertise() {
         val a = adapter ?: run {
@@ -297,6 +479,7 @@ internal class BarnardController(
                 "formatVersion" to formatVersion,
                 "serviceUuid" to serviceUuid.toString(),
                 "localName" to "BNRD",
+                "eventMode" to isEventMode,
             )
         )
     }
@@ -313,61 +496,91 @@ internal class BarnardController(
         emitDebug("info", "advertise_stop", null)
     }
 
+    // MARK: - GATT Server
+
     @SuppressLint("MissingPermission")
     private fun ensureGattServer() {
         if (gattServer != null) return
+        buildAndAddGattServer()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun rebuildGattServerIfNeeded() {
+        if (!hasConnectPermission()) return
+        gattServer?.close()
+        gattServer = null
+        if (isAdvertising) {
+            buildAndAddGattServer()
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun buildAndAddGattServer() {
         if (!hasConnectPermission()) {
             emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
             return
         }
         val manager = bluetoothManager ?: return
         val server = manager.openGattServer(appContext, gattServerCallback)
+
         val service = BluetoothGattService(serviceUuid, BluetoothGattService.SERVICE_TYPE_PRIMARY)
-        val ch = BluetoothGattCharacteristic(
+
+        // RPID characteristic (Read)
+        val rpidCh = BluetoothGattCharacteristic(
             rpidCharUuid,
             BluetoothGattCharacteristic.PROPERTY_READ,
             BluetoothGattCharacteristic.PERMISSION_READ,
         )
-        service.addCharacteristic(ch)
+        service.addCharacteristic(rpidCh)
+
+        // TEK characteristic (Read/Write)
+        val tekCh = BluetoothGattCharacteristic(
+            tekCharUuid,
+            BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_WRITE,
+            BluetoothGattCharacteristic.PERMISSION_READ or BluetoothGattCharacteristic.PERMISSION_WRITE,
+        )
+        service.addCharacteristic(tekCh)
+
+        // EventCodeHash characteristic (Read)
+        val eventCodeHashCh = BluetoothGattCharacteristic(
+            eventCodeHashCharUuid,
+            BluetoothGattCharacteristic.PROPERTY_READ,
+            BluetoothGattCharacteristic.PERMISSION_READ,
+        )
+        service.addCharacteristic(eventCodeHashCh)
+
         server.addService(service)
         gattServer = server
-        emitDebug("info", "gatt_server_started", null)
+        emitDebug("info", "gatt_server_started", mapOf(
+            "characteristics" to listOf("RPID", "TEK", "EventCodeHash")
+        ))
     }
+
+    // MARK: - RPID Payload Generation
 
     private fun computePayload(nowMs: Long): ByteArray {
-        val rotationSeconds = 600L
-        val window = (nowMs / 1000L) / rotationSeconds
-        val seed = getOrCreateSeed()
+        val enin = BarnardCrypto.calculateEnin(nowMs)
+        val rpik = BarnardCrypto.deriveRpik(currentTek)
+        val rpi = BarnardCrypto.generateRpi(rpik, enin)
 
-        val mac = Mac.getInstance("HmacSHA256")
-        mac.init(SecretKeySpec(seed, "HmacSHA256"))
-        val msg = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(window).array()
-        val digest = mac.doFinal(msg)
-
-        val out = ByteArray(17)
-        out[0] = (formatVersion and 0xFF).toByte()
-        System.arraycopy(digest, 0, out, 1, 16)
-        return out
+        val payload = ByteArray(17)
+        payload[0] = (formatVersion and 0xFF).toByte()
+        System.arraycopy(rpi, 0, payload, 1, 16)
+        return payload
     }
 
-    private fun getOrCreateSeed(): ByteArray {
-        val key = "rpidSeed"
-        val existing = prefs.getString(key, null)
-        if (existing != null) {
-            val bytes = Base64.decode(existing, Base64.DEFAULT)
-            if (bytes.size >= 16) return bytes
-        }
-        val bytes = ByteArray(32)
-        java.security.SecureRandom().nextBytes(bytes)
-        prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
-        return bytes
-    }
+    // MARK: - Event Emission
 
     private fun emitState(reasonCode: String?) {
         val payload = mapOf(
             "type" to "state",
             "timestamp" to BarnardIso8601.now(),
-            "state" to mapOf("isScanning" to isScanning, "isAdvertising" to isAdvertising),
+            "state" to mapOf(
+                "isScanning" to isScanning,
+                "isAdvertising" to isAdvertising,
+                "eventMode" to if (isEventMode) "event" else "anonymous",
+                "eventCode" to eventCode
+            ),
             "reasonCode" to reasonCode,
         )
         mainHandler.post { eventSink?.success(payload) }
@@ -395,7 +608,7 @@ internal class BarnardController(
         mainHandler.post { eventSink?.success(payload) }
     }
 
-    private fun emitDetection(timestampMs: Long, rssi: Int, payloadBytes: ByteArray) {
+    private fun emitDetection(timestampMs: Long, rssi: Int, payloadBytes: ByteArray, resolvedTek: ByteArray? = null) {
         if (payloadBytes.size != 17) {
             emitDebug("warn", "payload_invalid_length", mapOf("length" to payloadBytes.size))
             return
@@ -407,7 +620,28 @@ internal class BarnardController(
         }
         val rpid = payloadBytes.copyOfRange(1, 17)
         val displayId = rpid.copyOfRange(0, 4).joinToString("") { b -> "%02x".format(b) }
-        val payload = mapOf(
+
+        // Try to resolve RPI if we have exchanged TEKs
+        var resolvedTekToEmit = resolvedTek
+        var resolvedDisplayId: String? = null
+
+        if (resolvedTekToEmit == null && isEventMode) {
+            // Try to resolve from stored TEKs
+            val eventCodeHash = getEventCodeHash()
+            val knownTeks = tekStorage.getTeks(eventCodeHash)
+
+            resolvedTekToEmit = BarnardCrypto.resolveRpi(rpid, knownTeks)
+            if (resolvedTekToEmit != null) {
+                // Update lastSeenAt
+                tekStorage.updateLastSeen(resolvedTekToEmit, eventCodeHash)
+            }
+        }
+
+        if (resolvedTekToEmit != null) {
+            resolvedDisplayId = BarnardCrypto.displayId(resolvedTekToEmit)
+        }
+
+        val payload = mutableMapOf<String, Any?>(
             "type" to "detection",
             "timestamp" to BarnardIso8601.fromMs(timestampMs),
             "transport" to "ble",
@@ -418,6 +652,14 @@ internal class BarnardController(
             "rssiSummary" to null,
             "payloadRaw" to Base64.encodeToString(payloadBytes, Base64.NO_WRAP),
         )
+
+        if (resolvedTekToEmit != null) {
+            payload["resolvedTek"] = Base64.encodeToString(resolvedTekToEmit, Base64.NO_WRAP)
+        }
+        if (resolvedDisplayId != null) {
+            payload["resolvedDisplayId"] = resolvedDisplayId
+        }
+
         mainHandler.post { eventSink?.success(payload) }
     }
 
@@ -431,6 +673,8 @@ internal class BarnardController(
         )
         mainHandler.post { debugEventSink?.success(payload) }
     }
+
+    // MARK: - Permissions
 
     private fun hasScanPermission(): Boolean {
         if (Build.VERSION.SDK_INT < 31) return true
@@ -447,6 +691,8 @@ internal class BarnardController(
         return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
     }
 
+    // MARK: - Advertise Callback
+
     private val advertiseCallback = object : AdvertiseCallback() {
         override fun onStartFailure(errorCode: Int) {
             emitError("advertise_failed", "errorCode=$errorCode", recoverable = true)
@@ -458,6 +704,8 @@ internal class BarnardController(
             emitDebug("info", "advertise_started", null)
         }
     }
+
+    // MARK: - Scan Callback
 
     private var scanCallback: ScanCallback? = null
 
@@ -537,6 +785,8 @@ internal class BarnardController(
         }
     }
 
+    // MARK: - Connection Queue
+
     private fun enqueueConnect(device: BluetoothDevice) {
         val address = device.address ?: return
         // Skip if already in queue or currently connecting.
@@ -567,6 +817,8 @@ internal class BarnardController(
             return
         }
         lastConnectAttemptAtMs[key] = nowMs
+        peripheralReadValues[key] = GattReadValues()
+
         activeGatt =
             if (Build.VERSION.SDK_INT >= 23) {
                 device.connectGatt(appContext, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
@@ -577,12 +829,37 @@ internal class BarnardController(
         emitDebug("trace", "connect_attempt", mapOf("address" to device.address))
     }
 
+    // MARK: - GATT Exchange Logic
+
+    private fun shouldExchangeTek(remoteEventCodeHash: ByteArray?): Boolean {
+        // If we're in Anonymous Mode, don't exchange
+        if (!isEventMode) return false
+
+        // If remote is Anonymous (empty hash), don't exchange
+        if (remoteEventCodeHash == null || remoteEventCodeHash.isEmpty()) return false
+
+        // Check if hashes match
+        val myHash = getEventCodeHash()
+        return myHash.contentEquals(remoteEventCodeHash)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun finishConnection(gatt: BluetoothGatt) {
+        val address = gatt.device?.address ?: ""
+        peripheralReadValues.remove(address)
+        gatt.disconnect()
+    }
+
+    // MARK: - GATT Client Callback
+
     private val gattCallback = object : BluetoothGattCallback() {
         @SuppressLint("MissingPermission")
         override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 emitError("connect_failed", "status=$status", recoverable = true)
                 gatt.close()
+                val address = gatt.device?.address ?: ""
+                peripheralReadValues.remove(address)
                 activeGatt = null
                 pumpConnectQueue()
                 return
@@ -591,42 +868,46 @@ internal class BarnardController(
                 emitDebug("trace", "connected", mapOf("address" to gatt.device.address))
                 gatt.discoverServices()
             } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                val address = gatt.device?.address ?: ""
+                peripheralReadValues.remove(address)
                 gatt.close()
                 activeGatt = null
                 pumpConnectQueue()
             }
         }
 
+        @SuppressLint("MissingPermission")
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 emitError("service_discovery_failed", "status=$status", recoverable = true)
-                gatt.disconnect()
+                finishConnection(gatt)
                 return
             }
             val svc = gatt.getService(serviceUuid)
             if (svc == null) {
                 emitError("service_not_found", "Barnard service not found", recoverable = true)
-                gatt.disconnect()
+                finishConnection(gatt)
                 return
             }
-            val ch = svc.getCharacteristic(rpidCharUuid)
-            if (ch == null) {
-                emitError("characteristic_not_found", "RPID characteristic not found", recoverable = true)
-                gatt.disconnect()
-                return
+
+            // Step 1: Read EventCodeHash first
+            val eventCodeHashCh = svc.getCharacteristic(eventCodeHashCharUuid)
+            if (eventCodeHashCh != null && hasConnectPermission()) {
+                gatt.readCharacteristic(eventCodeHashCh)
+            } else {
+                // No EventCodeHash characteristic, read RPID directly
+                val rpidCh = svc.getCharacteristic(rpidCharUuid)
+                if (rpidCh != null && hasConnectPermission()) {
+                    gatt.readCharacteristic(rpidCh)
+                } else {
+                    finishConnection(gatt)
+                }
             }
-            if (!hasConnectPermission()) {
-                emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
-                gatt.disconnect()
-                return
-            }
-            @SuppressLint("MissingPermission")
-            gatt.readCharacteristic(ch)
         }
 
         override fun onCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
             val value = characteristic.value ?: ByteArray(0)
-            handleRead(gatt, status, value)
+            handleCharacteristicRead(gatt, characteristic.uuid, status, value)
         }
 
         override fun onCharacteristicRead(
@@ -635,22 +916,122 @@ internal class BarnardController(
             value: ByteArray,
             status: Int
         ) {
-            handleRead(gatt, status, value)
+            handleCharacteristicRead(gatt, characteristic.uuid, status, value)
         }
 
-        private fun handleRead(gatt: BluetoothGatt, status: Int, value: ByteArray) {
-            if (status != BluetoothGatt.GATT_SUCCESS) {
-                emitError("read_failed", "status=$status", recoverable = true)
-                gatt.disconnect()
+        @SuppressLint("MissingPermission")
+        private fun handleCharacteristicRead(gatt: BluetoothGatt, uuid: UUID, status: Int, value: ByteArray) {
+            val address = gatt.device?.address ?: ""
+            val svc = gatt.getService(serviceUuid) ?: run {
+                finishConnection(gatt)
                 return
             }
-            val address = gatt.device.address ?: ""
-            val rssi = discoveredRssi[address] ?: 0
-            val ts = discoveredAt[address] ?: System.currentTimeMillis()
-            emitDetection(ts, rssi, value)
-            gatt.disconnect()
+
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                emitError("read_failed", "status=$status uuid=$uuid", recoverable = true)
+                finishConnection(gatt)
+                return
+            }
+
+            when (uuid) {
+                eventCodeHashCharUuid -> {
+                    peripheralReadValues[address]?.eventCodeHash = value
+                    emitDebug("trace", "gatt_read_event_code_hash", mapOf(
+                        "address" to address,
+                        "bytes" to value.size,
+                        "isEmpty" to value.isEmpty()
+                    ))
+                    // Proceed to RPID read
+                    val rpidCh = svc.getCharacteristic(rpidCharUuid)
+                    if (rpidCh != null && hasConnectPermission()) {
+                        gatt.readCharacteristic(rpidCh)
+                    } else {
+                        finishConnection(gatt)
+                    }
+                }
+
+                rpidCharUuid -> {
+                    peripheralReadValues[address]?.rpid = value
+                    emitDebug("trace", "gatt_read_rpid", mapOf(
+                        "address" to address,
+                        "bytes" to value.size
+                    ))
+                    // Check if we should exchange TEK
+                    val remoteHash = peripheralReadValues[address]?.eventCodeHash
+                    if (shouldExchangeTek(remoteHash)) {
+                        val tekCh = svc.getCharacteristic(tekCharUuid)
+                        if (tekCh != null && hasConnectPermission()) {
+                            gatt.readCharacteristic(tekCh)
+                        } else {
+                            completeGattExchange(gatt)
+                        }
+                    } else {
+                        completeGattExchange(gatt)
+                    }
+                }
+
+                tekCharUuid -> {
+                    peripheralReadValues[address]?.tek = value
+                    emitDebug("trace", "gatt_read_tek", mapOf(
+                        "address" to address,
+                        "bytes" to value.size
+                    ))
+                    // Store received TEK
+                    val remoteHash = peripheralReadValues[address]?.eventCodeHash
+                    if (value.size == 16 && remoteHash != null && remoteHash.size == 8) {
+                        val entry = TekEntry(
+                            tek = value,
+                            eventCodeHash = remoteHash,
+                            exchangedAt = System.currentTimeMillis(),
+                            lastSeenAt = System.currentTimeMillis()
+                        )
+                        tekStorage.store(entry)
+                        emitDebug("info", "tek_received", mapOf(
+                            "displayId" to BarnardCrypto.displayId(value)
+                        ))
+                    }
+                    // Write our TEK to complete exchange
+                    val tekCh = svc.getCharacteristic(tekCharUuid)
+                    if (tekCh != null && hasConnectPermission()) {
+                        tekCh.value = currentTek
+                        gatt.writeCharacteristic(tekCh)
+                    } else {
+                        completeGattExchange(gatt)
+                    }
+                }
+            }
+        }
+
+        @SuppressLint("MissingPermission")
+        override fun onCharacteristicWrite(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                emitError("write_failed", "status=$status", recoverable = true)
+            } else {
+                emitDebug("trace", "gatt_write_tek", mapOf(
+                    "address" to (gatt.device?.address ?: ""),
+                    "displayId" to BarnardCrypto.displayId(currentTek)
+                ))
+            }
+            completeGattExchange(gatt)
+        }
+
+        private fun completeGattExchange(gatt: BluetoothGatt) {
+            val address = gatt.device?.address ?: ""
+            val values = peripheralReadValues[address]
+
+            // Emit detection
+            val rpidData = values?.rpid
+            if (rpidData != null) {
+                val rssi = discoveredRssi[address] ?: 0
+                val ts = discoveredAt[address] ?: System.currentTimeMillis()
+                emitDetection(ts, rssi, rpidData, values?.tek)
+            }
+
+            finishConnection(gatt)
         }
     }
+
+    // MARK: - GATT Server Callback
 
     private val gattServerCallback = object : BluetoothGattServerCallback() {
         @SuppressLint("MissingPermission")
@@ -661,21 +1042,117 @@ internal class BarnardController(
             characteristic: BluetoothGattCharacteristic
         ) {
             val server = gattServer ?: return
-            val payload = computePayload(System.currentTimeMillis())
-            val slice =
-                if (offset <= 0) payload
-                else if (offset >= payload.size) ByteArray(0)
-                else payload.copyOfRange(offset, payload.size)
-            server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
-            emitDebug(
-                "trace",
-                "gatt_read_rpid",
-                mapOf(
-                    "bytes" to payload.size,
-                    "formatVersion" to (payload[0].toInt() and 0xFF),
-                    "displayId" to displayIdForPayload(payload),
-                )
+
+            when (characteristic.uuid) {
+                rpidCharUuid -> {
+                    val payload = computePayload(System.currentTimeMillis())
+                    val slice =
+                        if (offset <= 0) payload
+                        else if (offset >= payload.size) ByteArray(0)
+                        else payload.copyOfRange(offset, payload.size)
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+                    emitDebug(
+                        "trace",
+                        "gatt_read_rpid",
+                        mapOf(
+                            "bytes" to payload.size,
+                            "formatVersion" to (payload[0].toInt() and 0xFF),
+                            "displayId" to displayIdForPayload(payload),
+                        )
+                    )
+                }
+
+                tekCharUuid -> {
+                    // Only return TEK in Event Mode
+                    if (isEventMode) {
+                        val slice =
+                            if (offset <= 0) currentTek
+                            else if (offset >= currentTek.size) ByteArray(0)
+                            else currentTek.copyOfRange(offset, currentTek.size)
+                        server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+                        emitDebug("trace", "gatt_respond_tek_read", mapOf(
+                            "displayId" to BarnardCrypto.displayId(currentTek)
+                        ))
+                    } else {
+                        server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+                        emitDebug("trace", "gatt_reject_tek_read", mapOf(
+                            "reason" to "anonymous_mode"
+                        ))
+                    }
+                }
+
+                eventCodeHashCharUuid -> {
+                    val hash = getEventCodeHash()
+                    val slice =
+                        if (offset <= 0) hash
+                        else if (offset >= hash.size) ByteArray(0)
+                        else hash.copyOfRange(offset, hash.size)
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+                    emitDebug("trace", "gatt_respond_event_code_hash", mapOf(
+                        "bytes" to hash.size,
+                        "isEmpty" to hash.isEmpty()
+                    ))
+                }
+
+                else -> {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED, offset, null)
+                }
+            }
+        }
+
+        @SuppressLint("MissingPermission")
+        override fun onCharacteristicWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            characteristic: BluetoothGattCharacteristic,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray?
+        ) {
+            val server = gattServer ?: return
+
+            if (characteristic.uuid != tekCharUuid) {
+                if (responseNeeded) {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+                }
+                return
+            }
+
+            if (value == null || value.size != 16) {
+                if (responseNeeded) {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH, offset, null)
+                }
+                return
+            }
+
+            // Only accept TEK writes in Event Mode
+            if (!isEventMode) {
+                if (responseNeeded) {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+                }
+                emitDebug("trace", "gatt_reject_tek_write", mapOf(
+                    "reason" to "anonymous_mode"
+                ))
+                return
+            }
+
+            // Store the received TEK
+            val eventCodeHash = getEventCodeHash()
+            val entry = TekEntry(
+                tek = value,
+                eventCodeHash = eventCodeHash,
+                exchangedAt = System.currentTimeMillis(),
+                lastSeenAt = System.currentTimeMillis()
             )
+            tekStorage.store(entry)
+
+            if (responseNeeded) {
+                server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+            }
+            emitDebug("info", "tek_received_via_write", mapOf(
+                "displayId" to BarnardCrypto.displayId(value)
+            ))
         }
     }
 

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -30,6 +30,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
 import android.util.Base64
+import network.greeting.barnard.BuildConfig
 import android.util.Log
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
@@ -73,6 +74,7 @@ internal class BarnardController(
     private var isAdvertising: Boolean = false
     private var allowDuplicates: Boolean = true
     private var formatVersion: Int = 1
+    private var debugOriginalName: String? = null
 
     // MARK: - Event Mode
 
@@ -85,6 +87,11 @@ internal class BarnardController(
 
     private val discoveredRssi: MutableMap<String, Int> = mutableMapOf()
     private val discoveredAt: MutableMap<String, Long> = mutableMapOf()
+    private val lastDiscoveryNameById: MutableMap<String, String> = mutableMapOf()
+
+    private fun isDebugBuild(): Boolean {
+        return BuildConfig.BUILD_TYPE != "release"
+    }
 
     // MARK: - Connection Queue
 
@@ -146,17 +153,9 @@ internal class BarnardController(
             val deviceSecret = getOrCreateDeviceSecret()
             currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret, eventCode!!)
         } else {
-            // Anonymous Mode: use stored random TEK or generate new one
-            val storedTek = prefs.getString("currentTek", null)
-            if (storedTek != null) {
-                val decoded = Base64.decode(storedTek, Base64.DEFAULT)
-                if (decoded.size == 16) {
-                    currentTek = decoded
-                    return
-                }
-            }
-            currentTek = BarnardCrypto.generateRandomTek()
-            prefs.edit().putString("currentTek", Base64.encodeToString(currentTek, Base64.NO_WRAP)).apply()
+            // Anonymous Mode: derive TEK from DeviceSecret
+            val deviceSecret = getOrCreateDeviceSecret()
+            currentTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret)
         }
     }
 
@@ -185,6 +184,13 @@ internal class BarnardController(
                     "isScanning" to isScanning,
                     "isAdvertising" to isAdvertising,
                     "eventMode" to if (eventCode != null) "event" else "anonymous",
+                    "eventCode" to eventCode
+                )
+            )
+
+            "getEventMode" -> result.success(
+                mapOf(
+                    "mode" to if (eventCode != null) "event" else "anonymous",
                     "eventCode" to eventCode
                 )
             )
@@ -306,7 +312,6 @@ internal class BarnardController(
         // Derive TEK from DeviceSecret + EventCode
         val deviceSecret = getOrCreateDeviceSecret()
         currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret, code)
-        prefs.edit().remove("currentTek").apply() // Event-derived TEK can be recomputed
 
         // Rebuild GATT server
         rebuildGattServerIfNeeded()
@@ -322,9 +327,9 @@ internal class BarnardController(
         eventCode = null
         prefs.edit().remove("eventCode").apply()
 
-        // Generate new random TEK
-        currentTek = BarnardCrypto.generateRandomTek()
-        prefs.edit().putString("currentTek", Base64.encodeToString(currentTek, Base64.NO_WRAP)).apply()
+        // Derive TEK from DeviceSecret
+        val deviceSecret = getOrCreateDeviceSecret()
+        currentTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret)
 
         // Rebuild GATT server
         rebuildGattServerIfNeeded()
@@ -426,6 +431,7 @@ internal class BarnardController(
         // Clear discovery state for clean restart
         discoveredRssi.clear()
         discoveredAt.clear()
+        lastDiscoveryNameById.clear()
         lastConnectAttemptAtMs.clear()
         peripheralReadValues.clear()
 
@@ -452,6 +458,14 @@ internal class BarnardController(
             emitConstraint("advertise_unsupported", "Multiple advertisement not supported")
             return
         }
+        if (!hasConnectPermission()) {
+            emitConstraint(
+                "permission_denied",
+                "Missing BLUETOOTH_CONNECT permission",
+                requiredAction = "grant_permission"
+            )
+            return
+        }
         val adv = a.bluetoothLeAdvertiser ?: run {
             emitError("advertise_failed", "BluetoothLeAdvertiser is null", recoverable = true)
             return
@@ -460,6 +474,26 @@ internal class BarnardController(
 
         ensureGattServer()
 
+        val localName = if (isDebugBuild()) {
+            val deviceSecret = getOrCreateDeviceSecret()
+            val tail = if (deviceSecret.size >= 2) {
+                deviceSecret.copyOfRange(deviceSecret.size - 2, deviceSecret.size)
+            } else {
+                deviceSecret
+            }
+            val suffix = tail.joinToString("") { "%02x".format(it) }.uppercase()
+            val debugName = "BND-" + if (suffix.isEmpty()) "DEAD" else suffix
+            if (debugOriginalName == null && !a.name.isNullOrEmpty()) {
+                debugOriginalName = a.name
+            }
+            if (a.name != debugName) {
+                a.name = debugName
+            }
+            debugName
+        } else {
+            "BNRD"
+        }
+
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
             .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
@@ -467,7 +501,7 @@ internal class BarnardController(
             .build()
         val data = AdvertiseData.Builder()
             .addServiceUuid(ParcelUuid(serviceUuid))
-            .setIncludeDeviceName(false)
+            .setIncludeDeviceName(isDebugBuild())
             .build()
         adv.startAdvertising(settings, data, advertiseCallback)
         isAdvertising = true
@@ -478,7 +512,7 @@ internal class BarnardController(
             mapOf(
                 "formatVersion" to formatVersion,
                 "serviceUuid" to serviceUuid.toString(),
-                "localName" to "BNRD",
+                "localName" to localName,
                 "eventMode" to isEventMode,
             )
         )
@@ -488,6 +522,13 @@ internal class BarnardController(
         if (!isAdvertising) return
         if (hasAdvertisePermission()) {
             adapter?.bluetoothLeAdvertiser?.stopAdvertising(advertiseCallback)
+        }
+        if (BuildConfig.DEBUG) {
+            val original = debugOriginalName
+            if (original != null && adapter?.name != original) {
+                adapter?.name = original
+            }
+            debugOriginalName = null
         }
         isAdvertising = false
         gattServer?.close()
@@ -608,7 +649,13 @@ internal class BarnardController(
         mainHandler.post { eventSink?.success(payload) }
     }
 
-    private fun emitDetection(timestampMs: Long, rssi: Int, payloadBytes: ByteArray, resolvedTek: ByteArray? = null) {
+    private fun emitDetection(
+        timestampMs: Long,
+        rssi: Int,
+        payloadBytes: ByteArray,
+        resolvedTek: ByteArray? = null,
+        debugLocalName: String? = null
+    ) {
         if (payloadBytes.size != 17) {
             emitDebug("warn", "payload_invalid_length", mapOf("length" to payloadBytes.size))
             return
@@ -658,6 +705,9 @@ internal class BarnardController(
         }
         if (resolvedDisplayId != null) {
             payload["resolvedDisplayId"] = resolvedDisplayId
+        }
+        if (isDebugBuild() && debugLocalName != null) {
+            payload["debugLocalName"] = debugLocalName
         }
 
         mainHandler.post { eventSink?.success(payload) }
@@ -753,6 +803,11 @@ internal class BarnardController(
         }
         discoveredRssi[address] = result.rssi
         discoveredAt[address] = nowMs
+        if (isDebugBuild()) {
+            result.scanRecord?.deviceName?.let { name ->
+                if (name.isNotEmpty()) lastDiscoveryNameById[address] = name
+            }
+        }
 
         emitDebug("trace", "ble_discovery_result", mapOf(
             "id" to address,
@@ -768,7 +823,7 @@ internal class BarnardController(
         val uuids = record.serviceUuids
         val hasService = uuids?.any { it.uuid == serviceUuid } == true
         val name = record.deviceName
-        val isBnrd = name == "BNRD"
+        val isBnrd = name == "BNRD" || (isDebugBuild() && name?.startsWith("BND-") == true)
         Log.d(TAG, "isBarnardScanResult: addr=${result.device?.address} name=$name hasService=$hasService isBnrd=$isBnrd uuids=$uuids")
         // 1. Service UUID match (reliable for Android-to-Android).
         if (hasService) return true
@@ -847,6 +902,7 @@ internal class BarnardController(
     private fun finishConnection(gatt: BluetoothGatt) {
         val address = gatt.device?.address ?: ""
         peripheralReadValues.remove(address)
+        lastDiscoveryNameById.remove(address)
         gatt.disconnect()
     }
 
@@ -860,6 +916,7 @@ internal class BarnardController(
                 gatt.close()
                 val address = gatt.device?.address ?: ""
                 peripheralReadValues.remove(address)
+                lastDiscoveryNameById.remove(address)
                 activeGatt = null
                 pumpConnectQueue()
                 return
@@ -870,6 +927,7 @@ internal class BarnardController(
             } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
                 val address = gatt.device?.address ?: ""
                 peripheralReadValues.remove(address)
+                lastDiscoveryNameById.remove(address)
                 gatt.close()
                 activeGatt = null
                 pumpConnectQueue()
@@ -993,8 +1051,16 @@ internal class BarnardController(
                     // Write our TEK to complete exchange
                     val tekCh = svc.getCharacteristic(tekCharUuid)
                     if (tekCh != null && hasConnectPermission()) {
-                        tekCh.value = currentTek
-                        gatt.writeCharacteristic(tekCh)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            gatt.writeCharacteristic(
+                                tekCh,
+                                currentTek,
+                                BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+                            )
+                        } else {
+                            tekCh.value = currentTek
+                            gatt.writeCharacteristic(tekCh)
+                        }
                     } else {
                         completeGattExchange(gatt)
                     }
@@ -1024,7 +1090,7 @@ internal class BarnardController(
             if (rpidData != null) {
                 val rssi = discoveredRssi[address] ?: 0
                 val ts = discoveredAt[address] ?: System.currentTimeMillis()
-                emitDetection(ts, rssi, rpidData, values?.tek)
+                emitDetection(ts, rssi, rpidData, values?.tek, lastDiscoveryNameById[address])
             }
 
             finishConnection(gatt)

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
@@ -18,7 +18,7 @@ import javax.crypto.spec.SecretKeySpec
  * ```
  * DeviceSecret (32 bytes)
  *      |
- *      +-- Anonymous Mode: TEK = random 16 bytes
+ *      +-- Anonymous Mode: TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)
  *      |
  *      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
  *                           |
@@ -45,9 +45,13 @@ object BarnardCrypto {
     }
 
     /**
-     * Generate a random TEK for Anonymous Mode.
+     * Derive TEK for Anonymous Mode from DeviceSecret.
+     *
+     * `TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)`
      */
-    fun generateRandomTek(): ByteArray = generateRandomBytes(16)
+    fun deriveTekForAnonymous(deviceSecret: ByteArray): ByteArray {
+        return hkdfSha256(deviceSecret, "barnard-tek-anonymous".toByteArray(Charsets.UTF_8), 16)
+    }
 
     // MARK: - RPIK Derivation
 
@@ -171,10 +175,10 @@ object BarnardCrypto {
     // MARK: - Display ID
 
     /**
-     * Get displayId from TEK (first 3 bytes as uppercase hex).
+     * Get displayId from TEK (first 3 bytes as lowercase hex).
      */
     fun displayId(tek: ByteArray): String {
-        return tek.take(3).joinToString("") { "%02X".format(it) }
+        return tek.take(3).joinToString("") { "%02x".format(it) }
     }
 
     // MARK: - HKDF

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
@@ -1,0 +1,211 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * GAEN v1.2-compatible cryptographic utilities for Resolvable ID.
+ *
+ * Key derivation chain:
+ * ```
+ * DeviceSecret (32 bytes)
+ *      |
+ *      +-- Anonymous Mode: TEK = random 16 bytes
+ *      |
+ *      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
+ *                           |
+ *                           v
+ *                      RPIK = HKDF(TEK, "EN-RPIK", 16)
+ *                           |
+ *                           v
+ *                      RPI = AES128-ECB(RPIK, PaddedData)
+ * ```
+ */
+object BarnardCrypto {
+
+    // MARK: - TEK Derivation
+
+    /**
+     * Derive TEK for Event Mode from DeviceSecret and EventCode.
+     *
+     * `TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`
+     */
+    fun deriveTekForEvent(deviceSecret: ByteArray, eventCode: String): ByteArray {
+        val eventCodeBytes = eventCode.toByteArray(Charsets.UTF_8)
+        val combined = deviceSecret + eventCodeBytes
+        return hkdfSha256(combined, "barnard-tek".toByteArray(Charsets.UTF_8), 16)
+    }
+
+    /**
+     * Generate a random TEK for Anonymous Mode.
+     */
+    fun generateRandomTek(): ByteArray = generateRandomBytes(16)
+
+    // MARK: - RPIK Derivation
+
+    /**
+     * Derive RPIK (Rolling Proximity Identifier Key) from TEK.
+     *
+     * `RPIK = HKDF(TEK, "EN-RPIK", 16)`
+     */
+    fun deriveRpik(tek: ByteArray): ByteArray {
+        if (tek.size != 16) return ByteArray(16)
+        return hkdfSha256(tek, "EN-RPIK".toByteArray(Charsets.UTF_8), 16)
+    }
+
+    // MARK: - RPI Generation
+
+    /**
+     * Generate RPI from RPIK and ENIN.
+     *
+     * `RPI = AES128-ECB(RPIK, PaddedData)`
+     *
+     * Where PaddedData = "EN-RPI" (6 bytes) + 0x000000000000 (6 bytes) + ENIN (4 bytes big-endian)
+     */
+    fun generateRpi(rpik: ByteArray, enin: UInt): ByteArray {
+        if (rpik.size != 16) return ByteArray(16)
+
+        // Build PaddedData: "EN-RPI" + 6 zero bytes + ENIN (4 bytes big-endian)
+        val paddedData = ByteArray(16)
+
+        // "EN-RPI" (6 bytes)
+        val prefix = "EN-RPI".toByteArray(Charsets.UTF_8)
+        System.arraycopy(prefix, 0, paddedData, 0, 6)
+
+        // 6 zero bytes (already initialized to 0)
+
+        // ENIN as 4 bytes big-endian at offset 12
+        val eninBytes = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(enin.toInt()).array()
+        System.arraycopy(eninBytes, 0, paddedData, 12, 4)
+
+        // AES-128-ECB encryption
+        return aes128EcbEncrypt(rpik, paddedData)
+    }
+
+    /**
+     * AES-128-ECB encryption of a single 16-byte block.
+     */
+    private fun aes128EcbEncrypt(key: ByteArray, plaintext: ByteArray): ByteArray {
+        if (key.size != 16 || plaintext.size != 16) return ByteArray(16)
+
+        return try {
+            val cipher = Cipher.getInstance("AES/ECB/NoPadding")
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"))
+            cipher.doFinal(plaintext)
+        } catch (e: Exception) {
+            ByteArray(16)
+        }
+    }
+
+    // MARK: - ENIN Calculation
+
+    /**
+     * Calculate ENIN (EN Interval Number) for a given timestamp.
+     *
+     * `ENIN = floor(unix_timestamp_seconds / 600)`
+     *
+     * Each ENIN represents a 10-minute interval.
+     */
+    fun calculateEnin(timestampMs: Long = System.currentTimeMillis()): UInt {
+        return ((timestampMs / 1000) / 600).toUInt()
+    }
+
+    // MARK: - EventCodeHash
+
+    /**
+     * Calculate EventCodeHash from EventCode.
+     *
+     * `EventCodeHash = SHA256(EventCode)[0:8]`
+     */
+    fun computeEventCodeHash(eventCode: String): ByteArray {
+        val eventCodeBytes = eventCode.toByteArray(Charsets.UTF_8)
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(eventCodeBytes)
+        return hash.copyOfRange(0, 8)
+    }
+
+    // MARK: - RPI Resolution
+
+    /**
+     * Attempt to resolve an RPI to a known TEK.
+     *
+     * Searches within a time window around the current ENIN (±6 past + 1 future).
+     *
+     * @param rpi The 16-byte RPI to resolve
+     * @param knownTeks List of known TEKs to search
+     * @param currentEnin Current ENIN (defaults to now)
+     * @return The matching TEK if found, null otherwise
+     */
+    fun resolveRpi(rpi: ByteArray, knownTeks: List<ByteArray>, currentEnin: UInt? = null): ByteArray? {
+        if (rpi.size != 16) return null
+
+        val enin = currentEnin ?: calculateEnin()
+
+        for (tek in knownTeks) {
+            if (tek.size != 16) continue
+
+            val rpik = deriveRpik(tek)
+
+            // Search window: 6 intervals past + current + 1 future
+            for (offset in -6..1) {
+                val testEnin = (enin.toInt() + offset).toUInt()
+                val candidate = generateRpi(rpik, testEnin)
+
+                if (candidate.contentEquals(rpi)) {
+                    return tek
+                }
+            }
+        }
+
+        return null
+    }
+
+    // MARK: - Display ID
+
+    /**
+     * Get displayId from TEK (first 3 bytes as uppercase hex).
+     */
+    fun displayId(tek: ByteArray): String {
+        return tek.take(3).joinToString("") { "%02X".format(it) }
+    }
+
+    // MARK: - HKDF
+
+    /**
+     * HKDF-SHA256 key derivation (simplified: no salt, extract-then-expand).
+     */
+    private fun hkdfSha256(ikm: ByteArray, info: ByteArray, outputLength: Int): ByteArray {
+        // Extract: PRK = HMAC-SHA256(salt=zeros, IKM)
+        val salt = ByteArray(32) // All zeros
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(salt, "HmacSHA256"))
+        val prk = mac.doFinal(ikm)
+
+        // Expand: OKM = HMAC-SHA256(PRK, info || 0x01)
+        mac.init(SecretKeySpec(prk, "HmacSHA256"))
+        mac.update(info)
+        mac.update(0x01.toByte())
+        val okm = mac.doFinal()
+
+        return okm.copyOfRange(0, outputLength)
+    }
+
+    // MARK: - Random Bytes
+
+    /**
+     * Generate cryptographically secure random bytes.
+     */
+    fun generateRandomBytes(count: Int): ByteArray {
+        val bytes = ByteArray(count)
+        SecureRandom().nextBytes(bytes)
+        return bytes
+    }
+}

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardTekStorage.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardTekStorage.kt
@@ -22,7 +22,7 @@ data class TekEntry(
     /** When the TEK holder was last seen (epoch millis). */
     var lastSeenAt: Long
 ) {
-    /** Display ID: first 3 bytes of TEK as uppercase hex. */
+    /** Display ID: first 3 bytes of TEK as lowercase hex. */
     val displayId: String
         get() = BarnardCrypto.displayId(tek)
 
@@ -112,7 +112,7 @@ class BarnardTekStorage(
 
         // Evict expired entries
         val now = System.currentTimeMillis()
-        val validEntries = entries.filter { now - it.exchangedAt < config.ttlMs }.toMutableList()
+        val validEntries = entries.filter { now - it.lastSeenAt < config.ttlMs }.toMutableList()
 
         // LRU eviction if over capacity
         if (validEntries.size > config.maxEntries) {
@@ -132,7 +132,7 @@ class BarnardTekStorage(
 
         // Filter expired entries
         val now = System.currentTimeMillis()
-        val validEntries = entries.filter { now - it.exchangedAt < config.ttlMs }
+        val validEntries = entries.filter { now - it.lastSeenAt < config.ttlMs }
 
         // Save back if we filtered any
         if (validEntries.size != entries.size) {

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardTekStorage.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardTekStorage.kt
@@ -1,0 +1,231 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A stored TEK entry from GATT exchange.
+ */
+data class TekEntry(
+    /** The 16-byte TEK. */
+    val tek: ByteArray,
+    /** The 8-byte EventCodeHash (SHA256(EventCode)[0:8]). */
+    val eventCodeHash: ByteArray,
+    /** When the TEK was first exchanged (epoch millis). */
+    val exchangedAt: Long,
+    /** When the TEK holder was last seen (epoch millis). */
+    var lastSeenAt: Long
+) {
+    /** Display ID: first 3 bytes of TEK as uppercase hex. */
+    val displayId: String
+        get() = BarnardCrypto.displayId(tek)
+
+    /** Convert to JSON for storage. */
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("tek", Base64.encodeToString(tek, Base64.NO_WRAP))
+        put("eventCodeHash", Base64.encodeToString(eventCodeHash, Base64.NO_WRAP))
+        put("exchangedAt", exchangedAt)
+        put("lastSeenAt", lastSeenAt)
+    }
+
+    /** Convert to platform channel map. */
+    fun toMap(): Map<String, Any?> = mapOf(
+        "tek" to Base64.encodeToString(tek, Base64.NO_WRAP),
+        "eventCodeHash" to Base64.encodeToString(eventCodeHash, Base64.NO_WRAP),
+        "exchangedAt" to BarnardIso8601.fromMs(exchangedAt),
+        "lastSeenAt" to BarnardIso8601.fromMs(lastSeenAt),
+        "displayId" to displayId
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TekEntry) return false
+        return tek.contentEquals(other.tek)
+    }
+
+    override fun hashCode(): Int = tek.contentHashCode()
+
+    companion object {
+        /** Create from JSON. */
+        fun fromJson(json: JSONObject): TekEntry? {
+            return try {
+                TekEntry(
+                    tek = Base64.decode(json.getString("tek"), Base64.DEFAULT),
+                    eventCodeHash = Base64.decode(json.getString("eventCodeHash"), Base64.DEFAULT),
+                    exchangedAt = json.getLong("exchangedAt"),
+                    lastSeenAt = json.getLong("lastSeenAt")
+                )
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+}
+
+/**
+ * TEK storage configuration.
+ */
+data class TekStorageConfig(
+    /** TTL in milliseconds (default 24 hours). */
+    val ttlMs: Long = 86400_000L,
+    /** Maximum number of stored entries (default 1000). */
+    val maxEntries: Int = 1000
+)
+
+/**
+ * Persistent storage for exchanged TEKs.
+ *
+ * Storage is organized by EventCodeHash (base64), with bounded size and TTL.
+ */
+class BarnardTekStorage(
+    private val context: Context,
+    private val config: TekStorageConfig = TekStorageConfig()
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("barnard_tek_storage", Context.MODE_PRIVATE)
+
+    private val keyPrefix = "teks_"
+
+    // MARK: - Public API
+
+    /**
+     * Store a TEK entry for a given event code hash.
+     */
+    fun store(entry: TekEntry) {
+        val key = storageKey(entry.eventCodeHash)
+        val entries = loadEntries(key).toMutableList()
+
+        // Check if we already have this TEK
+        val existingIndex = entries.indexOfFirst { it.tek.contentEquals(entry.tek) }
+        if (existingIndex >= 0) {
+            // Update lastSeenAt
+            entries[existingIndex].lastSeenAt = entry.lastSeenAt
+        } else {
+            entries.add(entry)
+        }
+
+        // Evict expired entries
+        val now = System.currentTimeMillis()
+        val validEntries = entries.filter { now - it.exchangedAt < config.ttlMs }.toMutableList()
+
+        // LRU eviction if over capacity
+        if (validEntries.size > config.maxEntries) {
+            validEntries.sortBy { it.lastSeenAt }
+            validEntries.subList(0, validEntries.size - config.maxEntries).clear()
+        }
+
+        saveEntries(validEntries, key)
+    }
+
+    /**
+     * Get all TEK entries for a given event code hash.
+     */
+    fun getEntries(eventCodeHash: ByteArray): List<TekEntry> {
+        val key = storageKey(eventCodeHash)
+        val entries = loadEntries(key)
+
+        // Filter expired entries
+        val now = System.currentTimeMillis()
+        val validEntries = entries.filter { now - it.exchangedAt < config.ttlMs }
+
+        // Save back if we filtered any
+        if (validEntries.size != entries.size) {
+            saveEntries(validEntries, key)
+        }
+
+        return validEntries
+    }
+
+    /**
+     * Get all TEKs (as ByteArray) for a given event code hash.
+     */
+    fun getTeks(eventCodeHash: ByteArray): List<ByteArray> {
+        return getEntries(eventCodeHash).map { it.tek }
+    }
+
+    /**
+     * Clear all TEKs for a given event code hash.
+     * @return The number of entries removed.
+     */
+    fun clear(eventCodeHash: ByteArray): Int {
+        val key = storageKey(eventCodeHash)
+        val entries = loadEntries(key)
+        val count = entries.size
+        prefs.edit().remove(key).apply()
+        return count
+    }
+
+    /**
+     * Clear all stored TEKs across all events.
+     * @return The total number of entries removed.
+     */
+    fun clearAll(): Int {
+        var total = 0
+
+        val allKeys = prefs.all.keys.filter { it.startsWith(keyPrefix) }
+        val editor = prefs.edit()
+
+        for (key in allKeys) {
+            val entries = loadEntries(key)
+            total += entries.size
+            editor.remove(key)
+        }
+
+        editor.apply()
+        return total
+    }
+
+    /**
+     * Update lastSeenAt for a TEK if it exists.
+     */
+    fun updateLastSeen(tek: ByteArray, eventCodeHash: ByteArray, at: Long = System.currentTimeMillis()) {
+        val key = storageKey(eventCodeHash)
+        val entries = loadEntries(key).toMutableList()
+
+        val index = entries.indexOfFirst { it.tek.contentEquals(tek) }
+        if (index >= 0) {
+            entries[index].lastSeenAt = at
+            saveEntries(entries, key)
+        }
+    }
+
+    // MARK: - Private
+
+    private fun storageKey(eventCodeHash: ByteArray): String {
+        return keyPrefix + Base64.encodeToString(eventCodeHash, Base64.NO_WRAP)
+    }
+
+    private fun loadEntries(key: String): List<TekEntry> {
+        val jsonString = prefs.getString(key, null) ?: return emptyList()
+
+        return try {
+            val array = JSONArray(jsonString)
+            (0 until array.length()).mapNotNull { i ->
+                TekEntry.fromJson(array.getJSONObject(i))
+            }
+        } catch (e: Exception) {
+            // Corrupted data, clear it
+            prefs.edit().remove(key).apply()
+            emptyList()
+        }
+    }
+
+    private fun saveEntries(entries: List<TekEntry>, key: String) {
+        if (entries.isEmpty()) {
+            prefs.edit().remove(key).apply()
+            return
+        }
+
+        val array = JSONArray()
+        for (entry in entries) {
+            array.put(entry.toJson())
+        }
+        prefs.edit().putString(key, array.toString()).apply()
+    }
+}

--- a/packages/dart/barnard/ios/Classes/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardBleController.swift
@@ -141,6 +141,13 @@ final class BarnardBleController: NSObject {
     isScanning = false
     connectQueue.removeAll()
     activePeripheral = nil
+
+    // Clear discovery state for clean restart
+    discoveredRssi.removeAll()
+    discoveredAt.removeAll()
+    peripheralsById.removeAll()
+    lastConnectAttemptAt.removeAll()
+
     emitState(reasonCode: "scan_stop")
     emitDebug(level: "info", name: "scan_stop", data: nil)
   }

--- a/packages/dart/barnard/ios/Classes/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardBleController.swift
@@ -4,6 +4,7 @@
 import CoreBluetooth
 import Flutter
 import Foundation
+import UIKit
 
 final class BarnardBleController: NSObject {
   // MARK: - UUIDs
@@ -13,6 +14,22 @@ final class BarnardBleController: NSObject {
   private let tekCharacteristicUUID = CBUUID(string: "0000B003-0000-1000-8000-00805F9B34FB")
   private let eventCodeHashCharacteristicUUID = CBUUID(string: "0000B004-0000-1000-8000-00805F9B34FB")
   private let localName = "BNRD"
+
+  private var debugLocalName: String {
+    #if DEBUG
+    let suffix = debugDeviceSuffix()
+    return "BND-\(suffix)"
+    #else
+    return localName
+    #endif
+  }
+
+  private func debugDeviceSuffix() -> String {
+    let deviceSecret = rpid.getDeviceSecret()
+    let tail = deviceSecret.suffix(2)
+    let hex = tail.map { String(format: "%02x", $0) }.joined().uppercased()
+    return hex.isEmpty ? "DEAD" : hex
+  }
 
   private let iso8601: ISO8601DateFormatter = {
     let f = ISO8601DateFormatter()
@@ -42,6 +59,8 @@ final class BarnardBleController: NSObject {
   private var isAdvertising = false
   private var allowDuplicates = true
   private var formatVersion: UInt8 = 1
+
+  private var lastDiscoveryNameById: [UUID: String] = [:]
 
   // MARK: - Discovery State
 
@@ -118,6 +137,12 @@ final class BarnardBleController: NSObject {
         "isScanning": isScanning,
         "isAdvertising": isAdvertising,
         "eventMode": rpid.isEventMode ? "event" : "anonymous",
+        "eventCode": rpid.eventCode as Any,
+      ])
+
+    case "getEventMode":
+      result([
+        "mode": rpid.isEventMode ? "event" : "anonymous",
         "eventCode": rpid.eventCode as Any,
       ])
 
@@ -262,6 +287,7 @@ final class BarnardBleController: NSObject {
     lastConnectAttemptAt.removeAll()
     peripheralCharacteristics.removeAll()
     peripheralReadValues.removeAll()
+    lastDiscoveryNameById.removeAll()
 
     emitState(reasonCode: "scan_stop")
     emitDebug(level: "info", name: "scan_stop", data: nil)
@@ -276,10 +302,12 @@ final class BarnardBleController: NSObject {
     }
     if isAdvertising { return }
     ensureGattService()
-    let ad: [String: Any] = [
-      CBAdvertisementDataLocalNameKey: localName,
+    var ad: [String: Any] = [
       CBAdvertisementDataServiceUUIDsKey: [discoveryServiceUUID],
     ]
+    #if DEBUG
+    ad[CBAdvertisementDataLocalNameKey] = debugLocalName
+    #endif
     peripheralManager.startAdvertising(ad)
     isAdvertising = true
     emitState(reasonCode: "advertise_start")
@@ -289,7 +317,7 @@ final class BarnardBleController: NSObject {
       data: [
         "formatVersion": Int(formatVersion),
         "serviceUuid": discoveryServiceUUID.uuidString,
-        "localName": localName,
+        "localName": debugLocalName,
         "eventMode": rpid.isEventMode,
       ]
     )
@@ -487,7 +515,8 @@ final class BarnardBleController: NSObject {
         timestamp: ts,
         rssi: rssi,
         payload: rpidData,
-        resolvedTek: values.tek
+        resolvedTek: values.tek,
+        debugLocalName: lastDiscoveryNameById[id]
       )
     }
 
@@ -498,6 +527,7 @@ final class BarnardBleController: NSObject {
     let id = peripheral.identifier
     peripheralCharacteristics.removeValue(forKey: id)
     peripheralReadValues.removeValue(forKey: id)
+    lastDiscoveryNameById.removeValue(forKey: id)
     centralManager.cancelPeripheralConnection(peripheral)
   }
 
@@ -550,7 +580,13 @@ final class BarnardBleController: NSObject {
     ])
   }
 
-  private func emitDetection(timestamp: Date, rssi: Int, payload: Data, resolvedTek: Data? = nil) {
+  private func emitDetection(
+    timestamp: Date,
+    rssi: Int,
+    payload: Data,
+    resolvedTek: Data? = nil,
+    debugLocalName: String? = nil
+  ) {
     guard payload.count == 17 else {
       emitDebug(level: "warn", name: "payload_invalid_length", data: ["length": payload.count])
       return
@@ -601,6 +637,11 @@ final class BarnardBleController: NSObject {
     if let dispId = resolvedDisplayId {
       event["resolvedDisplayId"] = dispId
     }
+    #if DEBUG
+    if let name = debugLocalName {
+      event["debugLocalName"] = name
+    }
+    #endif
 
     eventSink?(event)
   }
@@ -641,6 +682,12 @@ extension BarnardBleController: CBCentralManagerDelegate {
       "rssi": RSSI.intValue,
       "name": (advertisementData[CBAdvertisementDataLocalNameKey] as? String) as Any,
     ])
+
+    #if DEBUG
+    if let name = advertisementData[CBAdvertisementDataLocalNameKey] as? String, !name.isEmpty {
+      lastDiscoveryNameById[peripheral.identifier] = name
+    }
+    #endif
 
     enqueueConnect(peripheral)
   }

--- a/packages/dart/barnard/ios/Classes/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardBleController.swift
@@ -1,11 +1,17 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
 import CoreBluetooth
 import Flutter
 import Foundation
 
 final class BarnardBleController: NSObject {
-  // Spec constants (MVP).
+  // MARK: - UUIDs
+
   private let discoveryServiceUUID = CBUUID(string: "0000B001-0000-1000-8000-00805F9B34FB")
   private let rpidCharacteristicUUID = CBUUID(string: "0000B002-0000-1000-8000-00805F9B34FB")
+  private let tekCharacteristicUUID = CBUUID(string: "0000B003-0000-1000-8000-00805F9B34FB")
+  private let eventCodeHashCharacteristicUUID = CBUUID(string: "0000B004-0000-1000-8000-00805F9B34FB")
   private let localName = "BNRD"
 
   private let iso8601: ISO8601DateFormatter = {
@@ -14,20 +20,35 @@ final class BarnardBleController: NSObject {
     return f
   }()
 
+  // MARK: - Components
+
   private let rpid = BarnardRpidGenerator()
+  private let tekStorage = BarnardTekStorage()
+
+  // MARK: - BLE Managers
 
   private var centralManager: CBCentralManager!
   private var peripheralManager: CBPeripheralManager!
+
+  // MARK: - GATT Characteristics (Peripheral)
+
   private var rpidCharacteristic: CBMutableCharacteristic?
+  private var tekCharacteristic: CBMutableCharacteristic?
+  private var eventCodeHashCharacteristic: CBMutableCharacteristic?
+
+  // MARK: - State
 
   private var isScanning = false
   private var isAdvertising = false
-
   private var allowDuplicates = true
   private var formatVersion: UInt8 = 1
 
+  // MARK: - Discovery State
+
   private var discoveredRssi: [UUID: Int] = [:]
   private var discoveredAt: [UUID: Date] = [:]
+
+  // MARK: - Connection Queue
 
   private var connectQueue: [UUID] = []
   private var peripheralsById: [UUID: CBPeripheral] = [:]
@@ -38,11 +59,30 @@ final class BarnardBleController: NSObject {
   private let cooldownPerPeerSeconds: TimeInterval = 10
   private let maxConnectQueue = 20
 
+  // MARK: - Central GATT State (per connection)
+
+  /// Tracks discovered characteristics per peripheral for multi-characteristic read.
+  private var peripheralCharacteristics: [UUID: [CBUUID: CBCharacteristic]] = [:]
+
+  /// Tracks read values during GATT exchange.
+  private var peripheralReadValues: [UUID: PeripheralGattValues] = [:]
+
+  /// Values read from a peripheral during GATT exchange.
+  private struct PeripheralGattValues {
+    var eventCodeHash: Data?
+    var rpid: Data?
+    var tek: Data?
+  }
+
+  // MARK: - Event Sinks
+
   let eventsStreamHandler: BarnardStreamHandler
   let debugEventsStreamHandler: BarnardStreamHandler
 
   private var eventSink: FlutterEventSink?
   private var debugEventSink: FlutterEventSink?
+
+  // MARK: - Initialization
 
   override init() {
     let eventsHandler = BarnardStreamHandler()
@@ -60,6 +100,8 @@ final class BarnardBleController: NSObject {
     peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
   }
 
+  // MARK: - Platform Channel Handler
+
   func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "getCapabilities":
@@ -70,27 +112,35 @@ final class BarnardBleController: NSObject {
         "supportsBackground": false,
         "supportsHighRateRssi": false,
       ])
+
     case "getState":
       result([
         "isScanning": isScanning,
         "isAdvertising": isAdvertising,
+        "eventMode": rpid.isEventMode ? "event" : "anonymous",
+        "eventCode": rpid.eventCode as Any,
       ])
+
     case "startScan":
       let args = (call.arguments as? [String: Any]) ?? [:]
       allowDuplicates = (args["allowDuplicates"] as? Bool) ?? true
       startScan()
       result(nil)
+
     case "stopScan":
       stopScan()
       result(nil)
+
     case "startAdvertise":
       let args = (call.arguments as? [String: Any]) ?? [:]
       if let v = args["formatVersion"] as? Int, v >= 0, v <= 255 { formatVersion = UInt8(v) }
       startAdvertise()
       result(nil)
+
     case "stopAdvertise":
       stopAdvertise()
       result(nil)
+
     case "startAuto":
       let args = (call.arguments as? [String: Any]) ?? [:]
       if let scan = args["scan"] as? [String: Any] {
@@ -109,18 +159,81 @@ final class BarnardBleController: NSObject {
         "advertisingStarted": (!wasAdvertising && isAdvertising),
         "issues": [],
       ])
+
     case "stopAuto":
       stopScan()
       stopAdvertise()
       result(nil)
+
     case "dispose":
       stopScan()
       stopAdvertise()
       result(nil)
+
+    // MARK: Event Mode APIs
+
+    case "joinEvent":
+      guard let args = call.arguments as? [String: Any],
+        let eventCode = args["eventCode"] as? String
+      else {
+        result(FlutterError(code: "INVALID_ARGUMENT", message: "eventCode required", details: nil))
+        return
+      }
+      rpid.joinEvent(eventCode)
+      // Rebuild GATT service with new characteristics
+      rebuildGattServiceIfNeeded()
+      emitState(reasonCode: "join_event")
+      emitDebug(level: "info", name: "join_event", data: [
+        "eventCode": eventCode,
+        "displayId": rpid.getCurrentDisplayId(),
+      ])
+      result(nil)
+
+    case "leaveEvent":
+      rpid.leaveEvent()
+      // Rebuild GATT service
+      rebuildGattServiceIfNeeded()
+      emitState(reasonCode: "leave_event")
+      emitDebug(level: "info", name: "leave_event", data: nil)
+      result(nil)
+
+    case "getExchangedTeks":
+      guard let args = call.arguments as? [String: Any],
+        let eventCode = args["eventCode"] as? String
+      else {
+        result(FlutterError(code: "INVALID_ARGUMENT", message: "eventCode required", details: nil))
+        return
+      }
+      let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+      let entries = tekStorage.getEntries(for: eventCodeHash)
+      result(entries.map { $0.toDict() })
+
+    case "clearTeksForEvent":
+      guard let args = call.arguments as? [String: Any],
+        let eventCode = args["eventCode"] as? String
+      else {
+        result(FlutterError(code: "INVALID_ARGUMENT", message: "eventCode required", details: nil))
+        return
+      }
+      let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+      let count = tekStorage.clear(for: eventCodeHash)
+      emitDebug(level: "info", name: "clear_teks_for_event", data: [
+        "eventCode": eventCode,
+        "count": count,
+      ])
+      result(count)
+
+    case "clearAllTeks":
+      let count = tekStorage.clearAll()
+      emitDebug(level: "info", name: "clear_all_teks", data: ["count": count])
+      result(count)
+
     default:
       result(FlutterMethodNotImplemented)
     }
   }
+
+  // MARK: - Scan Control
 
   private func startScan() {
     guard centralManager.state == .poweredOn else {
@@ -147,10 +260,14 @@ final class BarnardBleController: NSObject {
     discoveredAt.removeAll()
     peripheralsById.removeAll()
     lastConnectAttemptAt.removeAll()
+    peripheralCharacteristics.removeAll()
+    peripheralReadValues.removeAll()
 
     emitState(reasonCode: "scan_stop")
     emitDebug(level: "info", name: "scan_stop", data: nil)
   }
+
+  // MARK: - Advertise Control
 
   private func startAdvertise() {
     guard peripheralManager.state == .poweredOn else {
@@ -173,6 +290,7 @@ final class BarnardBleController: NSObject {
         "formatVersion": Int(formatVersion),
         "serviceUuid": discoveryServiceUUID.uuidString,
         "localName": localName,
+        "eventMode": rpid.isEventMode,
       ]
     )
   }
@@ -185,21 +303,69 @@ final class BarnardBleController: NSObject {
     emitDebug(level: "info", name: "advertise_stop", data: nil)
   }
 
+  // MARK: - GATT Service Management
+
   private func ensureGattService() {
     if rpidCharacteristic != nil { return }
+    buildAndAddGattService()
+  }
 
-    let ch = CBMutableCharacteristic(
+  private func rebuildGattServiceIfNeeded() {
+    guard peripheralManager.state == .poweredOn else { return }
+
+    // Remove existing service
+    peripheralManager.removeAllServices()
+    rpidCharacteristic = nil
+    tekCharacteristic = nil
+    eventCodeHashCharacteristic = nil
+
+    // Rebuild
+    buildAndAddGattService()
+
+    emitDebug(level: "info", name: "gatt_service_rebuilt", data: [
+      "eventMode": rpid.isEventMode,
+    ])
+  }
+
+  private func buildAndAddGattService() {
+    // RPID characteristic (Read) - always present
+    let rpidCh = CBMutableCharacteristic(
       type: rpidCharacteristicUUID,
       properties: [.read],
       value: nil,
       permissions: [.readable]
     )
+
+    // TEK characteristic (Read/Write) - for TEK exchange
+    let tekCh = CBMutableCharacteristic(
+      type: tekCharacteristicUUID,
+      properties: [.read, .write],
+      value: nil,
+      permissions: [.readable, .writeable]
+    )
+
+    // EventCodeHash characteristic (Read) - for event matching
+    let eventCodeHashCh = CBMutableCharacteristic(
+      type: eventCodeHashCharacteristicUUID,
+      properties: [.read],
+      value: nil,
+      permissions: [.readable]
+    )
+
     let svc = CBMutableService(type: discoveryServiceUUID, primary: true)
-    svc.characteristics = [ch]
+    svc.characteristics = [rpidCh, tekCh, eventCodeHashCh]
     peripheralManager.add(svc)
-    rpidCharacteristic = ch
-    emitDebug(level: "info", name: "gatt_service_added", data: nil)
+
+    rpidCharacteristic = rpidCh
+    tekCharacteristic = tekCh
+    eventCodeHashCharacteristic = eventCodeHashCh
+
+    emitDebug(level: "info", name: "gatt_service_added", data: [
+      "characteristics": ["RPID", "TEK", "EventCodeHash"],
+    ])
   }
+
+  // MARK: - Connection Queue
 
   private func enqueueConnect(_ peripheral: CBPeripheral) {
     let id = peripheral.identifier
@@ -237,16 +403,129 @@ final class BarnardBleController: NSObject {
     activePeripheral = p
     lastConnectAttemptAt[nextId] = now
 
+    // Initialize state for this peripheral
+    peripheralReadValues[nextId] = PeripheralGattValues()
+
     p.delegate = self
     centralManager.connect(p, options: nil)
     emitDebug(level: "trace", name: "connect_attempt", data: ["id": nextId.uuidString])
   }
 
+  // MARK: - GATT Exchange Logic (Central)
+
+  /// After discovering characteristics, initiate the read sequence.
+  private func startGattExchange(for peripheral: CBPeripheral, service: CBService) {
+    let id = peripheral.identifier
+    var charMap: [CBUUID: CBCharacteristic] = [:]
+
+    guard let characteristics = service.characteristics else {
+      finishConnection(peripheral)
+      return
+    }
+
+    for ch in characteristics {
+      charMap[ch.uuid] = ch
+    }
+    peripheralCharacteristics[id] = charMap
+
+    // Step 1: Read EventCodeHash first to determine if TEK exchange is needed
+    if let eventCodeHashCh = charMap[eventCodeHashCharacteristicUUID] {
+      peripheral.readValue(for: eventCodeHashCh)
+    } else {
+      // No EventCodeHash characteristic, skip to RPID
+      readRpidCharacteristic(for: peripheral)
+    }
+  }
+
+  private func readRpidCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let rpidCh = charMap[rpidCharacteristicUUID]
+    else {
+      finishConnection(peripheral)
+      return
+    }
+    peripheral.readValue(for: rpidCh)
+  }
+
+  private func readTekCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let tekCh = charMap[tekCharacteristicUUID]
+    else {
+      completeGattExchange(for: peripheral)
+      return
+    }
+    peripheral.readValue(for: tekCh)
+  }
+
+  private func writeTekCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let tekCh = charMap[tekCharacteristicUUID]
+    else {
+      completeGattExchange(for: peripheral)
+      return
+    }
+
+    let myTek = rpid.getCurrentTek()
+    peripheral.writeValue(myTek, for: tekCh, type: .withResponse)
+  }
+
+  private func completeGattExchange(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let values = peripheralReadValues[id] else {
+      finishConnection(peripheral)
+      return
+    }
+
+    // Emit detection
+    if let rpidData = values.rpid {
+      let rssi = discoveredRssi[id] ?? 0
+      let ts = discoveredAt[id] ?? Date()
+      emitDetection(
+        timestamp: ts,
+        rssi: rssi,
+        payload: rpidData,
+        resolvedTek: values.tek
+      )
+    }
+
+    finishConnection(peripheral)
+  }
+
+  private func finishConnection(_ peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
+    centralManager.cancelPeripheralConnection(peripheral)
+  }
+
+  /// Check if we should exchange TEKs based on EventCodeHash match.
+  private func shouldExchangeTek(remoteEventCodeHash: Data?) -> Bool {
+    // If we're in Anonymous Mode, don't exchange
+    guard rpid.isEventMode else { return false }
+
+    // If remote is Anonymous (empty hash), don't exchange
+    guard let remoteHash = remoteEventCodeHash, !remoteHash.isEmpty else { return false }
+
+    // Check if hashes match
+    let myHash = rpid.getEventCodeHash()
+    return myHash == remoteHash
+  }
+
+  // MARK: - Event Emission
+
   private func emitState(reasonCode: String?) {
     eventSink?([
       "type": "state",
       "timestamp": iso8601.string(from: Date()),
-      "state": ["isScanning": isScanning, "isAdvertising": isAdvertising],
+      "state": [
+        "isScanning": isScanning,
+        "isAdvertising": isAdvertising,
+        "eventMode": rpid.isEventMode ? "event" : "anonymous",
+        "eventCode": rpid.eventCode as Any,
+      ],
       "reasonCode": reasonCode as Any,
     ])
   }
@@ -271,7 +550,7 @@ final class BarnardBleController: NSObject {
     ])
   }
 
-  private func emitDetection(timestamp: Date, rssi: Int, payload: Data) {
+  private func emitDetection(timestamp: Date, rssi: Int, payload: Data, resolvedTek: Data? = nil) {
     guard payload.count == 17 else {
       emitDebug(level: "warn", name: "payload_invalid_length", data: ["length": payload.count])
       return
@@ -284,7 +563,27 @@ final class BarnardBleController: NSObject {
     let rpidBytes = payload.subdata(in: 1 ..< 17)
     let displayId = rpidBytes.prefix(4).map { String(format: "%02x", $0) }.joined()
 
-    eventSink?([
+    // Try to resolve RPI if we have exchanged TEKs
+    var resolvedTekToEmit: Data? = resolvedTek
+    var resolvedDisplayId: String?
+
+    if resolvedTekToEmit == nil, rpid.isEventMode {
+      // Try to resolve from stored TEKs
+      let eventCodeHash = rpid.getEventCodeHash()
+      let knownTeks = tekStorage.getTeks(for: eventCodeHash)
+
+      if let matched = BarnardCrypto.resolveRpi(rpidBytes, knownTeks: knownTeks) {
+        resolvedTekToEmit = matched
+        // Update lastSeenAt
+        tekStorage.updateLastSeen(tek: matched, eventCodeHash: eventCodeHash)
+      }
+    }
+
+    if let tek = resolvedTekToEmit {
+      resolvedDisplayId = BarnardCrypto.displayId(from: tek)
+    }
+
+    var event: [String: Any] = [
       "type": "detection",
       "timestamp": iso8601.string(from: timestamp),
       "transport": "ble",
@@ -294,7 +593,16 @@ final class BarnardBleController: NSObject {
       "rssi": rssi,
       "rssiSummary": NSNull(),
       "payloadRaw": payload.base64EncodedString(),
-    ])
+    ]
+
+    if let tek = resolvedTekToEmit {
+      event["resolvedTek"] = tek.base64EncodedString()
+    }
+    if let dispId = resolvedDisplayId {
+      event["resolvedDisplayId"] = dispId
+    }
+
+    eventSink?(event)
   }
 
   private func emitDebug(level: String, name: String, data: [String: Any]?) {
@@ -307,6 +615,8 @@ final class BarnardBleController: NSObject {
     ])
   }
 }
+
+// MARK: - CBCentralManagerDelegate
 
 extension BarnardBleController: CBCentralManagerDelegate {
   func centralManagerDidUpdateState(_ central: CBCentralManager) {
@@ -342,65 +652,129 @@ extension BarnardBleController: CBCentralManagerDelegate {
 
   func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
     emitError(code: "connect_failed", message: error?.localizedDescription ?? "unknown", recoverable: true)
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
     activePeripheral = nil
     pumpConnectQueue()
   }
 
   func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
     activePeripheral = nil
     pumpConnectQueue()
   }
 }
 
+// MARK: - CBPeripheralDelegate
+
 extension BarnardBleController: CBPeripheralDelegate {
   func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
     if let error = error {
       emitError(code: "service_discovery_failed", message: error.localizedDescription, recoverable: true)
-      centralManager.cancelPeripheralConnection(peripheral)
+      finishConnection(peripheral)
       return
     }
     guard let services = peripheral.services, let svc = services.first(where: { $0.uuid == discoveryServiceUUID }) else {
       emitError(code: "service_not_found", message: "Barnard service not found", recoverable: true)
-      centralManager.cancelPeripheralConnection(peripheral)
+      finishConnection(peripheral)
       return
     }
-    peripheral.discoverCharacteristics([rpidCharacteristicUUID], for: svc)
+    // Discover all relevant characteristics
+    peripheral.discoverCharacteristics(
+      [rpidCharacteristicUUID, tekCharacteristicUUID, eventCodeHashCharacteristicUUID],
+      for: svc
+    )
   }
 
   func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
     if let error = error {
       emitError(code: "characteristic_discovery_failed", message: error.localizedDescription, recoverable: true)
-      centralManager.cancelPeripheralConnection(peripheral)
+      finishConnection(peripheral)
       return
     }
-    guard let chars = service.characteristics,
-      let ch = chars.first(where: { $0.uuid == rpidCharacteristicUUID })
-    else {
-      emitError(code: "characteristic_not_found", message: "RPID characteristic not found", recoverable: true)
-      centralManager.cancelPeripheralConnection(peripheral)
-      return
-    }
-    peripheral.readValue(for: ch)
+    startGattExchange(for: peripheral, service: service)
   }
 
   func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+    let id = peripheral.identifier
+
     if let error = error {
       emitError(code: "read_failed", message: error.localizedDescription, recoverable: true)
-      centralManager.cancelPeripheralConnection(peripheral)
+      finishConnection(peripheral)
       return
     }
-    guard let value = characteristic.value else {
-      emitError(code: "read_failed", message: "empty characteristic value", recoverable: true)
-      centralManager.cancelPeripheralConnection(peripheral)
-      return
+
+    let value = characteristic.value ?? Data()
+
+    switch characteristic.uuid {
+    case eventCodeHashCharacteristicUUID:
+      peripheralReadValues[id]?.eventCodeHash = value
+      emitDebug(level: "trace", name: "gatt_read_event_code_hash", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+        "isEmpty": value.isEmpty,
+      ])
+      // Proceed to RPID read
+      readRpidCharacteristic(for: peripheral)
+
+    case rpidCharacteristicUUID:
+      peripheralReadValues[id]?.rpid = value
+      emitDebug(level: "trace", name: "gatt_read_rpid", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+      ])
+      // Check if we should exchange TEK
+      let remoteHash = peripheralReadValues[id]?.eventCodeHash
+      if shouldExchangeTek(remoteEventCodeHash: remoteHash) {
+        readTekCharacteristic(for: peripheral)
+      } else {
+        completeGattExchange(for: peripheral)
+      }
+
+    case tekCharacteristicUUID:
+      peripheralReadValues[id]?.tek = value
+      emitDebug(level: "trace", name: "gatt_read_tek", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+      ])
+      // Store received TEK
+      if value.count == 16, let remoteHash = peripheralReadValues[id]?.eventCodeHash, remoteHash.count == 8 {
+        let entry = TekEntry(
+          tek: value,
+          eventCodeHash: remoteHash,
+          exchangedAt: Date(),
+          lastSeenAt: Date()
+        )
+        tekStorage.store(entry: entry)
+        emitDebug(level: "info", name: "tek_received", data: [
+          "displayId": BarnardCrypto.displayId(from: value),
+        ])
+      }
+      // Write our TEK to complete exchange
+      writeTekCharacteristic(for: peripheral)
+
+    default:
+      break
     }
-    let id = peripheral.identifier
-    let rssi = discoveredRssi[id] ?? 0
-    let ts = discoveredAt[id] ?? Date()
-    emitDetection(timestamp: ts, rssi: rssi, payload: value)
-    centralManager.cancelPeripheralConnection(peripheral)
+  }
+
+  func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+    if let error = error {
+      emitError(code: "write_failed", message: error.localizedDescription, recoverable: true)
+    } else {
+      emitDebug(level: "trace", name: "gatt_write_tek", data: [
+        "id": peripheral.identifier.uuidString,
+        "displayId": rpid.getCurrentDisplayId(),
+      ])
+    }
+    completeGattExchange(for: peripheral)
   }
 }
+
+// MARK: - CBPeripheralManagerDelegate
 
 extension BarnardBleController: CBPeripheralManagerDelegate {
   func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
@@ -425,22 +799,93 @@ extension BarnardBleController: CBPeripheralManagerDelegate {
   }
 
   func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
-    let payload = rpid.currentPayload(formatVersion: formatVersion, now: Date())
-    request.value = payload
-    peripheral.respond(to: request, withResult: .success)
-    var displayId = ""
-    if payload.count >= 5 {
-      let bytes = payload.subdata(in: 1 ..< 5)
-      displayId = bytes.map { String(format: "%02x", $0) }.joined()
+    switch request.characteristic.uuid {
+    case rpidCharacteristicUUID:
+      let payload = rpid.currentPayload(formatVersion: formatVersion, now: Date())
+      request.value = payload
+      peripheral.respond(to: request, withResult: .success)
+
+      var displayId = ""
+      if payload.count >= 5 {
+        let bytes = payload.subdata(in: 1 ..< 5)
+        displayId = bytes.map { String(format: "%02x", $0) }.joined()
+      }
+      emitDebug(
+        level: "trace",
+        name: "gatt_read_rpid",
+        data: [
+          "bytes": payload.count,
+          "formatVersion": Int(formatVersion),
+          "displayId": displayId,
+        ]
+      )
+
+    case tekCharacteristicUUID:
+      // Only return TEK in Event Mode
+      if rpid.isEventMode {
+        let tekData = rpid.getCurrentTek()
+        request.value = tekData
+        peripheral.respond(to: request, withResult: .success)
+        emitDebug(level: "trace", name: "gatt_respond_tek_read", data: [
+          "displayId": rpid.getCurrentDisplayId(),
+        ])
+      } else {
+        // Return empty or error in Anonymous Mode
+        peripheral.respond(to: request, withResult: .readNotPermitted)
+        emitDebug(level: "trace", name: "gatt_reject_tek_read", data: [
+          "reason": "anonymous_mode",
+        ])
+      }
+
+    case eventCodeHashCharacteristicUUID:
+      let hash = rpid.getEventCodeHash()
+      request.value = hash
+      peripheral.respond(to: request, withResult: .success)
+      emitDebug(level: "trace", name: "gatt_respond_event_code_hash", data: [
+        "bytes": hash.count,
+        "isEmpty": hash.isEmpty,
+      ])
+
+    default:
+      peripheral.respond(to: request, withResult: .attributeNotFound)
     }
-    emitDebug(
-      level: "trace",
-      name: "gatt_read_rpid",
-      data: [
-        "bytes": payload.count,
-        "formatVersion": Int(formatVersion),
-        "displayId": displayId,
-      ]
-    )
+  }
+
+  func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
+    for request in requests {
+      guard request.characteristic.uuid == tekCharacteristicUUID else {
+        peripheral.respond(to: request, withResult: .writeNotPermitted)
+        continue
+      }
+
+      guard let value = request.value, value.count == 16 else {
+        peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
+        continue
+      }
+
+      // Only accept TEK writes in Event Mode
+      guard rpid.isEventMode else {
+        peripheral.respond(to: request, withResult: .writeNotPermitted)
+        emitDebug(level: "trace", name: "gatt_reject_tek_write", data: [
+          "reason": "anonymous_mode",
+        ])
+        continue
+      }
+
+      // Store the received TEK
+      let eventCodeHash = rpid.getEventCodeHash()
+      let entry = TekEntry(
+        tek: value,
+        eventCodeHash: eventCodeHash,
+        exchangedAt: Date(),
+        lastSeenAt: Date()
+      )
+      tekStorage.store(entry: entry)
+
+      peripheral.respond(to: request, withResult: .success)
+      emitDebug(level: "info", name: "tek_received_via_write", data: [
+        "displayId": BarnardCrypto.displayId(from: value),
+      ])
+    }
   }
 }

--- a/packages/dart/barnard/ios/Classes/BarnardCrypto.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardCrypto.swift
@@ -1,0 +1,208 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import Foundation
+
+/// GAEN v1.2-compatible cryptographic utilities for Resolvable ID.
+///
+/// Key derivation chain:
+/// ```
+/// DeviceSecret (32 bytes)
+///      |
+///      +-- Anonymous Mode: TEK = random 16 bytes
+///      |
+///      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
+///                           |
+///                           v
+///                      RPIK = HKDF(TEK, "EN-RPIK", 16)
+///                           |
+///                           v
+///                      RPI = AES128-ECB(RPIK, PaddedData)
+/// ```
+enum BarnardCrypto {
+  // MARK: - TEK Derivation
+
+  /// Derive TEK for Event Mode from DeviceSecret and EventCode.
+  ///
+  /// `TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`
+  static func deriveTekForEvent(deviceSecret: Data, eventCode: String) -> Data {
+    guard let eventCodeData = eventCode.data(using: .utf8) else {
+      return generateRandomBytes(16)
+    }
+
+    var combined = deviceSecret
+    combined.append(eventCodeData)
+
+    let key = SymmetricKey(data: combined)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "barnard-tek".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  /// Generate a random TEK for Anonymous Mode.
+  static func generateRandomTek() -> Data {
+    generateRandomBytes(16)
+  }
+
+  // MARK: - RPIK Derivation
+
+  /// Derive RPIK (Rolling Proximity Identifier Key) from TEK.
+  ///
+  /// `RPIK = HKDF(TEK, "EN-RPIK", 16)`
+  static func deriveRpik(from tek: Data) -> Data {
+    guard tek.count == 16 else {
+      return Data(count: 16)
+    }
+
+    let key = SymmetricKey(data: tek)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "EN-RPIK".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  // MARK: - RPI Generation
+
+  /// Generate RPI from RPIK and ENIN.
+  ///
+  /// `RPI = AES128-ECB(RPIK, PaddedData)`
+  ///
+  /// Where PaddedData = "EN-RPI" (6 bytes) + 0x000000000000 (6 bytes) + ENIN (4 bytes big-endian)
+  static func generateRpi(rpik: Data, enin: UInt32) -> Data {
+    guard rpik.count == 16 else {
+      return Data(count: 16)
+    }
+
+    // Build PaddedData: "EN-RPI" + 6 zero bytes + ENIN (4 bytes big-endian)
+    var paddedData = Data(count: 16)
+
+    // "EN-RPI" (6 bytes)
+    let prefix = "EN-RPI".data(using: .utf8)!
+    paddedData.replaceSubrange(0 ..< 6, with: prefix)
+
+    // 6 zero bytes (already initialized to 0)
+
+    // ENIN as 4 bytes big-endian at offset 12
+    var eninBE = enin.bigEndian
+    let eninBytes = Data(bytes: &eninBE, count: 4)
+    paddedData.replaceSubrange(12 ..< 16, with: eninBytes)
+
+    // AES-128-ECB encryption
+    return aes128EcbEncrypt(key: rpik, plaintext: paddedData)
+  }
+
+  /// AES-128-ECB encryption of a single 16-byte block.
+  private static func aes128EcbEncrypt(key: Data, plaintext: Data) -> Data {
+    guard key.count == 16, plaintext.count == 16 else {
+      return Data(count: 16)
+    }
+
+    var outputBuffer = [UInt8](repeating: 0, count: 16)
+    var dataOutMoved = 0
+
+    // Use CommonCrypto for AES-ECB (CryptoKit doesn't support ECB)
+    let status = key.withUnsafeBytes { keyPtr in
+      plaintext.withUnsafeBytes { inputPtr in
+        CCCrypt(
+          CCOperation(kCCEncrypt),
+          CCAlgorithm(kCCAlgorithmAES128),
+          CCOptions(kCCOptionECBMode),
+          keyPtr.baseAddress, key.count,
+          nil, // No IV for ECB
+          inputPtr.baseAddress, plaintext.count,
+          &outputBuffer, outputBuffer.count,
+          &dataOutMoved
+        )
+      }
+    }
+
+    return status == kCCSuccess ? Data(outputBuffer) : Data(count: 16)
+  }
+
+  // MARK: - ENIN Calculation
+
+  /// Calculate ENIN (EN Interval Number) for a given timestamp.
+  ///
+  /// `ENIN = floor(unix_timestamp_seconds / 600)`
+  ///
+  /// Each ENIN represents a 10-minute interval.
+  static func calculateEnin(for date: Date = Date()) -> UInt32 {
+    UInt32(Int(date.timeIntervalSince1970) / 600)
+  }
+
+  // MARK: - EventCodeHash
+
+  /// Calculate EventCodeHash from EventCode.
+  ///
+  /// `EventCodeHash = SHA256(EventCode)[0:8]`
+  static func computeEventCodeHash(_ eventCode: String) -> Data {
+    guard let eventCodeData = eventCode.data(using: .utf8) else {
+      return Data(count: 8)
+    }
+
+    let hash = SHA256.hash(data: eventCodeData)
+    return Data(hash).prefix(8)
+  }
+
+  // MARK: - RPI Resolution
+
+  /// Attempt to resolve an RPI to a known TEK.
+  ///
+  /// Searches within a time window around the current ENIN (±6 past + 1 future).
+  ///
+  /// - Parameters:
+  ///   - rpi: The 16-byte RPI to resolve
+  ///   - knownTeks: List of known TEKs to search
+  ///   - currentEnin: Current ENIN (defaults to now)
+  /// - Returns: The matching TEK if found, nil otherwise
+  static func resolveRpi(_ rpi: Data, knownTeks: [Data], currentEnin: UInt32? = nil) -> Data? {
+    guard rpi.count == 16 else { return nil }
+
+    let enin = currentEnin ?? calculateEnin()
+
+    for tek in knownTeks {
+      guard tek.count == 16 else { continue }
+
+      let rpik = deriveRpik(from: tek)
+
+      // Search window: 6 intervals past + current + 1 future
+      for offset in -6 ... 1 {
+        let testEnin = UInt32(Int(enin) + offset)
+        let candidate = generateRpi(rpik: rpik, enin: testEnin)
+
+        if candidate == rpi {
+          return tek
+        }
+      }
+    }
+
+    return nil
+  }
+
+  // MARK: - Display ID
+
+  /// Get displayId from TEK (first 3 bytes as uppercase hex).
+  static func displayId(from tek: Data) -> String {
+    tek.prefix(3).map { String(format: "%02X", $0) }.joined()
+  }
+
+  // MARK: - Random Bytes
+
+  /// Generate cryptographically secure random bytes.
+  static func generateRandomBytes(_ count: Int) -> Data {
+    var bytes = [UInt8](repeating: 0, count: count)
+    _ = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+    return Data(bytes)
+  }
+}
+
+// Import CommonCrypto for AES-ECB
+import CommonCrypto

--- a/packages/dart/barnard/ios/Classes/BarnardCrypto.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardCrypto.swift
@@ -1,6 +1,7 @@
 // Copyright 2024-2026 The Greeting Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style license.
 
+import CommonCrypto
 import CryptoKit
 import Foundation
 
@@ -10,7 +11,7 @@ import Foundation
 /// ```
 /// DeviceSecret (32 bytes)
 ///      |
-///      +-- Anonymous Mode: TEK = random 16 bytes
+///      +-- Anonymous Mode: TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)
 ///      |
 ///      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
 ///                           |
@@ -44,9 +45,17 @@ enum BarnardCrypto {
     return derived.withUnsafeBytes { Data($0) }
   }
 
-  /// Generate a random TEK for Anonymous Mode.
-  static func generateRandomTek() -> Data {
-    generateRandomBytes(16)
+  /// Derive TEK for Anonymous Mode from DeviceSecret.
+  ///
+  /// `TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)`
+  static func deriveTekForAnonymous(deviceSecret: Data) -> Data {
+    let key = SymmetricKey(data: deviceSecret)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "barnard-tek-anonymous".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+    return derived.withUnsafeBytes { Data($0) }
   }
 
   // MARK: - RPIK Derivation
@@ -189,9 +198,9 @@ enum BarnardCrypto {
 
   // MARK: - Display ID
 
-  /// Get displayId from TEK (first 3 bytes as uppercase hex).
+  /// Get displayId from TEK (first 3 bytes as lowercase hex).
   static func displayId(from tek: Data) -> String {
-    tek.prefix(3).map { String(format: "%02X", $0) }.joined()
+    tek.prefix(3).map { String(format: "%02x", $0) }.joined()
   }
 
   // MARK: - Random Bytes
@@ -203,6 +212,3 @@ enum BarnardCrypto {
     return Data(bytes)
   }
 }
-
-// Import CommonCrypto for AES-ECB
-import CommonCrypto

--- a/packages/dart/barnard/ios/Classes/BarnardRpidGenerator.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardRpidGenerator.swift
@@ -8,14 +8,13 @@ import Security
 /// GAEN v1.2-compatible RPI generator with Event Mode support.
 ///
 /// Two modes of operation:
-/// - **Anonymous Mode** (default): Random TEK, no identification
+/// - **Anonymous Mode** (default): Deterministic TEK derived from DeviceSecret
 /// - **Event Mode**: Deterministic TEK derived from DeviceSecret + EventCode
 final class BarnardRpidGenerator {
   // MARK: - Storage Keys
 
   private let deviceSecretKey = "barnard.rpidSeed"
   private let eventCodeKey = "barnard.eventCode"
-  private let currentTekKey = "barnard.currentTek"
 
   // MARK: - State
 
@@ -37,20 +36,10 @@ final class BarnardRpidGenerator {
     // Load persisted event code
     let defaults = UserDefaults.standard
     eventCode = defaults.string(forKey: eventCodeKey)
+    currentTek = Data()
 
     // Initialize TEK based on mode
-    if let code = eventCode {
-      let deviceSecret = getOrCreateDeviceSecret()
-      currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: code)
-    } else {
-      // Anonymous Mode: use stored random TEK or generate new one
-      if let storedTek = defaults.data(forKey: currentTekKey), storedTek.count == 16 {
-        currentTek = storedTek
-      } else {
-        currentTek = BarnardCrypto.generateRandomTek()
-        defaults.set(currentTek, forKey: currentTekKey)
-      }
-    }
+    regenerateTek()
   }
 
   // MARK: - Mode Control
@@ -85,18 +74,14 @@ final class BarnardRpidGenerator {
 
   /// Regenerate TEK based on current mode.
   private func regenerateTek() {
-    let defaults = UserDefaults.standard
-
     if let code = eventCode {
       // Event Mode: derive TEK from DeviceSecret + EventCode
       let deviceSecret = getOrCreateDeviceSecret()
       currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: code)
-      // Don't persist event-derived TEK (can be recomputed)
-      defaults.removeObject(forKey: currentTekKey)
     } else {
-      // Anonymous Mode: generate new random TEK
-      currentTek = BarnardCrypto.generateRandomTek()
-      defaults.set(currentTek, forKey: currentTekKey)
+      // Anonymous Mode: derive TEK from DeviceSecret
+      let deviceSecret = getOrCreateDeviceSecret()
+      currentTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret: deviceSecret)
     }
   }
 

--- a/packages/dart/barnard/ios/Classes/BarnardRpidGenerator.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardRpidGenerator.swift
@@ -1,37 +1,158 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
 import CryptoKit
 import Foundation
 import Security
 
+/// GAEN v1.2-compatible RPI generator with Event Mode support.
+///
+/// Two modes of operation:
+/// - **Anonymous Mode** (default): Random TEK, no identification
+/// - **Event Mode**: Deterministic TEK derived from DeviceSecret + EventCode
 final class BarnardRpidGenerator {
-  private let storageKey = "barnard.rpidSeed"
+  // MARK: - Storage Keys
 
-  func currentPayload(formatVersion: UInt8, now: Date) -> Data {
-    let rotationSeconds: Int64 = 600
-    let unix = Int64(now.timeIntervalSince1970)
-    let window = unix / rotationSeconds
+  private let deviceSecretKey = "barnard.rpidSeed"
+  private let eventCodeKey = "barnard.eventCode"
+  private let currentTekKey = "barnard.currentTek"
 
-    let seed = getOrCreateSeed()
-    let key = SymmetricKey(data: seed)
-    var be = window.bigEndian
-    let msg = Data(bytes: &be, count: MemoryLayout.size(ofValue: be))
-    let mac = HMAC<SHA256>.authenticationCode(for: msg, using: key)
-    let rpid = Data(mac).prefix(16)
+  // MARK: - State
 
-    var out = Data([formatVersion])
-    out.append(rpid)
-    return out
+  /// Current Event Code (nil for Anonymous Mode)
+  private(set) var eventCode: String? {
+    didSet {
+      if eventCode != oldValue {
+        regenerateTek()
+      }
+    }
   }
 
-  private func getOrCreateSeed() -> Data {
+  /// Current TEK (Temporary Exposure Key)
+  private var currentTek: Data
+
+  // MARK: - Initialization
+
+  init() {
+    // Load persisted event code
     let defaults = UserDefaults.standard
-    if let existing = defaults.data(forKey: storageKey), existing.count >= 16 {
+    eventCode = defaults.string(forKey: eventCodeKey)
+
+    // Initialize TEK based on mode
+    if let code = eventCode {
+      let deviceSecret = getOrCreateDeviceSecret()
+      currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: code)
+    } else {
+      // Anonymous Mode: use stored random TEK or generate new one
+      if let storedTek = defaults.data(forKey: currentTekKey), storedTek.count == 16 {
+        currentTek = storedTek
+      } else {
+        currentTek = BarnardCrypto.generateRandomTek()
+        defaults.set(currentTek, forKey: currentTekKey)
+      }
+    }
+  }
+
+  // MARK: - Mode Control
+
+  /// Join an event, switching to Event Mode.
+  ///
+  /// - Parameter code: The event code to join
+  func joinEvent(_ code: String) {
+    let defaults = UserDefaults.standard
+    defaults.set(code, forKey: eventCodeKey)
+    eventCode = code
+  }
+
+  /// Leave the current event, switching to Anonymous Mode.
+  func leaveEvent() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: eventCodeKey)
+    eventCode = nil
+  }
+
+  /// Check if currently in Event Mode.
+  var isEventMode: Bool {
+    eventCode != nil
+  }
+
+  // MARK: - TEK Management
+
+  /// Get the current TEK.
+  func getCurrentTek() -> Data {
+    currentTek
+  }
+
+  /// Regenerate TEK based on current mode.
+  private func regenerateTek() {
+    let defaults = UserDefaults.standard
+
+    if let code = eventCode {
+      // Event Mode: derive TEK from DeviceSecret + EventCode
+      let deviceSecret = getOrCreateDeviceSecret()
+      currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: code)
+      // Don't persist event-derived TEK (can be recomputed)
+      defaults.removeObject(forKey: currentTekKey)
+    } else {
+      // Anonymous Mode: generate new random TEK
+      currentTek = BarnardCrypto.generateRandomTek()
+      defaults.set(currentTek, forKey: currentTekKey)
+    }
+  }
+
+  // MARK: - EventCodeHash
+
+  /// Get the EventCodeHash for GATT characteristic (8 bytes, or empty for Anonymous Mode).
+  func getEventCodeHash() -> Data {
+    guard let code = eventCode else {
+      return Data() // Empty for Anonymous Mode
+    }
+    return BarnardCrypto.computeEventCodeHash(code)
+  }
+
+  // MARK: - RPID Payload Generation
+
+  /// Generate the current RPID payload for BLE advertisement/GATT.
+  ///
+  /// - Parameters:
+  ///   - formatVersion: Protocol version byte (default: 1)
+  ///   - now: Current timestamp (default: now)
+  /// - Returns: 17 bytes: [formatVersion(1) + RPI(16)]
+  func currentPayload(formatVersion: UInt8 = 1, now: Date = Date()) -> Data {
+    let enin = BarnardCrypto.calculateEnin(for: now)
+    let rpik = BarnardCrypto.deriveRpik(from: currentTek)
+    let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: enin)
+
+    var payload = Data([formatVersion])
+    payload.append(rpi)
+    return payload
+  }
+
+  // MARK: - DeviceSecret Management
+
+  /// Get or create the DeviceSecret (32 bytes, device-unique, never transmitted).
+  private func getOrCreateDeviceSecret() -> Data {
+    let defaults = UserDefaults.standard
+
+    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
       return existing
     }
-    var bytes = [UInt8](repeating: 0, count: 32)
-    _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-    let seed = Data(bytes)
-    defaults.set(seed, forKey: storageKey)
-    return seed
+
+    // Generate new 32-byte DeviceSecret
+    let newSecret = BarnardCrypto.generateRandomBytes(32)
+    defaults.set(newSecret, forKey: deviceSecretKey)
+    return newSecret
+  }
+
+  /// Get the DeviceSecret (for platform channel access).
+  func getDeviceSecret() -> Data {
+    getOrCreateDeviceSecret()
+  }
+
+  // MARK: - Display IDs
+
+  /// Get the display ID for the current TEK.
+  func getCurrentDisplayId() -> String {
+    BarnardCrypto.displayId(from: currentTek)
   }
 }
-

--- a/packages/dart/barnard/ios/Classes/BarnardTekStorage.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardTekStorage.swift
@@ -17,9 +17,9 @@ struct TekEntry: Codable, Equatable {
   /// When the TEK holder was last seen (RPI resolved).
   var lastSeenAt: Date
 
-  /// Display ID: first 3 bytes of TEK as uppercase hex.
+  /// Display ID: first 3 bytes of TEK as lowercase hex.
   var displayId: String {
-    BarnardCrypto.displayId(from: tek)
+    tek.prefix(3).map { String(format: "%02x", $0) }.joined()
   }
 
   /// Create from platform channel dictionary.
@@ -104,7 +104,7 @@ final class BarnardTekStorage {
     // Evict expired entries
     let now = Date()
     entries = entries.filter { entry in
-      now.timeIntervalSince(entry.exchangedAt) < Double(config.ttlSeconds)
+      now.timeIntervalSince(entry.lastSeenAt) < Double(config.ttlSeconds)
     }
 
     // LRU eviction if over capacity
@@ -124,7 +124,7 @@ final class BarnardTekStorage {
     // Filter expired entries
     let now = Date()
     let validEntries = entries.filter { entry in
-      now.timeIntervalSince(entry.exchangedAt) < Double(config.ttlSeconds)
+      now.timeIntervalSince(entry.lastSeenAt) < Double(config.ttlSeconds)
     }
 
     // Save back if we filtered any

--- a/packages/dart/barnard/ios/Classes/BarnardTekStorage.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardTekStorage.swift
@@ -1,0 +1,218 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+
+/// A stored TEK entry from GATT exchange.
+struct TekEntry: Codable, Equatable {
+  /// The 16-byte TEK.
+  let tek: Data
+
+  /// The 8-byte EventCodeHash (SHA256(EventCode)[0:8]).
+  let eventCodeHash: Data
+
+  /// When the TEK was first exchanged.
+  let exchangedAt: Date
+
+  /// When the TEK holder was last seen (RPI resolved).
+  var lastSeenAt: Date
+
+  /// Display ID: first 3 bytes of TEK as uppercase hex.
+  var displayId: String {
+    BarnardCrypto.displayId(from: tek)
+  }
+
+  /// Create from platform channel dictionary.
+  static func from(dict: [String: Any]) -> TekEntry? {
+    guard
+      let tekB64 = dict["tek"] as? String,
+      let tekData = Data(base64Encoded: tekB64),
+      let hashB64 = dict["eventCodeHash"] as? String,
+      let hashData = Data(base64Encoded: hashB64),
+      let exchangedAtStr = dict["exchangedAt"] as? String,
+      let exchangedAt = ISO8601DateFormatter().date(from: exchangedAtStr),
+      let lastSeenAtStr = dict["lastSeenAt"] as? String,
+      let lastSeenAt = ISO8601DateFormatter().date(from: lastSeenAtStr)
+    else {
+      return nil
+    }
+
+    return TekEntry(
+      tek: tekData,
+      eventCodeHash: hashData,
+      exchangedAt: exchangedAt,
+      lastSeenAt: lastSeenAt
+    )
+  }
+
+  /// Convert to platform channel dictionary.
+  func toDict() -> [String: Any] {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    return [
+      "tek": tek.base64EncodedString(),
+      "eventCodeHash": eventCodeHash.base64EncodedString(),
+      "exchangedAt": formatter.string(from: exchangedAt),
+      "lastSeenAt": formatter.string(from: lastSeenAt),
+      "displayId": displayId,
+    ]
+  }
+}
+
+/// TEK storage configuration.
+struct TekStorageConfig {
+  /// TTL in seconds (default 24 hours = 86400 seconds).
+  let ttlSeconds: Int
+
+  /// Maximum number of stored entries (default 1000).
+  let maxEntries: Int
+
+  init(ttlSeconds: Int = 86400, maxEntries: Int = 1000) {
+    self.ttlSeconds = ttlSeconds
+    self.maxEntries = maxEntries
+  }
+}
+
+/// Persistent storage for exchanged TEKs.
+///
+/// Storage is organized by EventCodeHash (base64), with bounded size and TTL.
+final class BarnardTekStorage {
+  private let storageKeyPrefix = "barnard.tekStorage."
+  private let defaults = UserDefaults.standard
+  private let config: TekStorageConfig
+
+  init(config: TekStorageConfig = TekStorageConfig()) {
+    self.config = config
+  }
+
+  // MARK: - Public API
+
+  /// Store a TEK entry for a given event code hash.
+  func store(entry: TekEntry) {
+    let key = storageKey(for: entry.eventCodeHash)
+    var entries = loadEntries(key: key)
+
+    // Check if we already have this TEK
+    if let index = entries.firstIndex(where: { $0.tek == entry.tek }) {
+      // Update lastSeenAt
+      entries[index].lastSeenAt = entry.lastSeenAt
+    } else {
+      entries.append(entry)
+    }
+
+    // Evict expired entries
+    let now = Date()
+    entries = entries.filter { entry in
+      now.timeIntervalSince(entry.exchangedAt) < Double(config.ttlSeconds)
+    }
+
+    // LRU eviction if over capacity
+    if entries.count > config.maxEntries {
+      entries.sort { $0.lastSeenAt < $1.lastSeenAt }
+      entries = Array(entries.suffix(config.maxEntries))
+    }
+
+    saveEntries(entries, key: key)
+  }
+
+  /// Get all TEK entries for a given event code hash.
+  func getEntries(for eventCodeHash: Data) -> [TekEntry] {
+    let key = storageKey(for: eventCodeHash)
+    var entries = loadEntries(key: key)
+
+    // Filter expired entries
+    let now = Date()
+    let validEntries = entries.filter { entry in
+      now.timeIntervalSince(entry.exchangedAt) < Double(config.ttlSeconds)
+    }
+
+    // Save back if we filtered any
+    if validEntries.count != entries.count {
+      saveEntries(validEntries, key: key)
+    }
+
+    return validEntries
+  }
+
+  /// Get all TEKs (as Data) for a given event code hash.
+  func getTeks(for eventCodeHash: Data) -> [Data] {
+    getEntries(for: eventCodeHash).map(\.tek)
+  }
+
+  /// Clear all TEKs for a given event code hash.
+  /// Returns the number of entries removed.
+  func clear(for eventCodeHash: Data) -> Int {
+    let key = storageKey(for: eventCodeHash)
+    let entries = loadEntries(key: key)
+    let count = entries.count
+    defaults.removeObject(forKey: key)
+    return count
+  }
+
+  /// Clear all stored TEKs across all events.
+  /// Returns the total number of entries removed.
+  func clearAll() -> Int {
+    var total = 0
+
+    // Find all keys with our prefix
+    for key in defaults.dictionaryRepresentation().keys {
+      if key.hasPrefix(storageKeyPrefix) {
+        if let data = defaults.data(forKey: key),
+          let entries = try? JSONDecoder().decode([TekEntry].self, from: data)
+        {
+          total += entries.count
+        }
+        defaults.removeObject(forKey: key)
+      }
+    }
+
+    return total
+  }
+
+  /// Update lastSeenAt for a TEK if it exists.
+  func updateLastSeen(tek: Data, eventCodeHash: Data, at date: Date = Date()) {
+    let key = storageKey(for: eventCodeHash)
+    var entries = loadEntries(key: key)
+
+    if let index = entries.firstIndex(where: { $0.tek == tek }) {
+      entries[index].lastSeenAt = date
+      saveEntries(entries, key: key)
+    }
+  }
+
+  // MARK: - Private
+
+  private func storageKey(for eventCodeHash: Data) -> String {
+    storageKeyPrefix + eventCodeHash.base64EncodedString()
+  }
+
+  private func loadEntries(key: String) -> [TekEntry] {
+    guard let data = defaults.data(forKey: key) else {
+      return []
+    }
+
+    do {
+      return try JSONDecoder().decode([TekEntry].self, from: data)
+    } catch {
+      // Corrupted data, clear it
+      defaults.removeObject(forKey: key)
+      return []
+    }
+  }
+
+  private func saveEntries(_ entries: [TekEntry], key: String) {
+    guard !entries.isEmpty else {
+      defaults.removeObject(forKey: key)
+      return
+    }
+
+    do {
+      let data = try JSONEncoder().encode(entries)
+      defaults.set(data, forKey: key)
+    } catch {
+      // Encoding failed, don't crash
+      print("BarnardTekStorage: Failed to encode entries: \(error)")
+    }
+  }
+}

--- a/packages/dart/barnard/ios/barnard.podspec
+++ b/packages/dart/barnard/ios/barnard.podspec
@@ -15,6 +15,7 @@ Barnard BLE Transport for Flutter (GATT-first RPID).
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
+  # NOTE: Minimum iOS version is 14.0 for CryptoKit HKDF support.
   s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/packages/dart/barnard/ios/barnard.podspec
+++ b/packages/dart/barnard/ios/barnard.podspec
@@ -15,7 +15,7 @@ Barnard BLE Transport for Flutter (GATT-first RPID).
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '13.0'
+  s.platform = :ios, '14.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/dart/barnard/lib/barnard.dart
+++ b/packages/dart/barnard/lib/barnard.dart
@@ -1,9 +1,11 @@
 // domain
 export "src/domain/capabilities.dart";
 export "src/domain/config.dart";
+export "src/domain/crypto.dart";
 export "src/domain/events.dart";
 export "src/domain/rssi.dart";
 export "src/domain/state.dart";
+export "src/domain/tek_storage.dart";
 export "src/domain/transport.dart";
 
 // usecase (public interface)

--- a/packages/dart/barnard/lib/src/domain/config.dart
+++ b/packages/dart/barnard/lib/src/domain/config.dart
@@ -1,14 +1,33 @@
+import "tek_storage.dart";
 import "transport.dart";
 
 class BarnardConfig {
   const BarnardConfig({
     this.transport = TransportKind.ble,
+    this.eventCode,
+    this.tekStorage = const TekStorageConfig(),
     this.rpid = const RpidConfig(),
     this.rssi = const RssiConfig(),
     this.connect = const ConnectConfig(),
   });
 
   final TransportKind transport;
+
+  /// Event code for Event Mode. If null, operates in Anonymous Mode.
+  ///
+  /// In Anonymous Mode:
+  /// - RPID rotates but cannot be resolved to a device identity
+  /// - No TEK exchange occurs
+  ///
+  /// In Event Mode:
+  /// - TEK is derived from DeviceSecret + EventCode
+  /// - TEK exchange occurs with peers in the same event
+  /// - Peers can be identified and tracked within the event scope
+  final String? eventCode;
+
+  /// Configuration for TEK storage.
+  final TekStorageConfig tekStorage;
+
   final RpidConfig rpid;
   final RssiConfig rssi;
   final ConnectConfig connect;

--- a/packages/dart/barnard/lib/src/domain/crypto.dart
+++ b/packages/dart/barnard/lib/src/domain/crypto.dart
@@ -1,0 +1,299 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+/// GAEN v1.2-compatible cryptographic utilities for Resolvable ID.
+///
+/// This library implements the key derivation and RPI generation algorithms
+/// specified in the Google/Apple Exposure Notification Cryptography Spec v1.2.
+///
+/// Key derivation chain:
+/// ```
+/// DeviceSecret (32 bytes)
+///      |
+///      +-- Anonymous Mode: TEK = random 16 bytes
+///      |
+///      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
+///                           |
+///                           v
+///                      RPIK = HKDF(TEK, "EN-RPIK", 16)
+///                           |
+///                           v
+///                      RPI = AES128-ECB(RPIK, PaddedData)
+/// ```
+library;
+
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:pointycastle/export.dart';
+
+/// HKDF-SHA256 key derivation function (RFC 5869).
+///
+/// - [ikm]: Input keying material
+/// - [info]: Context and application-specific info
+/// - [length]: Output length in bytes
+/// - [salt]: Optional salt (defaults to 32 zero bytes)
+Uint8List hkdfSha256({
+  required Uint8List ikm,
+  required Uint8List info,
+  required int length,
+  Uint8List? salt,
+}) {
+  final actualSalt = salt ?? Uint8List(32);
+
+  // HKDF-Extract: PRK = HMAC-SHA256(salt, IKM)
+  final extractHmac = HMac(SHA256Digest(), 64)..init(KeyParameter(actualSalt));
+  final prk = Uint8List(32);
+  extractHmac.update(ikm, 0, ikm.length);
+  extractHmac.doFinal(prk, 0);
+
+  // HKDF-Expand
+  final hashLen = 32;
+  final n = (length + hashLen - 1) ~/ hashLen;
+  final okm = Uint8List(length);
+  var t = Uint8List(0);
+  var pos = 0;
+
+  for (var i = 1; i <= n; i++) {
+    final expandHmac = HMac(SHA256Digest(), 64)..init(KeyParameter(prk));
+
+    // T(i) = HMAC-SHA256(PRK, T(i-1) || info || i)
+    expandHmac.update(t, 0, t.length);
+    expandHmac.update(info, 0, info.length);
+    expandHmac.update(Uint8List.fromList([i]), 0, 1);
+
+    t = Uint8List(32);
+    expandHmac.doFinal(t, 0);
+
+    final copyLen = min(hashLen, length - pos);
+    okm.setRange(pos, pos + copyLen, t);
+    pos += copyLen;
+  }
+
+  return okm;
+}
+
+/// AES-128-ECB encryption of a single 16-byte block.
+///
+/// Used for RPI generation as specified in GAEN.
+Uint8List aes128EcbEncrypt(Uint8List key, Uint8List plaintext) {
+  if (key.length != 16) {
+    throw ArgumentError('Key must be 16 bytes');
+  }
+  if (plaintext.length != 16) {
+    throw ArgumentError('Plaintext must be 16 bytes');
+  }
+
+  final cipher = BlockCipher('AES/ECB')..init(true, KeyParameter(key));
+  final output = Uint8List(16);
+  cipher.processBlock(plaintext, 0, output, 0);
+  return output;
+}
+
+/// SHA-256 hash.
+Uint8List sha256(Uint8List data) {
+  final digest = SHA256Digest();
+  return digest.process(data);
+}
+
+/// Derive TEK from DeviceSecret and optional EventCode.
+///
+/// - Anonymous Mode (eventCode == null): Returns random 16 bytes.
+/// - Event Mode: Returns `HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`.
+Uint8List deriveTek(Uint8List deviceSecret, [String? eventCode]) {
+  if (eventCode == null) {
+    // Anonymous Mode: random TEK
+    final random = Random.secure();
+    return Uint8List.fromList(List.generate(16, (_) => random.nextInt(256)));
+  }
+
+  // Event Mode: deterministic TEK
+  final eventCodeBytes = utf8.encode(eventCode);
+  final combined = Uint8List(deviceSecret.length + eventCodeBytes.length);
+  combined.setRange(0, deviceSecret.length, deviceSecret);
+  combined.setRange(deviceSecret.length, combined.length, eventCodeBytes);
+
+  return hkdfSha256(
+    ikm: combined,
+    info: Uint8List.fromList(utf8.encode('barnard-tek')),
+    length: 16,
+  );
+}
+
+/// Derive RPIK (Rolling Proximity Identifier Key) from TEK.
+///
+/// `RPIK = HKDF(TEK, "EN-RPIK", 16)`
+Uint8List deriveRpik(Uint8List tek) {
+  if (tek.length != 16) {
+    throw ArgumentError('TEK must be 16 bytes');
+  }
+
+  return hkdfSha256(
+    ikm: tek,
+    info: Uint8List.fromList(utf8.encode('EN-RPIK')),
+    length: 16,
+  );
+}
+
+/// Generate RPI (Rolling Proximity Identifier) from RPIK and ENIN.
+///
+/// `RPI = AES128-ECB(RPIK, PaddedData)`
+///
+/// Where PaddedData = "EN-RPI" (6 bytes) + 0x000000000000 (6 bytes) + ENIN (4 bytes big-endian)
+Uint8List generateRpi(Uint8List rpik, int enin) {
+  if (rpik.length != 16) {
+    throw ArgumentError('RPIK must be 16 bytes');
+  }
+
+  // Build PaddedData: "EN-RPI" + 6 zero bytes + ENIN (4 bytes big-endian)
+  final paddedData = Uint8List(16);
+
+  // "EN-RPI" (6 bytes)
+  final prefix = utf8.encode('EN-RPI');
+  paddedData.setRange(0, 6, prefix);
+
+  // 6 zero bytes (already initialized to 0)
+
+  // ENIN as 4 bytes big-endian at offset 12
+  final eninBytes = ByteData(4)..setUint32(0, enin, Endian.big);
+  paddedData.setRange(12, 16, eninBytes.buffer.asUint8List());
+
+  return aes128EcbEncrypt(rpik, paddedData);
+}
+
+/// Calculate ENIN (EN Interval Number) for a given timestamp.
+///
+/// `ENIN = floor(unix_timestamp_seconds / 600)`
+///
+/// Each ENIN represents a 10-minute interval.
+int calculateEnin(DateTime timestamp) {
+  return timestamp.millisecondsSinceEpoch ~/ 1000 ~/ 600;
+}
+
+/// Calculate EventCodeHash from EventCode.
+///
+/// `EventCodeHash = SHA256(EventCode)[0:8]`
+Uint8List calculateEventCodeHash(String eventCode) {
+  final hash = sha256(Uint8List.fromList(utf8.encode(eventCode)));
+  return hash.sublist(0, 8);
+}
+
+/// Attempt to resolve an RPI to a known TEK.
+///
+/// Searches within a time window around [currentEnin] (default ±1 hour).
+///
+/// Returns the matching TEK if found, null otherwise.
+Uint8List? resolveRpi({
+  required Uint8List rpi,
+  required List<Uint8List> knownTeks,
+  required int currentEnin,
+  int windowSize = 8, // ±6 past + 1 current + 1 future
+}) {
+  if (rpi.length != 16) return null;
+
+  for (final tek in knownTeks) {
+    if (tek.length != 16) continue;
+
+    final rpik = deriveRpik(tek);
+
+    // Search window: 6 intervals past + current + 1 future
+    for (var offset = -6; offset <= 1; offset++) {
+      final enin = currentEnin + offset;
+      final candidate = generateRpi(rpik, enin);
+
+      if (_bytesEqual(candidate, rpi)) {
+        return tek;
+      }
+    }
+  }
+
+  return null;
+}
+
+/// Get displayId from TEK (first 3 bytes as lowercase hex).
+String tekToDisplayId(Uint8List tek) {
+  if (tek.length < 3) {
+    throw ArgumentError('TEK must be at least 3 bytes');
+  }
+  return tek
+      .sublist(0, 3)
+      .map((b) => b.toRadixString(16).padLeft(2, '0'))
+      .join();
+}
+
+/// Compare two byte lists for equality.
+bool _bytesEqual(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+/// Generate cryptographically secure random bytes.
+Uint8List generateSecureRandomBytes(int length) {
+  final random = Random.secure();
+  return Uint8List.fromList(List.generate(length, (_) => random.nextInt(256)));
+}
+
+/// Utility class providing static methods for Barnard cryptographic operations.
+///
+/// This class wraps the standalone crypto functions for convenient usage.
+abstract class BarnardCrypto {
+  /// Derive TEK for Event Mode from DeviceSecret and EventCode.
+  ///
+  /// `TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`
+  static Uint8List deriveTekForEvent(Uint8List deviceSecret, String eventCode) {
+    return deriveTek(deviceSecret, eventCode);
+  }
+
+  /// Derive TEK for Anonymous Mode (random 16 bytes).
+  static Uint8List deriveTekForAnonymous() {
+    return deriveTek(Uint8List(32), null);
+  }
+
+  /// Compute EventCodeHash from EventCode.
+  ///
+  /// `EventCodeHash = SHA256(EventCode)[0:8]`
+  static Uint8List computeEventCodeHash(String eventCode) {
+    return calculateEventCodeHash(eventCode);
+  }
+
+  /// Derive RPIK from TEK.
+  ///
+  /// `RPIK = HKDF(TEK, "EN-RPIK", 16)`
+  static Uint8List deriveRpikFromTek(Uint8List tek) {
+    return deriveRpik(tek);
+  }
+
+  /// Generate RPI from RPIK and ENIN.
+  ///
+  /// `RPI = AES128-ECB(RPIK, PaddedData)`
+  static Uint8List generateRpiFromRpik(Uint8List rpik, int enin) {
+    return generateRpi(rpik, enin);
+  }
+
+  /// Calculate current ENIN.
+  static int currentEnin() {
+    return calculateEnin(DateTime.now());
+  }
+
+  /// Attempt to resolve an RPI to a known TEK.
+  static Uint8List? tryResolveRpi({
+    required Uint8List rpi,
+    required List<Uint8List> knownTeks,
+    int? enin,
+  }) {
+    return resolveRpi(
+      rpi: rpi,
+      knownTeks: knownTeks,
+      currentEnin: enin ?? currentEnin(),
+    );
+  }
+
+  /// Get displayId from TEK (first 3 bytes as uppercase hex).
+  static String displayIdFromTek(Uint8List tek) {
+    return tekToDisplayId(tek).toUpperCase();
+  }
+}

--- a/packages/dart/barnard/lib/src/domain/crypto.dart
+++ b/packages/dart/barnard/lib/src/domain/crypto.dart
@@ -10,7 +10,7 @@
 /// ```
 /// DeviceSecret (32 bytes)
 ///      |
-///      +-- Anonymous Mode: TEK = random 16 bytes
+///      +-- Anonymous Mode: TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)
 ///      |
 ///      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
 ///                           |
@@ -99,13 +99,16 @@ Uint8List sha256(Uint8List data) {
 
 /// Derive TEK from DeviceSecret and optional EventCode.
 ///
-/// - Anonymous Mode (eventCode == null): Returns random 16 bytes.
+/// - Anonymous Mode (eventCode == null): Returns `HKDF(DeviceSecret, "barnard-tek-anonymous", 16)`.
 /// - Event Mode: Returns `HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`.
 Uint8List deriveTek(Uint8List deviceSecret, [String? eventCode]) {
   if (eventCode == null) {
-    // Anonymous Mode: random TEK
-    final random = Random.secure();
-    return Uint8List.fromList(List.generate(16, (_) => random.nextInt(256)));
+    // Anonymous Mode: deterministic TEK
+    return hkdfSha256(
+      ikm: deviceSecret,
+      info: Uint8List.fromList(utf8.encode('barnard-tek-anonymous')),
+      length: 16,
+    );
   }
 
   // Event Mode: deterministic TEK
@@ -248,9 +251,9 @@ abstract class BarnardCrypto {
     return deriveTek(deviceSecret, eventCode);
   }
 
-  /// Derive TEK for Anonymous Mode (random 16 bytes).
-  static Uint8List deriveTekForAnonymous() {
-    return deriveTek(Uint8List(32), null);
+  /// Derive TEK for Anonymous Mode from DeviceSecret.
+  static Uint8List deriveTekForAnonymous(Uint8List deviceSecret) {
+    return deriveTek(deviceSecret, null);
   }
 
   /// Compute EventCodeHash from EventCode.
@@ -292,8 +295,8 @@ abstract class BarnardCrypto {
     );
   }
 
-  /// Get displayId from TEK (first 3 bytes as uppercase hex).
+  /// Get displayId from TEK (first 3 bytes as lowercase hex).
   static String displayIdFromTek(Uint8List tek) {
-    return tekToDisplayId(tek).toUpperCase();
+    return tekToDisplayId(tek);
   }
 }

--- a/packages/dart/barnard/lib/src/domain/events.dart
+++ b/packages/dart/barnard/lib/src/domain/events.dart
@@ -23,6 +23,8 @@ final class DetectionEvent extends BarnardEvent {
     required this.displayId,
     this.rssiSummary,
     this.payloadRaw,
+    this.resolvedTek,
+    this.resolvedDisplayId,
   });
 
   final Uint8List rpid;
@@ -38,6 +40,18 @@ final class DetectionEvent extends BarnardEvent {
 
   /// Optional raw payload bytes as observed (if available).
   final Uint8List? payloadRaw;
+
+  /// The TEK that was used to derive this RPI, if resolution succeeded.
+  /// Only populated when both devices are in Event Mode with matching
+  /// EventCodeHash and have exchanged TEKs via GATT.
+  final Uint8List? resolvedTek;
+
+  /// Human-readable identifier derived from resolvedTek (first 3 bytes as hex).
+  /// Example: "A1B2C3". Only populated when resolvedTek is available.
+  final String? resolvedDisplayId;
+
+  /// Whether this detection was resolved to a known TEK.
+  bool get isResolved => resolvedTek != null;
 }
 
 final class StateEvent extends BarnardEvent {

--- a/packages/dart/barnard/lib/src/domain/events.dart
+++ b/packages/dart/barnard/lib/src/domain/events.dart
@@ -25,6 +25,7 @@ final class DetectionEvent extends BarnardEvent {
     this.payloadRaw,
     this.resolvedTek,
     this.resolvedDisplayId,
+    this.debugLocalName,
   });
 
   final Uint8List rpid;
@@ -47,8 +48,11 @@ final class DetectionEvent extends BarnardEvent {
   final Uint8List? resolvedTek;
 
   /// Human-readable identifier derived from resolvedTek (first 3 bytes as hex).
-  /// Example: "A1B2C3". Only populated when resolvedTek is available.
+  /// Example: "a1b2c3". Only populated when resolvedTek is available.
   final String? resolvedDisplayId;
+
+  /// Debug-only local name of the peer, if present in advertisements.
+  final String? debugLocalName;
 
   /// Whether this detection was resolved to a known TEK.
   bool get isResolved => resolvedTek != null;

--- a/packages/dart/barnard/lib/src/domain/tek_storage.dart
+++ b/packages/dart/barnard/lib/src/domain/tek_storage.dart
@@ -1,0 +1,114 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+/// TEK (Temporary Exposure Key) storage data models.
+///
+/// Storage is implemented per-platform (iOS: UserDefaults, Android: SharedPreferences).
+/// This file contains the Dart data models used to communicate with native storage.
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+
+/// A stored TEK entry from GATT exchange.
+@immutable
+class TekEntry {
+  /// Creates a new TEK entry.
+  const TekEntry({
+    required this.tek,
+    required this.eventCodeHash,
+    required this.exchangedAt,
+    required this.lastSeenAt,
+  });
+
+  /// The 16-byte TEK.
+  final Uint8List tek;
+
+  /// The 8-byte EventCodeHash (SHA256(EventCode)[0:8]).
+  final Uint8List eventCodeHash;
+
+  /// When the TEK was first exchanged.
+  final DateTime exchangedAt;
+
+  /// When the TEK holder was last seen (RPI resolved).
+  final DateTime lastSeenAt;
+
+  /// Display ID: first 3 bytes of TEK as lowercase hex.
+  String get displayId =>
+      tek.sublist(0, 3).map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+  /// Create from JSON map (for platform channel).
+  factory TekEntry.fromMap(Map<String, dynamic> map) {
+    return TekEntry(
+      tek: _decodeBase64(map['tek'] as String),
+      eventCodeHash: _decodeBase64(map['eventCodeHash'] as String),
+      exchangedAt: DateTime.parse(map['exchangedAt'] as String),
+      lastSeenAt: DateTime.parse(map['lastSeenAt'] as String),
+    );
+  }
+
+  /// Convert to JSON map (for platform channel).
+  Map<String, dynamic> toMap() => {
+    'tek': base64Encode(tek),
+    'eventCodeHash': base64Encode(eventCodeHash),
+    'exchangedAt': exchangedAt.toUtc().toIso8601String(),
+    'lastSeenAt': lastSeenAt.toUtc().toIso8601String(),
+    'displayId': displayId,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TekEntry &&
+          runtimeType == other.runtimeType &&
+          _bytesEqual(tek, other.tek);
+
+  @override
+  int get hashCode => Object.hashAll(tek);
+
+  @override
+  String toString() =>
+      'TekEntry(displayId: $displayId, exchangedAt: $exchangedAt)';
+}
+
+/// Configuration for TEK storage.
+@immutable
+class TekStorageConfig {
+  /// Creates TEK storage configuration.
+  ///
+  /// - [ttlSeconds]: Time-to-live for TEK entries (default 24 hours).
+  /// - [maxEntries]: Maximum number of entries before LRU eviction (default 1000).
+  const TekStorageConfig({this.ttlSeconds = 86400, this.maxEntries = 1000});
+
+  /// TTL in seconds (default 24 hours = 86400 seconds).
+  final int ttlSeconds;
+
+  /// Maximum number of stored entries (default 1000).
+  final int maxEntries;
+
+  /// Convert to map for platform channel.
+  Map<String, dynamic> toMap() => {
+    'ttlSeconds': ttlSeconds,
+    'maxEntries': maxEntries,
+  };
+
+  @override
+  String toString() =>
+      'TekStorageConfig(ttlSeconds: $ttlSeconds, maxEntries: $maxEntries)';
+}
+
+// Helper functions
+
+Uint8List _decodeBase64(String encoded) {
+  return base64Decode(encoded);
+}
+
+bool _bytesEqual(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
@@ -57,9 +57,16 @@ class BarnardBleClient implements BarnardClient {
     final Map<Object?, Object?> stateMap =
         (await _methods.invokeMethod<Map<Object?, Object?>>("getState")) ??
             <Object?, Object?>{};
-    final Map<Object?, Object?> modeMap =
-        (await _methods.invokeMethod<Map<Object?, Object?>>("getEventMode")) ??
-            <Object?, Object?>{};
+    Map<Object?, Object?> modeMap;
+    try {
+      modeMap = (await _methods
+              .invokeMethod<Map<Object?, Object?>>("getEventMode")) ??
+          <Object?, Object?>{};
+    } on MissingPluginException {
+      modeMap = <Object?, Object?>{};
+    } on PlatformException {
+      modeMap = <Object?, Object?>{};
+    }
 
     final String? modeStr = modeMap["mode"] as String?;
     final EventMode initialMode =
@@ -417,6 +424,7 @@ BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
           ? null
           : Uint8List.fromList(base64Decode(resolvedTekB64));
       final String? resolvedDisplayId = map["resolvedDisplayId"] as String?;
+      final String? debugLocalName = map["debugLocalName"] as String?;
 
       return DetectionEvent(
         timestamp: ts,
@@ -429,6 +437,7 @@ BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
         payloadRaw: payloadRaw,
         resolvedTek: resolvedTek,
         resolvedDisplayId: resolvedDisplayId,
+        debugLocalName: debugLocalName,
       );
   }
 }

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
@@ -6,6 +6,7 @@ import "../../domain/config.dart";
 import "../../domain/events.dart";
 import "../../domain/rssi.dart";
 import "../../domain/state.dart";
+import "../../domain/tek_storage.dart";
 import "../../domain/transport.dart";
 import "../../usecase/barnard_client.dart";
 import "package:flutter/services.dart";
@@ -14,35 +15,62 @@ class BarnardBleClient implements BarnardClient {
   BarnardBleClient._({
     required BarnardCapabilities capabilities,
     required BarnardState initialState,
+    required EventMode initialMode,
+    String? initialEventCode,
   })  : _capabilities = capabilities,
-        _state = initialState;
+        _state = initialState,
+        _currentMode = initialMode,
+        _currentEventCode = initialEventCode;
 
   static const MethodChannel _methods = MethodChannel("barnard/methods");
   static const EventChannel _eventsChannel = EventChannel("barnard/events");
-  static const EventChannel _debugEventsChannel = EventChannel("barnard/debugEvents");
+  static const EventChannel _debugEventsChannel = EventChannel(
+    "barnard/debugEvents",
+  );
 
-  final StreamController<BarnardEvent> _eventsController = StreamController<BarnardEvent>.broadcast();
-  final StreamController<BarnardDebugEvent> _debugEventsController = StreamController<BarnardDebugEvent>.broadcast();
+  final StreamController<BarnardEvent> _eventsController =
+      StreamController<BarnardEvent>.broadcast();
+  final StreamController<BarnardDebugEvent> _debugEventsController =
+      StreamController<BarnardDebugEvent>.broadcast();
 
   late final StreamSubscription<dynamic> _eventsSub;
   late final StreamSubscription<dynamic> _debugEventsSub;
 
-  final _BoundedBuffer<BarnardDebugEvent> _debugBuffer = _BoundedBuffer<BarnardDebugEvent>(2000);
-  final _BoundedBuffer<RssiSample> _rssiBuffer = _BoundedBuffer<RssiSample>(const RssiConfig().bufferMaxSamples);
+  final _BoundedBuffer<BarnardDebugEvent> _debugBuffer =
+      _BoundedBuffer<BarnardDebugEvent>(2000);
+  final _BoundedBuffer<RssiSample> _rssiBuffer = _BoundedBuffer<RssiSample>(
+    const RssiConfig().bufferMaxSamples,
+  );
 
   final BarnardCapabilities _capabilities;
   BarnardState _state;
+  EventMode _currentMode;
+  String? _currentEventCode;
   bool _disposed = false;
 
   static Future<BarnardBleClient> create() async {
     final Map<Object?, Object?> capsMap =
-        (await _methods.invokeMethod<Map<Object?, Object?>>("getCapabilities")) ?? <Object?, Object?>{};
+        (await _methods.invokeMethod<Map<Object?, Object?>>(
+              "getCapabilities",
+            )) ??
+            <Object?, Object?>{};
     final Map<Object?, Object?> stateMap =
-        (await _methods.invokeMethod<Map<Object?, Object?>>("getState")) ?? <Object?, Object?>{};
+        (await _methods.invokeMethod<Map<Object?, Object?>>("getState")) ??
+            <Object?, Object?>{};
+    final Map<Object?, Object?> modeMap =
+        (await _methods.invokeMethod<Map<Object?, Object?>>("getEventMode")) ??
+            <Object?, Object?>{};
+
+    final String? modeStr = modeMap["mode"] as String?;
+    final EventMode initialMode =
+        modeStr == "event" ? EventMode.event : EventMode.anonymous;
+    final String? eventCode = modeMap["eventCode"] as String?;
 
     final BarnardBleClient client = BarnardBleClient._(
       capabilities: _parseCapabilities(capsMap),
       initialState: _parseState(stateMap),
+      initialMode: initialMode,
+      initialEventCode: eventCode,
     );
     await client._attachStreams();
     return client;
@@ -53,12 +81,21 @@ class BarnardBleClient implements BarnardClient {
       final BarnardEvent event = _parseBarnardEvent(_expectMap(data));
       if (event is StateEvent) _state = event.state;
       if (event is DetectionEvent) {
-        _rssiBuffer.add(RssiSample(timestamp: event.timestamp, rpid: event.rpid, rssi: event.rssi, transport: event.transport));
+        _rssiBuffer.add(
+          RssiSample(
+            timestamp: event.timestamp,
+            rpid: event.rpid,
+            rssi: event.rssi,
+            transport: event.transport,
+          ),
+        );
       }
       _eventsController.add(event);
     });
 
-    _debugEventsSub = _debugEventsChannel.receiveBroadcastStream().listen((dynamic data) {
+    _debugEventsSub = _debugEventsChannel.receiveBroadcastStream().listen((
+      dynamic data,
+    ) {
       final BarnardDebugEvent event = _parseDebugEvent(_expectMap(data));
       _debugBuffer.add(event);
       _debugEventsController.add(event);
@@ -70,6 +107,12 @@ class BarnardBleClient implements BarnardClient {
 
   @override
   BarnardState get state => _state;
+
+  @override
+  EventMode get currentMode => _currentMode;
+
+  @override
+  String? get currentEventCode => _currentEventCode;
 
   @override
   Stream<BarnardEvent> get events => _eventsController.stream;
@@ -92,7 +135,10 @@ class BarnardBleClient implements BarnardClient {
   @override
   Future<void> startAdvertise([AdvertiseConfig? config]) async {
     _ensureNotDisposed();
-    await _methods.invokeMethod<void>("startAdvertise", _encodeAdvertiseConfig(config));
+    await _methods.invokeMethod<void>(
+      "startAdvertise",
+      _encodeAdvertiseConfig(config),
+    );
   }
 
   @override
@@ -105,9 +151,16 @@ class BarnardBleClient implements BarnardClient {
   Future<BarnardStartResult> startAuto([AutoConfig? config]) async {
     _ensureNotDisposed();
     final Map<Object?, Object?>? out =
-        await _methods.invokeMethod<Map<Object?, Object?>>("startAuto", _encodeAutoConfig(config));
+        await _methods.invokeMethod<Map<Object?, Object?>>(
+      "startAuto",
+      _encodeAutoConfig(config),
+    );
     if (out == null) {
-      return const BarnardStartResult(scanningStarted: false, advertisingStarted: false, issues: <BarnardIssue>[]);
+      return const BarnardStartResult(
+        scanningStarted: false,
+        advertisingStarted: false,
+        issues: <BarnardIssue>[],
+      );
     }
     return _parseStartResult(out);
   }
@@ -118,8 +171,72 @@ class BarnardBleClient implements BarnardClient {
     await _methods.invokeMethod<void>("stopAuto");
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Event Mode APIs
+  // ─────────────────────────────────────────────────────────────────────────
+
   @override
-  List<BarnardDebugEvent> getDebugBuffer({int? limit}) => _debugBuffer.toList(limit: limit);
+  Future<void> joinEvent(String eventCode) async {
+    _ensureNotDisposed();
+    if (_currentMode == EventMode.event) {
+      throw StateError("Already in Event Mode. Call leaveEvent() first.");
+    }
+    await _methods.invokeMethod<void>("joinEvent", <String, Object?>{
+      "eventCode": eventCode,
+    });
+    _currentMode = EventMode.event;
+    _currentEventCode = eventCode;
+  }
+
+  @override
+  Future<void> leaveEvent() async {
+    _ensureNotDisposed();
+    if (_currentMode == EventMode.anonymous) {
+      throw StateError("Not in Event Mode. Call joinEvent() first.");
+    }
+    await _methods.invokeMethod<void>("leaveEvent");
+    _currentMode = EventMode.anonymous;
+    _currentEventCode = null;
+  }
+
+  @override
+  Future<List<TekEntry>> getExchangedTeks(String eventCode) async {
+    _ensureNotDisposed();
+    final List<Object?>? rawList = await _methods.invokeMethod<List<Object?>>(
+      "getExchangedTeks",
+      <String, Object?>{"eventCode": eventCode},
+    );
+    if (rawList == null) return const <TekEntry>[];
+    return rawList
+        .whereType<Map<Object?, Object?>>()
+        .map((Map<Object?, Object?> m) => _parseTekEntry(m))
+        .toList(growable: false);
+  }
+
+  @override
+  Future<int> clearTeksForEvent(String eventCode) async {
+    _ensureNotDisposed();
+    final int? count = await _methods.invokeMethod<int>(
+      "clearTeksForEvent",
+      <String, Object?>{"eventCode": eventCode},
+    );
+    return count ?? 0;
+  }
+
+  @override
+  Future<int> clearAllTeks() async {
+    _ensureNotDisposed();
+    final int? count = await _methods.invokeMethod<int>("clearAllTeks");
+    return count ?? 0;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Pull APIs
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @override
+  List<BarnardDebugEvent> getDebugBuffer({int? limit}) =>
+      _debugBuffer.toList(limit: limit);
 
   @override
   List<RssiSample> getRssiSamples({
@@ -127,13 +244,16 @@ class BarnardBleClient implements BarnardClient {
     int? limit,
     List<int>? rpidBytes,
   }) {
-    final Uint8List? filterRpid = rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
+    final Uint8List? filterRpid =
+        rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
     Iterable<RssiSample> samples = _rssiBuffer.toList();
     if (since != null) {
       samples = samples.where((RssiSample s) => !s.timestamp.isBefore(since));
     }
     if (filterRpid != null) {
-      samples = samples.where((RssiSample s) => _bytesEqual(s.rpid, filterRpid));
+      samples = samples.where(
+        (RssiSample s) => _bytesEqual(s.rpid, filterRpid),
+      );
     }
     final List<RssiSample> out = samples.toList(growable: false);
     if (limit == null) return out;
@@ -160,12 +280,15 @@ class BarnardBleClient implements BarnardClient {
 
 Map<String, Object?> _encodeScanConfig(ScanConfig? config) => <String, Object?>{
       "transport": (config?.transport ?? TransportKind.ble).name,
-      "allowDuplicates": config?.allowDuplicates ?? const ScanConfig().allowDuplicates,
+      "allowDuplicates":
+          config?.allowDuplicates ?? const ScanConfig().allowDuplicates,
     };
 
-Map<String, Object?> _encodeAdvertiseConfig(AdvertiseConfig? config) => <String, Object?>{
+Map<String, Object?> _encodeAdvertiseConfig(AdvertiseConfig? config) =>
+    <String, Object?>{
       "transport": (config?.transport ?? TransportKind.ble).name,
-      "formatVersion": config?.formatVersion ?? const AdvertiseConfig().formatVersion,
+      "formatVersion":
+          config?.formatVersion ?? const AdvertiseConfig().formatVersion,
     };
 
 Map<String, Object?> _encodeAutoConfig(AutoConfig? config) => <String, Object?>{
@@ -192,7 +315,11 @@ BarnardStartResult _parseStartResult(Map<Object?, Object?> map) {
       issues.add(BarnardIssue(severity: sev, code: code, message: message));
     }
   }
-  return BarnardStartResult(scanningStarted: scanningStarted, advertisingStarted: advertisingStarted, issues: issues);
+  return BarnardStartResult(
+    scanningStarted: scanningStarted,
+    advertisingStarted: advertisingStarted,
+    issues: issues,
+  );
 }
 
 BarnardCapabilities _parseCapabilities(Map<Object?, Object?> map) {
@@ -200,11 +327,18 @@ BarnardCapabilities _parseCapabilities(Map<Object?, Object?> map) {
   final List<Object?> transports = raw is List ? raw : const <Object?>["ble"];
   final Set<TransportKind> supportedTransports = transports
       .whereType<String>()
-      .map((String s) => TransportKind.values.firstWhere((e) => e.name == s, orElse: () => TransportKind.unknown))
+      .map(
+        (String s) => TransportKind.values.firstWhere(
+          (e) => e.name == s,
+          orElse: () => TransportKind.unknown,
+        ),
+      )
       .toSet();
 
   return BarnardCapabilities(
-    supportedTransports: supportedTransports.isEmpty ? <TransportKind>{TransportKind.ble} : supportedTransports,
+    supportedTransports: supportedTransports.isEmpty
+        ? <TransportKind>{TransportKind.ble}
+        : supportedTransports,
     supportsConnectionlessRpid: map["supportsConnectionlessRpid"] == true,
     supportsGattFallback: map["supportsGattFallback"] == true,
     supportsBackground: map["supportsBackground"] == true,
@@ -220,13 +354,18 @@ BarnardState _parseState(Map<Object?, Object?> map) {
 
 BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
   final String? type = map["type"] as String?;
-  final DateTime ts = DateTime.parse((map["timestamp"] as String?) ?? DateTime.now().toIso8601String());
+  final DateTime ts = DateTime.parse(
+    (map["timestamp"] as String?) ?? DateTime.now().toIso8601String(),
+  );
   switch (type) {
     case "state":
       final Map<Object?, Object?> state = _expectMap(map["state"]);
       return StateEvent(
         timestamp: ts,
-        state: BarnardState(isScanning: state["isScanning"] == true, isAdvertising: state["isAdvertising"] == true),
+        state: BarnardState(
+          isScanning: state["isScanning"] == true,
+          isAdvertising: state["isAdvertising"] == true,
+        ),
         reasonCode: map["reasonCode"] as String?,
       );
     case "constraint":
@@ -249,14 +388,20 @@ BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
         (e) => e.name == (map["transport"] as String?),
         orElse: () => TransportKind.unknown,
       );
-      final Uint8List rpid = Uint8List.fromList(base64Decode((map["rpid"] as String?) ?? ""));
+      final Uint8List rpid = Uint8List.fromList(
+        base64Decode((map["rpid"] as String?) ?? ""),
+      );
       final String displayId = (map["displayId"] as String?) ?? "";
       final int rssi = (map["rssi"] as int?) ?? 0;
       final int formatVersion = (map["formatVersion"] as int?) ?? 0;
       final String? payloadRawB64 = map["payloadRaw"] as String?;
-      final Uint8List? payloadRaw = payloadRawB64 == null ? null : Uint8List.fromList(base64Decode(payloadRawB64));
+      final Uint8List? payloadRaw = payloadRawB64 == null
+          ? null
+          : Uint8List.fromList(base64Decode(payloadRawB64));
 
-      final Map<Object?, Object?>? summaryMap = map["rssiSummary"] is Map ? map["rssiSummary"] as Map<Object?, Object?> : null;
+      final Map<Object?, Object?>? summaryMap = map["rssiSummary"] is Map
+          ? map["rssiSummary"] as Map<Object?, Object?>
+          : null;
       final RssiSummary? summary = summaryMap == null
           ? null
           : RssiSummary(
@@ -265,6 +410,13 @@ BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
               max: (summaryMap["max"] as int?) ?? 0,
               mean: (summaryMap["mean"] as num?)?.toDouble() ?? 0.0,
             );
+
+      // Parse resolved TEK fields (Event Mode)
+      final String? resolvedTekB64 = map["resolvedTek"] as String?;
+      final Uint8List? resolvedTek = resolvedTekB64 == null
+          ? null
+          : Uint8List.fromList(base64Decode(resolvedTekB64));
+      final String? resolvedDisplayId = map["resolvedDisplayId"] as String?;
 
       return DetectionEvent(
         timestamp: ts,
@@ -275,12 +427,16 @@ BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
         displayId: displayId,
         rssiSummary: summary,
         payloadRaw: payloadRaw,
+        resolvedTek: resolvedTek,
+        resolvedDisplayId: resolvedDisplayId,
       );
   }
 }
 
 BarnardDebugEvent _parseDebugEvent(Map<Object?, Object?> map) {
-  final DateTime ts = DateTime.parse((map["timestamp"] as String?) ?? DateTime.now().toIso8601String());
+  final DateTime ts = DateTime.parse(
+    (map["timestamp"] as String?) ?? DateTime.now().toIso8601String(),
+  );
   final String? levelStr = map["level"] as String?;
   final DebugLevel level = switch (levelStr) {
     "trace" => DebugLevel.trace,
@@ -289,9 +445,20 @@ BarnardDebugEvent _parseDebugEvent(Map<Object?, Object?> map) {
     _ => DebugLevel.info,
   };
   final String name = (map["name"] as String?) ?? "debug";
-  final Map<Object?, Object?>? rawData = map["data"] is Map ? map["data"] as Map<Object?, Object?> : null;
-  final Map<String, Object?>? data = rawData?.map((k, v) => MapEntry(k.toString(), v));
+  final Map<Object?, Object?>? rawData =
+      map["data"] is Map ? map["data"] as Map<Object?, Object?> : null;
+  final Map<String, Object?>? data = rawData?.map(
+    (k, v) => MapEntry(k.toString(), v),
+  );
   return DebugEvent(timestamp: ts, level: level, name: name, data: data);
+}
+
+TekEntry _parseTekEntry(Map<Object?, Object?> map) {
+  // Convert Object? map to String keys for TekEntry.fromMap
+  final Map<String, dynamic> typed = map.map(
+    (k, v) => MapEntry(k.toString(), v),
+  );
+  return TekEntry.fromMap(typed);
 }
 
 Map<Object?, Object?> _expectMap(Object? value) {

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
@@ -6,9 +6,11 @@ import "dart:typed_data";
 import "../../usecase/barnard_client.dart";
 import "../../domain/capabilities.dart";
 import "../../domain/config.dart";
+import "../../domain/crypto.dart";
 import "../../domain/events.dart";
 import "../../domain/rssi.dart";
 import "../../domain/state.dart";
+import "../../domain/tek_storage.dart";
 import "../../domain/transport.dart";
 import "mock_peer.dart";
 import "ring_buffer.dart";
@@ -30,10 +32,14 @@ class MockBarnard implements BarnardClient {
     int simulatedPeerCount = 50,
     int tickMs = 200,
     MockBarnardOverrides? overrides,
-  })  : _tickMs = tickMs.clamp(50, 2000),
-        _random = Random(),
-        _overrides = overrides {
-    _peers = List<MockPeer>.generate(simulatedPeerCount.clamp(1, 2000), (int i) {
+    Uint8List? deviceSecret,
+  }) : _tickMs = tickMs.clamp(50, 2000),
+       _random = Random(),
+       _overrides = overrides,
+       _deviceSecret = deviceSecret ?? _generateRandomBytes(32) {
+    _peers = List<MockPeer>.generate(simulatedPeerCount.clamp(1, 2000), (
+      int i,
+    ) {
       final int seed = _random.nextInt(1 << 31);
       return MockPeer(id: i, seed: seed, transport: TransportKind.ble);
     });
@@ -43,13 +49,18 @@ class MockBarnard implements BarnardClient {
     _debugEvents = StreamController<BarnardDebugEvent>.broadcast();
     _debugBuffer = RingBuffer<BarnardDebugEvent>(2000);
 
-    final int bufferMaxSamples = _overrides?.bufferMaxSamples ?? const RssiConfig().bufferMaxSamples;
+    final int bufferMaxSamples =
+        _overrides?.bufferMaxSamples ?? const RssiConfig().bufferMaxSamples;
     _rssiBuffer = RingBuffer<RssiSample>(bufferMaxSamples);
+
+    // Initialize with a random TEK for Anonymous Mode
+    _currentTek = _generateRandomBytes(16);
   }
 
   final int _tickMs;
   final Random _random;
   final MockBarnardOverrides? _overrides;
+  final Uint8List _deviceSecret;
 
   late final List<MockPeer> _peers;
 
@@ -63,6 +74,15 @@ class MockBarnard implements BarnardClient {
   Timer? _timer;
   bool _disposed = false;
 
+  // Event Mode state
+  EventMode _currentMode = EventMode.anonymous;
+  String? _currentEventCode;
+  late Uint8List _currentTek;
+  Uint8List? _currentEventCodeHash;
+
+  // TEK storage: eventCodeHash (base64) -> List<TekEntry>
+  final Map<String, List<TekEntry>> _tekStore = <String, List<TekEntry>>{};
+
   final Map<String, _RssiAgg> _aggByRpidKey = <String, _RssiAgg>{};
   int? _lastWindowIndex;
 
@@ -70,15 +90,21 @@ class MockBarnard implements BarnardClient {
 
   @override
   BarnardCapabilities get capabilities => const BarnardCapabilities(
-        supportedTransports: {TransportKind.ble},
-        supportsConnectionlessRpid: true,
-        supportsGattFallback: false,
-        supportsBackground: false,
-        supportsHighRateRssi: true,
-      );
+    supportedTransports: {TransportKind.ble},
+    supportsConnectionlessRpid: true,
+    supportsGattFallback: false,
+    supportsBackground: false,
+    supportsHighRateRssi: true,
+  );
 
   @override
   BarnardState get state => _state;
+
+  @override
+  EventMode get currentMode => _currentMode;
+
+  @override
+  String? get currentEventCode => _currentEventCode;
 
   @override
   Stream<BarnardEvent> get events => _events.stream;
@@ -90,7 +116,10 @@ class MockBarnard implements BarnardClient {
   Future<void> startScan([ScanConfig? config]) async {
     _ensureNotDisposed();
     if (_state.isScanning) return;
-    _setState(BarnardState(isScanning: true, isAdvertising: _state.isAdvertising), reasonCode: "scan_start");
+    _setState(
+      BarnardState(isScanning: true, isAdvertising: _state.isAdvertising),
+      reasonCode: "scan_start",
+    );
     _ensureTicker();
   }
 
@@ -98,7 +127,10 @@ class MockBarnard implements BarnardClient {
   Future<void> stopScan() async {
     _ensureNotDisposed();
     if (!_state.isScanning) return;
-    _setState(BarnardState(isScanning: false, isAdvertising: _state.isAdvertising), reasonCode: "scan_stop");
+    _setState(
+      BarnardState(isScanning: false, isAdvertising: _state.isAdvertising),
+      reasonCode: "scan_stop",
+    );
     _clearAggregation();
     _maybeStopTicker();
   }
@@ -107,7 +139,10 @@ class MockBarnard implements BarnardClient {
   Future<void> startAdvertise([AdvertiseConfig? config]) async {
     _ensureNotDisposed();
     if (_state.isAdvertising) return;
-    _setState(BarnardState(isScanning: _state.isScanning, isAdvertising: true), reasonCode: "advertise_start");
+    _setState(
+      BarnardState(isScanning: _state.isScanning, isAdvertising: true),
+      reasonCode: "advertise_start",
+    );
     _ensureTicker();
   }
 
@@ -115,7 +150,10 @@ class MockBarnard implements BarnardClient {
   Future<void> stopAdvertise() async {
     _ensureNotDisposed();
     if (!_state.isAdvertising) return;
-    _setState(BarnardState(isScanning: _state.isScanning, isAdvertising: false), reasonCode: "advertise_stop");
+    _setState(
+      BarnardState(isScanning: _state.isScanning, isAdvertising: false),
+      reasonCode: "advertise_stop",
+    );
     _maybeStopTicker();
   }
 
@@ -142,8 +180,130 @@ class MockBarnard implements BarnardClient {
     await stopAdvertise();
   }
 
+  // ─────────────────────────────────────────────────────────────────────────
+  // Event Mode APIs
+  // ─────────────────────────────────────────────────────────────────────────
+
   @override
-  List<BarnardDebugEvent> getDebugBuffer({int? limit}) => _debugBuffer.toList(limit: limit);
+  Future<void> joinEvent(String eventCode) async {
+    _ensureNotDisposed();
+    if (_currentMode == EventMode.event) {
+      throw StateError("Already in Event Mode. Call leaveEvent() first.");
+    }
+
+    _currentEventCode = eventCode;
+    _currentMode = EventMode.event;
+
+    // Derive TEK from DeviceSecret + EventCode
+    _currentTek = BarnardCrypto.deriveTekForEvent(_deviceSecret, eventCode);
+    _currentEventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode);
+
+    _emitDebug(DebugLevel.info, "mock_join_event", <String, Object?>{
+      "eventCode": eventCode,
+      "tekDisplayId": _tekDisplayId(_currentTek),
+      "eventCodeHash": base64Encode(_currentEventCodeHash!),
+    });
+  }
+
+  @override
+  Future<void> leaveEvent() async {
+    _ensureNotDisposed();
+    if (_currentMode == EventMode.anonymous) {
+      throw StateError("Not in Event Mode. Call joinEvent() first.");
+    }
+
+    final String leftEvent = _currentEventCode!;
+    _currentEventCode = null;
+    _currentMode = EventMode.anonymous;
+    _currentEventCodeHash = null;
+
+    // Generate a new random TEK for Anonymous Mode
+    _currentTek = _generateRandomBytes(16);
+
+    _emitDebug(DebugLevel.info, "mock_leave_event", <String, Object?>{
+      "leftEvent": leftEvent,
+    });
+  }
+
+  @override
+  Future<List<TekEntry>> getExchangedTeks(String eventCode) async {
+    _ensureNotDisposed();
+    final Uint8List hash = BarnardCrypto.computeEventCodeHash(eventCode);
+    final String key = base64Encode(hash);
+    return List<TekEntry>.unmodifiable(_tekStore[key] ?? const <TekEntry>[]);
+  }
+
+  @override
+  Future<int> clearTeksForEvent(String eventCode) async {
+    _ensureNotDisposed();
+    final Uint8List hash = BarnardCrypto.computeEventCodeHash(eventCode);
+    final String key = base64Encode(hash);
+    final List<TekEntry>? removed = _tekStore.remove(key);
+    final int count = removed?.length ?? 0;
+
+    _emitDebug(DebugLevel.info, "mock_clear_teks_for_event", <String, Object?>{
+      "eventCode": eventCode,
+      "removed": count,
+    });
+
+    return count;
+  }
+
+  @override
+  Future<int> clearAllTeks() async {
+    _ensureNotDisposed();
+    int total = 0;
+    for (final List<TekEntry> entries in _tekStore.values) {
+      total += entries.length;
+    }
+    _tekStore.clear();
+
+    _emitDebug(DebugLevel.info, "mock_clear_all_teks", <String, Object?>{
+      "removed": total,
+    });
+
+    return total;
+  }
+
+  /// Simulates receiving a TEK from another peer (for testing).
+  ///
+  /// In the real BLE implementation, this happens via GATT exchange.
+  void simulateReceivedTek(Uint8List tek, Uint8List eventCodeHash) {
+    final String key = base64Encode(eventCodeHash);
+    final List<TekEntry> entries = _tekStore.putIfAbsent(
+      key,
+      () => <TekEntry>[],
+    );
+
+    // Check if we already have this TEK
+    final String tekB64 = base64Encode(tek);
+    final bool alreadyHave = entries.any((e) => base64Encode(e.tek) == tekB64);
+    if (alreadyHave) return;
+
+    final DateTime now = DateTime.now();
+    entries.add(
+      TekEntry(
+        tek: Uint8List.fromList(tek),
+        eventCodeHash: Uint8List.fromList(eventCodeHash),
+        exchangedAt: now,
+        lastSeenAt: now,
+      ),
+    );
+
+    _emitDebug(DebugLevel.info, "mock_tek_received", <String, Object?>{
+      "tekDisplayId": _tekDisplayId(tek),
+      "eventCodeHashB64": key,
+      "totalTeks": entries.length,
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Pull APIs
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @override
+  List<BarnardDebugEvent> getDebugBuffer({int? limit}) =>
+      _debugBuffer.toList(limit: limit);
 
   @override
   List<RssiSample> getRssiSamples({
@@ -152,14 +312,18 @@ class MockBarnard implements BarnardClient {
     List<int>? rpidBytes,
   }) {
     final List<RssiSample> all = _rssiBuffer.toList();
-    final Uint8List? filterRpid = rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
+    final Uint8List? filterRpid = rpidBytes == null
+        ? null
+        : Uint8List.fromList(rpidBytes);
 
     Iterable<RssiSample> filtered = all;
     if (since != null) {
       filtered = filtered.where((RssiSample s) => !s.timestamp.isBefore(since));
     }
     if (filterRpid != null) {
-      filtered = filtered.where((RssiSample s) => _bytesEqual(s.rpid, filterRpid));
+      filtered = filtered.where(
+        (RssiSample s) => _bytesEqual(s.rpid, filterRpid),
+      );
     }
 
     final List<RssiSample> out = filtered.toList(growable: false);
@@ -195,7 +359,8 @@ class MockBarnard implements BarnardClient {
 
     final DateTime now = DateTime.now();
     final int rotationSeconds = _clampRotationSeconds();
-    final int windowIndex = (now.millisecondsSinceEpoch ~/ 1000) ~/ rotationSeconds;
+    final int windowIndex =
+        (now.millisecondsSinceEpoch ~/ 1000) ~/ rotationSeconds;
     if (_lastWindowIndex != windowIndex) {
       _lastWindowIndex = windowIndex;
       _clearAggregation();
@@ -211,7 +376,14 @@ class MockBarnard implements BarnardClient {
       final Uint8List rpid = peer.rpidForWindow(windowIndex);
       final int rssi = peer.nextRssi();
 
-      _rssiBuffer.add(RssiSample(timestamp: now, rpid: rpid, rssi: rssi, transport: peer.transport));
+      _rssiBuffer.add(
+        RssiSample(
+          timestamp: now,
+          rpid: rpid,
+          rssi: rssi,
+          transport: peer.transport,
+        ),
+      );
       _accumulateAndMaybeEmit(now: now, peer: peer, rpid: rpid, rssi: rssi);
     }
   }
@@ -227,8 +399,11 @@ class MockBarnard implements BarnardClient {
     agg.add(rssi, now: now);
     _evictAggIfNeeded(now);
 
-    final int minIntervalMs = (_overrides?.minPushIntervalMs ?? const RssiConfig().minPushIntervalMs).clamp(50, 60 * 1000);
-    if (agg.lastEmitAt != null && now.difference(agg.lastEmitAt!).inMilliseconds < minIntervalMs) {
+    final int minIntervalMs =
+        (_overrides?.minPushIntervalMs ?? const RssiConfig().minPushIntervalMs)
+            .clamp(50, 60 * 1000);
+    if (agg.lastEmitAt != null &&
+        now.difference(agg.lastEmitAt!).inMilliseconds < minIntervalMs) {
       return;
     }
 
@@ -260,7 +435,9 @@ class MockBarnard implements BarnardClient {
   void _setState(BarnardState next, {required String reasonCode}) {
     _state = next;
     final DateTime now = DateTime.now();
-    _events.add(StateEvent(timestamp: now, state: next, reasonCode: reasonCode));
+    _events.add(
+      StateEvent(timestamp: now, state: next, reasonCode: reasonCode),
+    );
     _emitDebug(DebugLevel.info, "state", <String, Object?>{
       "isScanning": next.isScanning,
       "isAdvertising": next.isAdvertising,
@@ -269,7 +446,12 @@ class MockBarnard implements BarnardClient {
   }
 
   void _emitDebug(DebugLevel level, String name, Map<String, Object?> data) {
-    final DebugEvent e = DebugEvent(timestamp: DateTime.now(), level: level, name: name, data: data);
+    final DebugEvent e = DebugEvent(
+      timestamp: DateTime.now(),
+      level: level,
+      name: name,
+      data: data,
+    );
     _debugBuffer.add(e);
     _debugEvents.add(e);
   }
@@ -283,10 +465,13 @@ class MockBarnard implements BarnardClient {
 
     // Evict the least-recently-seen entries to keep the mock bounded.
     // This is O(n) but only triggers when the map exceeds the cap.
-    final List<MapEntry<String, _RssiAgg>> entries = _aggByRpidKey.entries.toList(growable: false);
+    final List<MapEntry<String, _RssiAgg>> entries = _aggByRpidKey.entries
+        .toList(growable: false);
     entries.sort((a, b) {
-      final DateTime aSeen = a.value.lastSeenAt ?? DateTime.fromMillisecondsSinceEpoch(0);
-      final DateTime bSeen = b.value.lastSeenAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final DateTime aSeen =
+          a.value.lastSeenAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final DateTime bSeen =
+          b.value.lastSeenAt ?? DateTime.fromMillisecondsSinceEpoch(0);
       return aSeen.compareTo(bSeen);
     });
 
@@ -307,13 +492,20 @@ class MockBarnard implements BarnardClient {
   }
 
   int _clampRotationSeconds() {
-    final int rotationSeconds = _overrides?.rotationSeconds ?? const RpidConfig().rotationSeconds;
-    return rotationSeconds.clamp(const RpidConfig().minRotationSeconds, const RpidConfig().maxRotationSeconds);
+    final int rotationSeconds =
+        _overrides?.rotationSeconds ?? const RpidConfig().rotationSeconds;
+    return rotationSeconds.clamp(
+      const RpidConfig().minRotationSeconds,
+      const RpidConfig().maxRotationSeconds,
+    );
   }
 
   static String _displayId(Uint8List rpid) {
     final int take = min(4, rpid.length);
-    final String hex = rpid.sublist(0, take).map((int b) => b.toRadixString(16).padLeft(2, "0")).join();
+    final String hex = rpid
+        .sublist(0, take)
+        .map((int b) => b.toRadixString(16).padLeft(2, "0"))
+        .join();
     return hex;
   }
 
@@ -325,6 +517,22 @@ class MockBarnard implements BarnardClient {
       if (a[i] != b[i]) return false;
     }
     return true;
+  }
+
+  static Uint8List _generateRandomBytes(int length) {
+    final Random random = Random.secure();
+    return Uint8List.fromList(
+      List<int>.generate(length, (_) => random.nextInt(256)),
+    );
+  }
+
+  static String _tekDisplayId(Uint8List tek) {
+    final int take = min(3, tek.length);
+    return tek
+        .sublist(0, take)
+        .map((int b) => b.toRadixString(16).padLeft(2, "0"))
+        .join()
+        .toUpperCase();
   }
 }
 

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
@@ -33,10 +33,10 @@ class MockBarnard implements BarnardClient {
     int tickMs = 200,
     MockBarnardOverrides? overrides,
     Uint8List? deviceSecret,
-  }) : _tickMs = tickMs.clamp(50, 2000),
-       _random = Random(),
-       _overrides = overrides,
-       _deviceSecret = deviceSecret ?? _generateRandomBytes(32) {
+  })  : _tickMs = tickMs.clamp(50, 2000),
+        _random = Random(),
+        _overrides = overrides,
+        _deviceSecret = deviceSecret ?? _generateRandomBytes(32) {
     _peers = List<MockPeer>.generate(simulatedPeerCount.clamp(1, 2000), (
       int i,
     ) {
@@ -53,8 +53,8 @@ class MockBarnard implements BarnardClient {
         _overrides?.bufferMaxSamples ?? const RssiConfig().bufferMaxSamples;
     _rssiBuffer = RingBuffer<RssiSample>(bufferMaxSamples);
 
-    // Initialize with a random TEK for Anonymous Mode
-    _currentTek = _generateRandomBytes(16);
+    // Initialize with a deterministic TEK for Anonymous Mode
+    _currentTek = BarnardCrypto.deriveTekForAnonymous(_deviceSecret);
   }
 
   final int _tickMs;
@@ -90,12 +90,12 @@ class MockBarnard implements BarnardClient {
 
   @override
   BarnardCapabilities get capabilities => const BarnardCapabilities(
-    supportedTransports: {TransportKind.ble},
-    supportsConnectionlessRpid: true,
-    supportsGattFallback: false,
-    supportsBackground: false,
-    supportsHighRateRssi: true,
-  );
+        supportedTransports: {TransportKind.ble},
+        supportsConnectionlessRpid: true,
+        supportsGattFallback: false,
+        supportsBackground: false,
+        supportsHighRateRssi: true,
+      );
 
   @override
   BarnardState get state => _state;
@@ -217,8 +217,8 @@ class MockBarnard implements BarnardClient {
     _currentMode = EventMode.anonymous;
     _currentEventCodeHash = null;
 
-    // Generate a new random TEK for Anonymous Mode
-    _currentTek = _generateRandomBytes(16);
+    // Generate a deterministic TEK for Anonymous Mode
+    _currentTek = BarnardCrypto.deriveTekForAnonymous(_deviceSecret);
 
     _emitDebug(DebugLevel.info, "mock_leave_event", <String, Object?>{
       "leftEvent": leftEvent,
@@ -312,9 +312,8 @@ class MockBarnard implements BarnardClient {
     List<int>? rpidBytes,
   }) {
     final List<RssiSample> all = _rssiBuffer.toList();
-    final Uint8List? filterRpid = rpidBytes == null
-        ? null
-        : Uint8List.fromList(rpidBytes);
+    final Uint8List? filterRpid =
+        rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
 
     Iterable<RssiSample> filtered = all;
     if (since != null) {
@@ -419,6 +418,7 @@ class MockBarnard implements BarnardClient {
       displayId: _displayId(rpid),
       rssiSummary: summary,
       payloadRaw: null,
+      debugLocalName: null,
     );
 
     _events.add(event);
@@ -465,8 +465,8 @@ class MockBarnard implements BarnardClient {
 
     // Evict the least-recently-seen entries to keep the mock bounded.
     // This is O(n) but only triggers when the map exceeds the cap.
-    final List<MapEntry<String, _RssiAgg>> entries = _aggByRpidKey.entries
-        .toList(growable: false);
+    final List<MapEntry<String, _RssiAgg>> entries =
+        _aggByRpidKey.entries.toList(growable: false);
     entries.sort((a, b) {
       final DateTime aSeen =
           a.value.lastSeenAt ?? DateTime.fromMillisecondsSinceEpoch(0);
@@ -531,8 +531,7 @@ class MockBarnard implements BarnardClient {
     return tek
         .sublist(0, take)
         .map((int b) => b.toRadixString(16).padLeft(2, "0"))
-        .join()
-        .toUpperCase();
+        .join();
   }
 }
 

--- a/packages/dart/barnard/lib/src/usecase/barnard_client.dart
+++ b/packages/dart/barnard/lib/src/usecase/barnard_client.dart
@@ -3,6 +3,19 @@ import "../domain/capabilities.dart";
 import "../domain/config.dart";
 import "../domain/events.dart";
 import "../domain/state.dart";
+import "../domain/tek_storage.dart";
+
+/// Operating mode for the Barnard client.
+enum EventMode {
+  /// Anonymous mode: detections only, no identification.
+  /// TEK is randomly generated and not exchanged.
+  anonymous,
+
+  /// Event mode: identification and tracking enabled.
+  /// TEK is derived from DeviceSecret + EventCode, exchanged with peers
+  /// that have matching EventCodeHash.
+  event,
+}
 
 class BarnardStartResult {
   const BarnardStartResult({
@@ -34,6 +47,12 @@ abstract class BarnardClient {
   BarnardCapabilities get capabilities;
   BarnardState get state;
 
+  /// Current operating mode: anonymous or event.
+  EventMode get currentMode;
+
+  /// The active event code when in Event Mode, null otherwise.
+  String? get currentEventCode;
+
   Stream<BarnardEvent> get events;
   Stream<BarnardDebugEvent> get debugEvents;
 
@@ -49,6 +68,52 @@ abstract class BarnardClient {
   /// returned result.
   Future<BarnardStartResult> startAuto([AutoConfig? config]);
   Future<void> stopAuto();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Event Mode APIs
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /// Joins an event, switching from Anonymous to Event Mode.
+  ///
+  /// [eventCode] is the shared event code (e.g., "CONF2025-HALL-A").
+  /// This triggers:
+  /// 1. TEK derivation from DeviceSecret + eventCode
+  /// 2. EventCodeHash calculation (first 8 bytes of SHA256)
+  /// 3. RPID generation using GAEN-compatible derivation
+  /// 4. TEK exchange with peers having matching EventCodeHash
+  ///
+  /// Throws [StateError] if already in Event Mode.
+  Future<void> joinEvent(String eventCode);
+
+  /// Leaves the current event, switching back to Anonymous Mode.
+  ///
+  /// This triggers:
+  /// 1. TEK regeneration (random)
+  /// 2. EventCodeHash cleared (empty)
+  /// 3. Stored TEKs for this event are retained until explicitly cleared
+  ///
+  /// Throws [StateError] if not in Event Mode.
+  Future<void> leaveEvent();
+
+  /// Returns all exchanged TEKs for the specified event code.
+  ///
+  /// Each [TekEntry] contains the TEK bytes, timestamp, and optional metadata.
+  /// Returns empty list if no TEKs stored for this event.
+  Future<List<TekEntry>> getExchangedTeks(String eventCode);
+
+  /// Clears all stored TEKs for the specified event code.
+  ///
+  /// Returns the number of entries removed.
+  Future<int> clearTeksForEvent(String eventCode);
+
+  /// Clears all stored TEKs across all events.
+  ///
+  /// Returns the number of entries removed.
+  Future<int> clearAllTeks();
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Pull APIs
+  // ─────────────────────────────────────────────────────────────────────────
 
   /// Pull: read the in-memory debug buffer snapshot.
   List<BarnardDebugEvent> getDebugBuffer({int? limit});

--- a/packages/dart/barnard/pubspec.yaml
+++ b/packages/dart/barnard/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.11.0
+  pointycastle: ^3.9.1  # HKDF, AES-128 for GAEN-compatible crypto
 
 dev_dependencies:
   flutter_test:

--- a/packages/dart/barnard/test/crypto_test.dart
+++ b/packages/dart/barnard/test/crypto_test.dart
@@ -1,0 +1,385 @@
+import "dart:convert";
+import "dart:typed_data";
+
+import "package:barnard/barnard.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("GAEN-compatible key derivation", () {
+    test("HKDF-SHA256 produces 16-byte output", () {
+      final ikm = Uint8List.fromList(List.generate(32, (i) => i));
+      final info = Uint8List.fromList(utf8.encode("test-info"));
+
+      final result = hkdfSha256(ikm: ikm, info: info, length: 16);
+
+      expect(result.length, equals(16));
+    });
+
+    test("HKDF-SHA256 is deterministic", () {
+      final ikm = Uint8List.fromList(List.generate(32, (i) => i));
+      final info = Uint8List.fromList(utf8.encode("test-info"));
+
+      final result1 = hkdfSha256(ikm: ikm, info: info, length: 16);
+      final result2 = hkdfSha256(ikm: ikm, info: info, length: 16);
+
+      expect(result1, equals(result2));
+    });
+
+    test("AES-128-ECB encrypts 16-byte block", () {
+      final key = Uint8List.fromList(List.generate(16, (i) => i));
+      final plaintext = Uint8List.fromList(List.generate(16, (i) => 0xFF - i));
+
+      final ciphertext = aes128EcbEncrypt(key, plaintext);
+
+      expect(ciphertext.length, equals(16));
+      expect(ciphertext, isNot(equals(plaintext)));
+    });
+
+    test("AES-128-ECB is deterministic", () {
+      final key = Uint8List.fromList(List.generate(16, (i) => i));
+      final plaintext = Uint8List.fromList(List.generate(16, (i) => 0xFF - i));
+
+      final ciphertext1 = aes128EcbEncrypt(key, plaintext);
+      final ciphertext2 = aes128EcbEncrypt(key, plaintext);
+
+      expect(ciphertext1, equals(ciphertext2));
+    });
+
+    test("SHA-256 produces 32-byte output", () {
+      final input = Uint8List.fromList(utf8.encode("TECH2026"));
+
+      final hash = sha256(input);
+
+      expect(hash.length, equals(32));
+    });
+  });
+
+  group("TEK derivation", () {
+    test("deriveTek produces 16-byte output", () {
+      final deviceSecret = Uint8List.fromList(List.generate(32, (i) => i * 2));
+      const eventCode = "TECH2026";
+
+      final tek = deriveTek(deviceSecret, eventCode);
+
+      expect(tek.length, equals(16));
+    });
+
+    test("deriveTek is deterministic for same inputs", () {
+      final deviceSecret = Uint8List.fromList(List.generate(32, (i) => i * 2));
+      const eventCode = "TECH2026";
+
+      final tek1 = deriveTek(deviceSecret, eventCode);
+      final tek2 = deriveTek(deviceSecret, eventCode);
+
+      expect(tek1, equals(tek2));
+    });
+
+    test("deriveTek produces different output for different event codes", () {
+      final deviceSecret = Uint8List.fromList(List.generate(32, (i) => i * 2));
+
+      final tek1 = deriveTek(deviceSecret, "EVENT_A");
+      final tek2 = deriveTek(deviceSecret, "EVENT_B");
+
+      expect(tek1, isNot(equals(tek2)));
+    });
+
+    test("deriveTek produces different output for different device secrets",
+        () {
+      final deviceSecret1 = Uint8List.fromList(List.generate(32, (i) => i));
+      final deviceSecret2 = Uint8List.fromList(List.generate(32, (i) => i + 1));
+      const eventCode = "TECH2026";
+
+      final tek1 = deriveTek(deviceSecret1, eventCode);
+      final tek2 = deriveTek(deviceSecret2, eventCode);
+
+      expect(tek1, isNot(equals(tek2)));
+    });
+  });
+
+  group("RPIK derivation", () {
+    test("deriveRpik produces 16-byte output", () {
+      final tek = Uint8List.fromList(List.generate(16, (i) => i));
+
+      final rpik = deriveRpik(tek);
+
+      expect(rpik.length, equals(16));
+    });
+
+    test("deriveRpik is deterministic", () {
+      final tek = Uint8List.fromList(List.generate(16, (i) => i));
+
+      final rpik1 = deriveRpik(tek);
+      final rpik2 = deriveRpik(tek);
+
+      expect(rpik1, equals(rpik2));
+    });
+
+    test("deriveRpik produces different output for different TEKs", () {
+      final tek1 = Uint8List.fromList(List.generate(16, (i) => i));
+      final tek2 = Uint8List.fromList(List.generate(16, (i) => i + 1));
+
+      final rpik1 = deriveRpik(tek1);
+      final rpik2 = deriveRpik(tek2);
+
+      expect(rpik1, isNot(equals(rpik2)));
+    });
+
+    test("deriveRpik throws for invalid TEK length", () {
+      final invalidTek = Uint8List.fromList(List.generate(15, (i) => i));
+
+      expect(() => deriveRpik(invalidTek), throwsArgumentError);
+    });
+  });
+
+  group("RPI generation", () {
+    test("generateRpi produces 16-byte output", () {
+      final rpik = Uint8List.fromList(List.generate(16, (i) => i));
+      const enin = 2948599; // Example ENIN
+
+      final rpi = generateRpi(rpik, enin);
+
+      expect(rpi.length, equals(16));
+    });
+
+    test("generateRpi is deterministic for same RPIK and ENIN", () {
+      final rpik = Uint8List.fromList(List.generate(16, (i) => i));
+      const enin = 2948599;
+
+      final rpi1 = generateRpi(rpik, enin);
+      final rpi2 = generateRpi(rpik, enin);
+
+      expect(rpi1, equals(rpi2));
+    });
+
+    test("generateRpi produces different output for different ENINs", () {
+      final rpik = Uint8List.fromList(List.generate(16, (i) => i));
+      const enin1 = 2948599;
+      const enin2 = 2948600;
+
+      final rpi1 = generateRpi(rpik, enin1);
+      final rpi2 = generateRpi(rpik, enin2);
+
+      expect(rpi1, isNot(equals(rpi2)));
+    });
+
+    test("generateRpi throws for invalid RPIK length", () {
+      final invalidRpik = Uint8List.fromList(List.generate(15, (i) => i));
+      const enin = 2948599;
+
+      expect(() => generateRpi(invalidRpik, enin), throwsArgumentError);
+    });
+  });
+
+  group("ENIN calculation", () {
+    test("calculateEnin returns correct value", () {
+      // UNIX timestamp 1736947200 = 2026-01-15 12:00:00 UTC
+      final timestamp =
+          DateTime.fromMillisecondsSinceEpoch(1736947200 * 1000, isUtc: true);
+
+      final enin = calculateEnin(timestamp);
+
+      // ENIN = 1736947200 / 600 = 2894912
+      expect(enin, equals(2894912));
+    });
+
+    test("calculateEnin changes every 10 minutes", () {
+      final timestamp1 =
+          DateTime.fromMillisecondsSinceEpoch(1736947200 * 1000, isUtc: true);
+      final timestamp2 = DateTime.fromMillisecondsSinceEpoch(
+          (1736947200 + 600) * 1000,
+          isUtc: true);
+
+      final enin1 = calculateEnin(timestamp1);
+      final enin2 = calculateEnin(timestamp2);
+
+      expect(enin2, equals(enin1 + 1));
+    });
+
+    test("calculateEnin is stable within 10-minute window", () {
+      final timestamp1 =
+          DateTime.fromMillisecondsSinceEpoch(1736947200 * 1000, isUtc: true);
+      final timestamp2 = DateTime.fromMillisecondsSinceEpoch(
+          (1736947200 + 599) * 1000,
+          isUtc: true);
+
+      final enin1 = calculateEnin(timestamp1);
+      final enin2 = calculateEnin(timestamp2);
+
+      expect(enin1, equals(enin2));
+    });
+  });
+
+  group("EventCodeHash calculation", () {
+    test("calculateEventCodeHash produces 8-byte output", () {
+      const eventCode = "TECH2026";
+
+      final hash = calculateEventCodeHash(eventCode);
+
+      expect(hash.length, equals(8));
+    });
+
+    test("calculateEventCodeHash is deterministic", () {
+      const eventCode = "TECH2026";
+
+      final hash1 = calculateEventCodeHash(eventCode);
+      final hash2 = calculateEventCodeHash(eventCode);
+
+      expect(hash1, equals(hash2));
+    });
+
+    test("calculateEventCodeHash produces different output for different codes",
+        () {
+      const eventCode1 = "EVENT_A";
+      const eventCode2 = "EVENT_B";
+
+      final hash1 = calculateEventCodeHash(eventCode1);
+      final hash2 = calculateEventCodeHash(eventCode2);
+
+      expect(hash1, isNot(equals(hash2)));
+    });
+  });
+
+  group("RPI resolution", () {
+    test("resolveRpi finds matching TEK", () {
+      // Create a TEK and generate an RPI from it
+      final tek = Uint8List.fromList(List.generate(16, (i) => i + 10));
+      final rpik = deriveRpik(tek);
+      const currentEnin = 2948599;
+      final rpi = generateRpi(rpik, currentEnin);
+
+      // Try to resolve the RPI
+      final result = resolveRpi(
+        rpi: rpi,
+        knownTeks: [tek],
+        currentEnin: currentEnin,
+      );
+
+      expect(result, isNotNull);
+      expect(result, equals(tek));
+    });
+
+    test("resolveRpi finds TEK within time window", () {
+      final tek = Uint8List.fromList(List.generate(16, (i) => i + 20));
+      final rpik = deriveRpik(tek);
+      const currentEnin = 2948599;
+      // Generate RPI for ENIN that's 3 intervals in the past (within ±6 window)
+      final rpi = generateRpi(rpik, currentEnin - 3);
+
+      final result = resolveRpi(
+        rpi: rpi,
+        knownTeks: [tek],
+        currentEnin: currentEnin,
+      );
+
+      expect(result, isNotNull);
+      expect(result, equals(tek));
+    });
+
+    test("resolveRpi returns null for unknown RPI", () {
+      final knownTek = Uint8List.fromList(List.generate(16, (i) => i));
+      final unknownTek = Uint8List.fromList(List.generate(16, (i) => i + 100));
+      final unknownRpik = deriveRpik(unknownTek);
+      const currentEnin = 2948599;
+      final unknownRpi = generateRpi(unknownRpik, currentEnin);
+
+      final result = resolveRpi(
+        rpi: unknownRpi,
+        knownTeks: [knownTek],
+        currentEnin: currentEnin,
+      );
+
+      expect(result, isNull);
+    });
+
+    test("resolveRpi returns null for RPI outside time window", () {
+      final tek = Uint8List.fromList(List.generate(16, (i) => i + 30));
+      final rpik = deriveRpik(tek);
+      const currentEnin = 2948599;
+      // Generate RPI for ENIN that's 10 intervals in the past (outside ±6 window)
+      final rpi = generateRpi(rpik, currentEnin - 10);
+
+      final result = resolveRpi(
+        rpi: rpi,
+        knownTeks: [tek],
+        currentEnin: currentEnin,
+      );
+
+      expect(result, isNull);
+    });
+
+    test("resolveRpi finds correct TEK among multiple", () {
+      final tek1 = Uint8List.fromList(List.generate(16, (i) => i + 40));
+      final tek2 = Uint8List.fromList(List.generate(16, (i) => i + 50));
+      final tek3 = Uint8List.fromList(List.generate(16, (i) => i + 60));
+
+      // Generate RPI from tek2
+      final rpik2 = deriveRpik(tek2);
+      const currentEnin = 2948599;
+      final rpi = generateRpi(rpik2, currentEnin);
+
+      final result = resolveRpi(
+        rpi: rpi,
+        knownTeks: [tek1, tek2, tek3],
+        currentEnin: currentEnin,
+      );
+
+      expect(result, isNotNull);
+      expect(result, equals(tek2));
+    });
+  });
+
+  group("End-to-end key derivation chain", () {
+    test("full chain: DeviceSecret -> TEK -> RPIK -> RPI -> resolve", () {
+      // Simulate Device A
+      final deviceSecretA = Uint8List.fromList(List.generate(32, (i) => i * 3));
+      const eventCode = "TECH2026";
+
+      // Derive keys
+      final tekA = deriveTek(deviceSecretA, eventCode);
+      final rpikA = deriveRpik(tekA);
+      const currentEnin = 2948599;
+      final rpiA = generateRpi(rpikA, currentEnin);
+
+      // Simulate Device B receiving and resolving
+      final resolvedTek = resolveRpi(
+        rpi: rpiA,
+        knownTeks: [tekA], // B has A's TEK from GATT exchange
+        currentEnin: currentEnin,
+      );
+
+      expect(resolvedTek, equals(tekA));
+
+      // Verify displayId derivation
+      final displayId = tekA
+          .sublist(0, 3)
+          .map((b) => b.toRadixString(16).padLeft(2, "0"))
+          .join();
+      expect(displayId.length, equals(6));
+    });
+
+    test("different event codes produce unlinkable identities", () {
+      final deviceSecret = Uint8List.fromList(List.generate(32, (i) => i));
+
+      final tekEvent1 = deriveTek(deviceSecret, "EVENT_1");
+      final tekEvent2 = deriveTek(deviceSecret, "EVENT_2");
+
+      final rpikEvent1 = deriveRpik(tekEvent1);
+      final rpikEvent2 = deriveRpik(tekEvent2);
+
+      const enin = 2948599;
+      final rpiEvent1 = generateRpi(rpikEvent1, enin);
+      final rpiEvent2 = generateRpi(rpikEvent2, enin);
+
+      // RPIs from different events should be completely different
+      expect(rpiEvent1, isNot(equals(rpiEvent2)));
+
+      // Cannot resolve RPI from event1 using TEK from event2
+      final resolveResult = resolveRpi(
+        rpi: rpiEvent1,
+        knownTeks: [tekEvent2],
+        currentEnin: enin,
+      );
+      expect(resolveResult, isNull);
+    });
+  });
+}

--- a/schema/barnard/v1/common.schema.json
+++ b/schema/barnard/v1/common.schema.json
@@ -20,6 +20,16 @@
     "Timestamp": {
       "type": "string",
       "format": "date-time"
+    },
+    "TekBytes": {
+      "description": "TEK (Temporary Exposure Key) as 16 bytes encoded as base64.",
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "EventCodeHashBytes": {
+      "description": "EventCodeHash as first 8 bytes of SHA256(EventCode) encoded as base64.",
+      "type": "string",
+      "contentEncoding": "base64"
     }
   }
 }

--- a/schema/barnard/v1/events.schema.json
+++ b/schema/barnard/v1/events.schema.json
@@ -22,7 +22,19 @@
         "displayId": { "type": "string", "minLength": 1 },
         "rssi": { "type": "integer" },
         "rssiSummary": { "$ref": "#/$defs/RssiSummary" },
-        "payloadRaw": { "type": ["string", "null"], "contentEncoding": "base64" }
+        "payloadRaw": { "type": ["string", "null"], "contentEncoding": "base64" },
+        "resolvedTek": {
+          "oneOf": [
+            { "$ref": "common.schema.json#/$defs/TekBytes" },
+            { "type": "null" }
+          ],
+          "description": "TEK of the resolved peer (null if not resolved or Anonymous Mode)"
+        },
+        "resolvedDisplayId": {
+          "type": ["string", "null"],
+          "pattern": "^[0-9a-f]{6}$",
+          "description": "First 3 bytes of resolved TEK as lowercase hex (6 chars)"
+        }
       },
       "required": ["type", "timestamp", "transport", "formatVersion", "rpid", "displayId", "rssi"]
     },

--- a/schema/barnard/v1/events.schema.json
+++ b/schema/barnard/v1/events.schema.json
@@ -34,6 +34,10 @@
           "type": ["string", "null"],
           "pattern": "^[0-9a-f]{6}$",
           "description": "First 3 bytes of resolved TEK as lowercase hex (6 chars)"
+        },
+        "debugLocalName": {
+          "type": ["string", "null"],
+          "description": "Debug-only local name observed during scan (may be omitted in release builds)"
         }
       },
       "required": ["type", "timestamp", "transport", "formatVersion", "rpid", "displayId", "rssi"]
@@ -106,4 +110,3 @@
     }
   }
 }
-

--- a/specs/004-resolvable-id/spec.md
+++ b/specs/004-resolvable-id/spec.md
@@ -56,7 +56,7 @@ Key constraint: **No global device uniqueness** - identity must be scoped to a s
 ### Anonymous Mode
 
 - Default mode when no Event Code is set
-- RPI generation uses GAEN algorithm with random TEK (not shared)
+- RPI generation uses GAEN algorithm with a deterministic TEK derived from DeviceSecret
 - Other devices can detect presence but cannot identify or track
 - Privacy-first for users who don't want to be identifiable
 
@@ -73,7 +73,7 @@ Key constraint: **No global device uniqueness** - identity must be scoped to a s
 DeviceSecret (32 bytes, device-generated, never transmitted)
      │
      ├── Anonymous Mode (no Event Code)
-     │   └── TEK = random 16 bytes (regenerated periodically)
+     │   └── TEK = HKDF-SHA256(DeviceSecret, info="barnard-tek-anonymous", length=16)
      │
      └── Event Mode (Event Code present)
          │
@@ -361,6 +361,10 @@ class DetectionEvent extends BarnardEvent {
   /// Display ID of the resolved peer (null if not resolved).
   /// Format: first 3 bytes of TEK as lowercase hex (6 chars).
   final String? resolvedDisplayId;
+
+  /// Debug-only local name observed in advertisements, if present.
+  /// May be omitted in release builds.
+  final String? debugLocalName;
 }
 ```
 

--- a/specs/004-resolvable-id/spec.md
+++ b/specs/004-resolvable-id/spec.md
@@ -1,0 +1,511 @@
+# Feature Specification: Resolvable ID
+
+**Feature Directory**: `specs/004-resolvable-id`  
+**Created**: 2026-01-22  
+**Status**: In Progress  
+**Issue**: [#31](https://github.com/thegreeting/barnard/issues/31)
+
+## Problem Statement
+
+The current RPID implementation uses simple random value rotation (`HMAC-SHA256(rpidSeed, windowIndex)`), but lacks a mechanism for **authorized parties to identify a device within an event**.
+
+Current limitations:
+- **Detection only**: We can detect "a Barnard user is nearby"
+- **No identification**: We cannot determine "who it is" (event-scoped device ID)
+- **No continuous tracking**: We cannot correlate "the person at 10:00 and 10:15 is the same"
+
+Key constraint: **No global device uniqueness** - identity must be scoped to a specific event only.
+
+## Goals
+
+- Implement GAEN (Google/Apple Exposure Notification) v1.2 compatible key derivation
+- Enable event-scoped device identification via GATT TEK exchange
+- Support two modes: Anonymous Mode and Event Mode
+- Maintain privacy: no device-unique persistent identifiers on-wire
+- No server required for TEK exchange
+
+## Non-goals
+
+- Server-side TEK registry (GAEN's diagnosis key upload model)
+- Daily key rotation (TEKi derivation)
+- Background TEK exchange
+- Cross-event device tracking (by design)
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **Detection** | Knowing "a Barnard user is nearby" |
+| **Identification** | Knowing "this is the holder of TEK_A" (event-scoped device ID) |
+| **Continuous Tracking** | Knowing "RPI at 10:00 and RPI at 10:15 belong to the same device" |
+| **DeviceSecret** | 32-byte random value, generated once per device, never leaves device |
+| **Event Code** | User-input string (e.g., "TECH2026") shared among event participants |
+| **TEK** | Temporary Exposure Key (16 bytes), derived from DeviceSecret + Event Code |
+| **RPIK** | RPI Key (16 bytes), derived from TEK |
+| **RPI** | Rolling Proximity Identifier (16 bytes), rotates every 10-15 minutes |
+| **ENIN** | EN Interval Number = floor(unix_timestamp / 600) |
+| **displayId** | Event-scoped device ID: first 3 bytes of TEK as hex (6 chars) |
+
+## Two Modes
+
+| Mode | EventCodeHash | TEK Exchange | Identification | Continuous Tracking |
+|------|---------------|--------------|----------------|---------------------|
+| **Anonymous Mode** | Empty (0 bytes) | No | No | No |
+| **Event Mode** | 8 bytes | Yes | Yes | Yes |
+
+### Anonymous Mode
+
+- Default mode when no Event Code is set
+- RPI generation uses GAEN algorithm with random TEK (not shared)
+- Other devices can detect presence but cannot identify or track
+- Privacy-first for users who don't want to be identifiable
+
+### Event Mode
+
+- Activated when user joins an event with an Event Code
+- TEK derived from DeviceSecret + Event Code
+- TEK exchanged via GATT with other Event Mode participants
+- Enables identification and continuous tracking within event scope
+
+## Key Derivation (GAEN v1.2 Compatible)
+
+```
+DeviceSecret (32 bytes, device-generated, never transmitted)
+     │
+     ├── Anonymous Mode (no Event Code)
+     │   └── TEK = random 16 bytes (regenerated periodically)
+     │
+     └── Event Mode (Event Code present)
+         │
+         ▼
+    TEK = HKDF-SHA256(DeviceSecret ‖ EventCode, info="barnard-tek", length=16)
+         │
+         ▼
+    RPIK = HKDF-SHA256(TEK, info="EN-RPIK", length=16)
+         │
+         ▼
+    RPI = AES128-ECB(RPIK, PaddedData)
+    
+    where PaddedData = "EN-RPI" (6 bytes) ‖ 0x000000000000 (6 bytes) ‖ ENIN (4 bytes, big-endian)
+```
+
+### ENIN Calculation
+
+```
+ENIN = floor(unix_timestamp_seconds / 600)
+```
+
+Each ENIN represents a 10-minute interval. RPI rotates at ENIN boundaries.
+
+### EventCodeHash Calculation
+
+```
+EventCodeHash = SHA256(EventCode)[0:8]  // First 8 bytes
+```
+
+Used to verify same-event participation before TEK exchange.
+
+## GATT Service Specification
+
+### Service and Characteristic UUIDs
+
+| Name | UUID | Notes |
+|------|------|-------|
+| Discovery Service | `0000B001-0000-1000-8000-00805F9B34FB` | Existing |
+| RPID Characteristic | `0000B002-0000-1000-8000-00805F9B34FB` | Existing |
+| TEK Characteristic | `0000B003-0000-1000-8000-00805F9B34FB` | **New** |
+| EventCodeHash Characteristic | `0000B004-0000-1000-8000-00805F9B34FB` | **New** |
+
+### Characteristic Details
+
+#### RPID Characteristic (existing, unchanged)
+
+- **Properties**: Read
+- **Value**: `[formatVersion(1 byte) + RPI(16 bytes)]` = 17 bytes
+- **formatVersion**: `1` (unchanged)
+
+#### TEK Characteristic (new)
+
+- **Properties**: Read, Write
+- **Value**: `[TEK(16 bytes)]` = 16 bytes
+- **Behavior**:
+  - Read: Returns this device's TEK (only in Event Mode)
+  - Write: Stores the remote device's TEK
+- **Access Control**: Only accessible when EventCodeHash matches
+
+#### EventCodeHash Characteristic (new)
+
+- **Properties**: Read
+- **Value**: `[SHA256(EventCode)[0:8]]` = 8 bytes, or empty (0 bytes) in Anonymous Mode
+- **Purpose**: Verify same-event participation before TEK exchange
+
+## GATT Exchange Flow
+
+### Case 1: Both in Event Mode (Same Event)
+
+```
+Central (B)                    Peripheral (A)
+    │                              │
+    │◄── Advertisement ────────────│  (Service UUID only)
+    │──── GATT Connect ───────────►│
+    │                              │
+    │──── EventCodeHash Read ─────►│
+    │◄─── [hash_A = 8 bytes] ──────│
+    │                              │
+    │   hash_A == hash_B? → YES    │
+    │                              │
+    │──── RPID Read ──────────────►│
+    │◄─── [ver + RPI_A] ───────────│
+    │                              │
+    │──── TEK Read ───────────────►│
+    │◄─── [TEK_A] ─────────────────│
+    │                              │
+    │──── TEK Write ──────────────►│
+    │     [TEK_B] ─────────────────►│
+    │                              │
+    │◄─── Disconnect ──────────────│
+```
+
+**Result**: Both devices store each other's TEK → Identification & continuous tracking enabled
+
+### Case 2: Both in Event Mode (Different Events)
+
+```
+Central (B)                    Peripheral (A)
+    │                              │
+    │──── EventCodeHash Read ─────►│
+    │◄─── [hash_A = 8 bytes] ──────│
+    │                              │
+    │   hash_A == hash_B? → NO     │
+    │                              │
+    │──── RPID Read ──────────────►│  (detection only)
+    │◄─── [ver + RPI_A] ───────────│
+    │                              │
+    │   (skip TEK exchange)        │
+    │                              │
+    │◄─── Disconnect ──────────────│
+```
+
+**Result**: Detection only, no TEK exchange
+
+### Case 3: Either in Anonymous Mode
+
+```
+Central (B)                    Peripheral (A)
+    │                              │
+    │──── EventCodeHash Read ─────►│
+    │◄─── [empty = 0 bytes] ───────│  ← A is Anonymous
+    │                              │
+    │   A is Anonymous → skip TEK  │
+    │                              │
+    │──── RPID Read ──────────────►│
+    │◄─── [ver + RPI_A] ───────────│
+    │                              │
+    │   (skip TEK exchange)        │
+    │                              │
+    │◄─── Disconnect ──────────────│
+```
+
+**Result**: Detection only, Anonymous party's privacy preserved
+
+## TEK Storage Specification
+
+### Storage Structure
+
+```
+TEK Storage Entry:
+├── tek: 16 bytes (primary key)
+├── eventCodeHash: 8 bytes
+├── exchangedAt: timestamp (when TEK was received)
+├── lastSeenAt: timestamp (updated on successful RPI resolution)
+└── ttl: configurable (default 24 hours)
+```
+
+### Eviction Policy
+
+```
+if (now - lastSeenAt > ttl):
+    delete entry
+```
+
+Eviction runs periodically (e.g., on app launch, every hour).
+
+### Re-exchange Behavior
+
+| Case | Condition | Action |
+|------|-----------|--------|
+| **First exchange** | TEK not in storage | Save new entry |
+| **Re-exchange (same TEK)** | TEK already exists | Update `lastSeenAt` |
+| **Re-exchange (different TEK)** | Same peer, different TEK | Add as new entry |
+
+### Storage Limits
+
+- **maxEntries**: 1000 (configurable)
+- **Eviction**: LRU when limit exceeded
+
+### Platform Implementation
+
+- **iOS**: UserDefaults (JSON-encoded array)
+- **Android**: SharedPreferences (JSON-encoded array)
+
+## Identification Algorithm
+
+```python
+def resolve_rpi(received_rpi: bytes, known_teks: List[bytes], current_enin: int) -> Optional[Match]:
+    """
+    Attempt to resolve a received RPI to a known TEK.
+    
+    Args:
+        received_rpi: 16-byte RPI from remote device
+        known_teks: List of TEKs from exchanged peers
+        current_enin: Current EN Interval Number
+    
+    Returns:
+        Match object with tek and display_id if resolved, None otherwise
+    """
+    for tek in known_teks:
+        rpik = hkdf_sha256(tek, info=b"EN-RPIK", length=16)
+        
+        # Search within ±1 hour window (±6 intervals)
+        for enin in range(current_enin - 6, current_enin + 2):
+            padded_data = b"EN-RPI" + b"\x00" * 6 + enin.to_bytes(4, 'big')
+            candidate_rpi = aes128_ecb_encrypt(rpik, padded_data)
+            
+            if candidate_rpi == received_rpi:
+                display_id = tek[:3].hex()  # First 3 bytes as hex
+                return Match(tek=tek, display_id=display_id, enin=enin)
+    
+    return None
+```
+
+### Performance Considerations
+
+- **Lookup complexity**: O(known_teks × enin_window) = O(N × 8)
+- **Optimization**: Pre-compute RPIK for all known TEKs on storage load
+- **Caching**: Cache recent (RPI, TEK) resolutions to avoid repeated computation
+
+## Barnard Library Interface
+
+### Configuration
+
+```dart
+class BarnardConfig {
+  const BarnardConfig({
+    this.transport = TransportKind.ble,
+    this.eventCode,  // null for Anonymous Mode
+    this.tekStorage = const TekStorageConfig(),
+    // ... existing fields
+  });
+  
+  final String? eventCode;
+  final TekStorageConfig tekStorage;
+}
+
+class TekStorageConfig {
+  const TekStorageConfig({
+    this.ttlSeconds = 86400,  // 24 hours
+    this.maxEntries = 1000,
+  });
+  
+  final int ttlSeconds;
+  final int maxEntries;
+}
+```
+
+### Client API
+
+```dart
+abstract class BarnardClient {
+  // Existing methods...
+  
+  /// Join an event, switching to Event Mode.
+  /// Derives TEK from DeviceSecret + eventCode.
+  Future<void> joinEvent(String eventCode);
+  
+  /// Leave the current event, switching to Anonymous Mode.
+  Future<void> leaveEvent();
+  
+  /// Current operating mode.
+  EventMode get currentMode;
+  
+  /// List all exchanged TEKs (for debugging/UI).
+  Future<List<ExchangedTek>> getExchangedTeks();
+  
+  /// Clear TEKs for a specific event.
+  Future<void> clearTeksForEvent(String eventCode);
+  
+  /// Clear all stored TEKs.
+  Future<void> clearAllTeks();
+}
+
+enum EventMode { anonymous, event }
+
+class ExchangedTek {
+  final Uint8List tek;
+  final String displayId;  // TEK[0:3] as hex (6 chars)
+  final Uint8List eventCodeHash;
+  final DateTime exchangedAt;
+  final DateTime lastSeenAt;
+}
+```
+
+### Detection Event Extension
+
+```dart
+class DetectionEvent extends BarnardEvent {
+  // Existing fields...
+  
+  /// TEK of the resolved peer (null if not resolved).
+  final Uint8List? resolvedTek;
+  
+  /// Display ID of the resolved peer (null if not resolved).
+  /// Format: first 3 bytes of TEK as lowercase hex (6 chars).
+  final String? resolvedDisplayId;
+}
+```
+
+## Concrete Example
+
+### Setup
+
+```
+Event Code: "TECH2026"
+
+Device A:
+  DeviceSecret_A: 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
+  TEK_A = HKDF(DeviceSecret_A ‖ "TECH2026", info="barnard-tek", 16)
+        = 0x7A3F8B2C91D4E6F0A2B5C8D1E4F7A0B3
+  displayId_A = "7a3f8b"
+
+Device B:
+  DeviceSecret_B: 0xABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789
+  TEK_B = HKDF(DeviceSecret_B ‖ "TECH2026", info="barnard-tek", 16)
+        = 0x4E2D9A1BF8C7E6D5A4B3C2D1E0F9A8B7
+  displayId_B = "4e2d9a"
+
+EventCodeHash = SHA256("TECH2026")[0:8] = 0x9F8E7D6C5B4A3928
+```
+
+### GATT Exchange
+
+```
+1. B connects to A
+2. B reads EventCodeHash from A → 0x9F8E7D6C5B4A3928
+3. B compares with own hash → Match!
+4. B reads RPID from A → [0x01, RPI_A...]
+5. B reads TEK from A → 0x7A3F8B2C91D4E6F0A2B5C8D1E4F7A0B3
+6. B writes TEK_B to A → 0x4E2D9A1BF8C7E6D5A4B3C2D1E0F9A8B7
+7. Disconnect
+```
+
+### After Exchange
+
+```
+Device A's TEK Storage:
+  └── { tek: TEK_B, displayId: "4e2d9a", eventCodeHash: 0x9F8E..., exchangedAt: ..., lastSeenAt: ... }
+
+Device B's TEK Storage:
+  └── { tek: TEK_A, displayId: "7a3f8b", eventCodeHash: 0x9F8E..., exchangedAt: ..., lastSeenAt: ... }
+```
+
+### Later Detection
+
+```
+Time: 10:15 AM, ENIN = 2948599
+
+Device B receives RPI from advertisement, connects, reads RPID characteristic:
+  RPI = 0x2C5E8A1F7B4D9C3E6A2F8D1B5C7E4A9F
+
+Resolution by Device B:
+  for tek in [TEK_A]:
+    rpik = HKDF(TEK_A, info="EN-RPIK", 16) = 0x91B2C3D4E5F6A7B8C9D0E1F2A3B4C5D6
+    for enin in [2948593..2948600]:
+      candidate = AES128(rpik, "EN-RPI" ‖ 0x000000000000 ‖ enin)
+      if enin == 2948599:
+        candidate == received_rpi → Match!
+        
+Result: DetectionEvent with:
+  - rpid: RPI
+  - displayId: "2c5e8a1f" (from RPI, for non-resolved display)
+  - resolvedTek: TEK_A
+  - resolvedDisplayId: "7a3f8b" (from TEK_A)
+```
+
+## Security & Privacy Analysis
+
+| Property | Status | Notes |
+|----------|--------|-------|
+| No device-unique persistent identifiers on-wire | ✓ | RPI rotates every 10-15 min |
+| No cross-event tracking | ✓ | Different TEK per event |
+| Third-party unlinkability | ✓ | RPI appears random without RPIK |
+| Event Code leak safety | ✓ | TEK requires DeviceSecret (never shared) |
+| Minimum privilege | ✓ | Only GATT-exchanged peers can identify |
+
+### Replay Attack Protection
+
+- **ENIN window**: Only accept RPIs within ±1 hour of current time
+- **Duplicate detection**: Cache seen (RPI, timestamp) pairs, reject exact duplicates
+- **Cache bounds**: TTL = 2 hours, max = 10000 entries (LRU eviction)
+
+### EventCodeHash Collision
+
+- **Probability**: 8 bytes = 64 bits → ~10^19 possible values
+- **Impact**: If collision occurs, TEK exchange proceeds but identification fails
+- **Mitigation**: Acceptable for practical use; no security impact
+
+## Compatibility
+
+### With Existing Implementation
+
+- **formatVersion**: Remains `1` (internal logic change only)
+- **RPID Characteristic**: Unchanged (17 bytes: version + RPI)
+- **Advertisement**: Unchanged (Service UUID only)
+- **Backward compatibility**: None required (development phase)
+
+### With GAEN v1.2
+
+- **Key derivation**: Compatible (HKDF-SHA256, AES-128)
+- **RPI format**: Compatible (16 bytes, ENIN-based rotation)
+- **Differences**:
+  - GAEN uses daily TEK rotation; Barnard uses event-scoped TEK
+  - GAEN uses server for TEK distribution; Barnard uses GATT exchange
+
+## Test Plan
+
+### Unit Tests
+
+1. **Key derivation tests** (`test/crypto_test.dart`)
+   - HKDF-SHA256 output matches expected values
+   - AES-128-ECB encryption matches expected values
+   - TEK derivation is deterministic for same inputs
+   - RPIK derivation is deterministic
+   - RPI generation matches GAEN spec
+
+2. **TEK storage tests** (`test/tek_storage_test.dart`)
+   - Add/retrieve TEK entries
+   - TTL-based eviction
+   - LRU eviction when limit exceeded
+   - Re-exchange updates lastSeenAt
+   - Event-specific clearing
+
+3. **Identifier tests** (`test/identifier_test.dart`)
+   - Resolve RPI to known TEK
+   - Handle unknown RPI (no match)
+   - ENIN window boundaries
+   - Multiple known TEKs
+
+### Integration Tests
+
+4. **GATT exchange tests** (`test/gatt_exchange_integration_test.dart`)
+   - Same event: full TEK exchange
+   - Different event: detection only
+   - Anonymous mode: detection only
+   - Re-exchange: lastSeenAt update
+
+## References
+
+- [GAEN Cryptography Specification v1.2](https://blog.google/documents/69/Exposure_Notification_-_Cryptography_Specification_v1.2.1.pdf)
+- [Wikipedia: Exposure Notification](https://en.wikipedia.org/wiki/Exposure_Notification)
+- [DP-3T Protocol](https://github.com/DP-3T/documents)
+- HKDF (RFC 5869)
+- AES-128 (FIPS 197)


### PR DESCRIPTION
## Summary

Implements event-scoped device identification via GATT TEK exchange, enabling continuous tracking within events while maintaining privacy (no device-unique persistent identifiers on-wire).

- Add GAEN v1.2-compatible cryptographic key derivation (HKDF-SHA256, AES-128-ECB)
- Add TEK (B003) and EventCodeHash (B004) GATT characteristics for peer identification
- Add Event Mode with deterministic TEK derivation from DeviceSecret + EventCode
- Add TEK storage with TTL-based expiration and LRU eviction
- Add RPI resolution algorithm for device identification within ±1 hour window

## New APIs for Library Users

### Event Mode APIs (New)

This release introduces **Event Mode** for device identification within events.

```dart
// Join an event — enables peer identification
await barnard.joinEvent("TECH2026");

// Leave event — returns to Anonymous Mode
await barnard.leaveEvent();

// Get current event mode
final mode = await barnard.getEventMode();
// Returns: EventMode.anonymous or EventMode.event("TECH2026")

// Retrieve exchanged TEKs for post-event analysis
final teks = await barnard.getExchangedTeks("TECH2026");
```

| API | Description |
|-----|-------------|
| `joinEvent(String eventCode)` | Join event and start TEK exchange with peers sharing the same event code |
| `leaveEvent()` | Leave event and return to Anonymous Mode |
| `getEventMode()` | Get current mode (anonymous or event with code) |
| `getExchangedTeks(String eventCode)` | Get list of TEKs exchanged during the event |

### DetectionEvent Extensions (New Fields)

When in Event Mode, `DetectionEvent` now includes resolved peer information:

```dart
stream.listen((event) {
  if (event is DetectionEvent) {
    print('Detected: ${event.displayId}');
    
    // New fields (null in Anonymous Mode)
    if (event.resolvedDisplayId != null) {
      print('Resolved peer: ${event.resolvedDisplayId}'); // e.g., "7a3f8b"
      print('TEK: ${event.resolvedTek}'); // 16-byte TEK
    }
  }
});
```

| Field | Type | Description |
|-------|------|-------------|
| `resolvedTek` | `Uint8List?` | TEK of resolved peer (null if unresolved) |
| `resolvedDisplayId` | `String?` | First 3 bytes of TEK as hex (e.g., `"7a3f8b"`) |
| `debugLocalName` | `String?` | Debug-only: BLE local name (release builds omit) |

## Behavioral Changes

| Scenario | Before | After |
|----------|--------|-------|
| Default mode | Anonymous only | Anonymous (unchanged default) |
| Peer identification | Not possible | Possible via `joinEvent()` |
| Cross-event tracking | N/A | Prevented by design |
| TEK storage | N/A | Auto-managed with TTL (24h default) |

> **Backward Compatible**: Existing code continues to work. Anonymous Mode remains the default.

## Schema Changes (Backward Compatible)

All schema changes are **additive only**. No breaking changes.

### `common.schema.json`
| Change | Field | Description |
|--------|-------|-------------|
| Added | `TekBytes` | TEK (16 bytes, base64) type definition |
| Added | `EventCodeHashBytes` | EventCodeHash (8 bytes, base64) type definition |

### `events.schema.json` — `DetectionEvent`
| Change | Field | Type | Description |
|--------|-------|------|-------------|
| Added | `resolvedTek` | `TekBytes \| null` | TEK of resolved peer |
| Added | `resolvedDisplayId` | `string \| null` | First 3 bytes of TEK as lowercase hex |
| Added | `debugLocalName` | `string \| null` | Debug-only BLE local name |

> **No Breaking Changes**: All new fields are optional. The `required` array is unchanged.

## Platform Requirements

| Platform | Minimum Version | Notes |
|----------|-----------------|-------|
| iOS | **14.0** | CryptoKit HKDF requires iOS 14+ (was iOS 12) |
| Android | API 21 | Unchanged |

## Migration Guide

### For existing users (no action required)

Your existing code continues to work unchanged. The SDK defaults to Anonymous Mode.

### To enable Event Mode

```dart
// 1. Join an event when user enters
await barnard.joinEvent("YOUR_EVENT_CODE");

// 2. Handle resolved peers in detection events
stream.listen((event) {
  if (event is DetectionEvent && event.resolvedDisplayId != null) {
    // This peer is identified within the event
    trackPeer(event.resolvedDisplayId!);
  }
});

// 3. Leave event when done
await barnard.leaveEvent();
```

## Files Changed

### Schema
- `schema/barnard/v1/common.schema.json` - Add TekBytes, EventCodeHashBytes
- `schema/barnard/v1/events.schema.json` - Add resolvedTek, resolvedDisplayId, debugLocalName

### Dart
- `lib/src/domain/crypto.dart` - GAEN crypto utilities (new)
- `lib/src/domain/tek_storage.dart` - TEK storage models (new)
- `lib/src/domain/config.dart` - Add eventCode, TekStorageConfig
- `lib/src/domain/events.dart` - Add resolved fields to DetectionEvent
- `lib/src/usecase/barnard_client.dart` - Add EventMode, joinEvent/leaveEvent APIs
- `lib/src/interface_adapter/ble/barnard_ble_client.dart` - Wire TEK methods
- `lib/src/interface_adapter/mock/mock_barnard.dart` - Add Event Mode support
- `test/crypto_test.dart` - Unit tests for key derivation (new)

### iOS (Swift)
- `BarnardCrypto.swift` - GAEN crypto utilities (new)
- `BarnardTekStorage.swift` - TEK persistence with UserDefaults (new)
- `BarnardRpidGenerator.swift` - GAEN-compatible RPI generation
- `BarnardBleController.swift` - TEK/EventCodeHash characteristics + platform channel handlers

### Android (Kotlin)
- `BarnardCrypto.kt` - GAEN crypto utilities (new)
- `BarnardTekStorage.kt` - TEK persistence with SharedPreferences (new)
- `BarnardController.kt` - GAEN RPI generation + TEK characteristics

## Testing

- 32 unit tests passing (crypto, mock, integration)
- Tested key derivation chain: DeviceSecret → TEK → RPIK → RPI → resolve
- Tested ENIN calculation and time window boundaries
- Tested EventCodeHash collision scenarios

## Security &amp; Privacy

| Property | Status |
|----------|--------|
| No device-unique persistent identifiers on-wire | ✓ |
| No cross-event tracking | ✓ |
| Third-party unlinkability | ✓ |
| Event Code leak safety | ✓ |
| Minimum privilege (GATT-exchanged peers only) | ✓ |

## Spec Reference

See `specs/004-resolvable-id/spec.md` for detailed design documentation.

Closes #31