### PR TITLE
feat(flutter): add myResolvedDisplayId API to check own resolved display ID

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -195,6 +195,8 @@ internal class BarnardController(
                 )
             )
 
+            "getMyResolvedDisplayId" -> result.success(BarnardCrypto.displayId(currentTek))
+
             "startScan" -> {
                 val args = call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()
                 allowDuplicates = args["allowDuplicates"] as? Boolean ?: true

--- a/packages/dart/barnard/ios/Classes/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/Classes/BarnardBleController.swift
@@ -146,6 +146,9 @@ final class BarnardBleController: NSObject {
         "eventCode": rpid.eventCode as Any,
       ])
 
+    case "getMyResolvedDisplayId":
+      result(rpid.getCurrentDisplayId())
+
     case "startScan":
       let args = (call.arguments as? [String: Any]) ?? [:]
       allowDuplicates = (args["allowDuplicates"] as? Bool) ?? true

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
@@ -17,10 +17,12 @@ class BarnardBleClient implements BarnardClient {
     required BarnardState initialState,
     required EventMode initialMode,
     String? initialEventCode,
-  })  : _capabilities = capabilities,
-        _state = initialState,
-        _currentMode = initialMode,
-        _currentEventCode = initialEventCode;
+    String? initialMyResolvedDisplayId,
+  }) : _capabilities = capabilities,
+       _state = initialState,
+       _currentMode = initialMode,
+       _currentEventCode = initialEventCode,
+       _myResolvedDisplayId = initialMyResolvedDisplayId;
 
   static const MethodChannel _methods = MethodChannel("barnard/methods");
   static const EventChannel _eventsChannel = EventChannel("barnard/events");
@@ -46,21 +48,24 @@ class BarnardBleClient implements BarnardClient {
   BarnardState _state;
   EventMode _currentMode;
   String? _currentEventCode;
+  String? _myResolvedDisplayId;
   bool _disposed = false;
 
   static Future<BarnardBleClient> create() async {
     final Map<Object?, Object?> capsMap =
         (await _methods.invokeMethod<Map<Object?, Object?>>(
-              "getCapabilities",
-            )) ??
-            <Object?, Object?>{};
+          "getCapabilities",
+        )) ??
+        <Object?, Object?>{};
     final Map<Object?, Object?> stateMap =
         (await _methods.invokeMethod<Map<Object?, Object?>>("getState")) ??
-            <Object?, Object?>{};
+        <Object?, Object?>{};
     Map<Object?, Object?> modeMap;
     try {
-      modeMap = (await _methods
-              .invokeMethod<Map<Object?, Object?>>("getEventMode")) ??
+      modeMap =
+          (await _methods.invokeMethod<Map<Object?, Object?>>(
+            "getEventMode",
+          )) ??
           <Object?, Object?>{};
     } on MissingPluginException {
       modeMap = <Object?, Object?>{};
@@ -69,15 +74,29 @@ class BarnardBleClient implements BarnardClient {
     }
 
     final String? modeStr = modeMap["mode"] as String?;
-    final EventMode initialMode =
-        modeStr == "event" ? EventMode.event : EventMode.anonymous;
+    final EventMode initialMode = modeStr == "event"
+        ? EventMode.event
+        : EventMode.anonymous;
     final String? eventCode = modeMap["eventCode"] as String?;
+
+    // Fetch own resolved display ID
+    String? myResolvedDisplayId;
+    try {
+      myResolvedDisplayId = await _methods.invokeMethod<String?>(
+        "getMyResolvedDisplayId",
+      );
+    } on MissingPluginException {
+      myResolvedDisplayId = null;
+    } on PlatformException {
+      myResolvedDisplayId = null;
+    }
 
     final BarnardBleClient client = BarnardBleClient._(
       capabilities: _parseCapabilities(capsMap),
       initialState: _parseState(stateMap),
       initialMode: initialMode,
       initialEventCode: eventCode,
+      initialMyResolvedDisplayId: myResolvedDisplayId,
     );
     await client._attachStreams();
     return client;
@@ -122,6 +141,9 @@ class BarnardBleClient implements BarnardClient {
   String? get currentEventCode => _currentEventCode;
 
   @override
+  String? get myResolvedDisplayId => _myResolvedDisplayId;
+
+  @override
   Stream<BarnardEvent> get events => _eventsController.stream;
 
   @override
@@ -157,11 +179,11 @@ class BarnardBleClient implements BarnardClient {
   @override
   Future<BarnardStartResult> startAuto([AutoConfig? config]) async {
     _ensureNotDisposed();
-    final Map<Object?, Object?>? out =
-        await _methods.invokeMethod<Map<Object?, Object?>>(
-      "startAuto",
-      _encodeAutoConfig(config),
-    );
+    final Map<Object?, Object?>? out = await _methods
+        .invokeMethod<Map<Object?, Object?>>(
+          "startAuto",
+          _encodeAutoConfig(config),
+        );
     if (out == null) {
       return const BarnardStartResult(
         scanningStarted: false,
@@ -193,6 +215,10 @@ class BarnardBleClient implements BarnardClient {
     });
     _currentMode = EventMode.event;
     _currentEventCode = eventCode;
+    // Refresh display ID after TEK change
+    _myResolvedDisplayId = await _methods.invokeMethod<String?>(
+      "getMyResolvedDisplayId",
+    );
   }
 
   @override
@@ -204,6 +230,10 @@ class BarnardBleClient implements BarnardClient {
     await _methods.invokeMethod<void>("leaveEvent");
     _currentMode = EventMode.anonymous;
     _currentEventCode = null;
+    // Refresh display ID after TEK change
+    _myResolvedDisplayId = await _methods.invokeMethod<String?>(
+      "getMyResolvedDisplayId",
+    );
   }
 
   @override
@@ -251,8 +281,9 @@ class BarnardBleClient implements BarnardClient {
     int? limit,
     List<int>? rpidBytes,
   }) {
-    final Uint8List? filterRpid =
-        rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
+    final Uint8List? filterRpid = rpidBytes == null
+        ? null
+        : Uint8List.fromList(rpidBytes);
     Iterable<RssiSample> samples = _rssiBuffer.toList();
     if (since != null) {
       samples = samples.where((RssiSample s) => !s.timestamp.isBefore(since));
@@ -286,10 +317,10 @@ class BarnardBleClient implements BarnardClient {
 }
 
 Map<String, Object?> _encodeScanConfig(ScanConfig? config) => <String, Object?>{
-      "transport": (config?.transport ?? TransportKind.ble).name,
-      "allowDuplicates":
-          config?.allowDuplicates ?? const ScanConfig().allowDuplicates,
-    };
+  "transport": (config?.transport ?? TransportKind.ble).name,
+  "allowDuplicates":
+      config?.allowDuplicates ?? const ScanConfig().allowDuplicates,
+};
 
 Map<String, Object?> _encodeAdvertiseConfig(AdvertiseConfig? config) =>
     <String, Object?>{
@@ -299,9 +330,9 @@ Map<String, Object?> _encodeAdvertiseConfig(AdvertiseConfig? config) =>
     };
 
 Map<String, Object?> _encodeAutoConfig(AutoConfig? config) => <String, Object?>{
-      "scan": _encodeScanConfig(config?.scan),
-      "advertise": _encodeAdvertiseConfig(config?.advertise),
-    };
+  "scan": _encodeScanConfig(config?.scan),
+  "advertise": _encodeAdvertiseConfig(config?.advertise),
+};
 
 BarnardStartResult _parseStartResult(Map<Object?, Object?> map) {
   final bool scanningStarted = map["scanningStarted"] == true;
@@ -454,8 +485,9 @@ BarnardDebugEvent _parseDebugEvent(Map<Object?, Object?> map) {
     _ => DebugLevel.info,
   };
   final String name = (map["name"] as String?) ?? "debug";
-  final Map<Object?, Object?>? rawData =
-      map["data"] is Map ? map["data"] as Map<Object?, Object?> : null;
+  final Map<Object?, Object?>? rawData = map["data"] is Map
+      ? map["data"] as Map<Object?, Object?>
+      : null;
   final Map<String, Object?>? data = rawData?.map(
     (k, v) => MapEntry(k.toString(), v),
   );

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
@@ -33,10 +33,10 @@ class MockBarnard implements BarnardClient {
     int tickMs = 200,
     MockBarnardOverrides? overrides,
     Uint8List? deviceSecret,
-  })  : _tickMs = tickMs.clamp(50, 2000),
-        _random = Random(),
-        _overrides = overrides,
-        _deviceSecret = deviceSecret ?? _generateRandomBytes(32) {
+  }) : _tickMs = tickMs.clamp(50, 2000),
+       _random = Random(),
+       _overrides = overrides,
+       _deviceSecret = deviceSecret ?? _generateRandomBytes(32) {
     _peers = List<MockPeer>.generate(simulatedPeerCount.clamp(1, 2000), (
       int i,
     ) {
@@ -90,12 +90,12 @@ class MockBarnard implements BarnardClient {
 
   @override
   BarnardCapabilities get capabilities => const BarnardCapabilities(
-        supportedTransports: {TransportKind.ble},
-        supportsConnectionlessRpid: true,
-        supportsGattFallback: false,
-        supportsBackground: false,
-        supportsHighRateRssi: true,
-      );
+    supportedTransports: {TransportKind.ble},
+    supportsConnectionlessRpid: true,
+    supportsGattFallback: false,
+    supportsBackground: false,
+    supportsHighRateRssi: true,
+  );
 
   @override
   BarnardState get state => _state;
@@ -105,6 +105,9 @@ class MockBarnard implements BarnardClient {
 
   @override
   String? get currentEventCode => _currentEventCode;
+
+  @override
+  String? get myResolvedDisplayId => _tekDisplayId(_currentTek);
 
   @override
   Stream<BarnardEvent> get events => _events.stream;
@@ -312,8 +315,9 @@ class MockBarnard implements BarnardClient {
     List<int>? rpidBytes,
   }) {
     final List<RssiSample> all = _rssiBuffer.toList();
-    final Uint8List? filterRpid =
-        rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
+    final Uint8List? filterRpid = rpidBytes == null
+        ? null
+        : Uint8List.fromList(rpidBytes);
 
     Iterable<RssiSample> filtered = all;
     if (since != null) {
@@ -465,8 +469,8 @@ class MockBarnard implements BarnardClient {
 
     // Evict the least-recently-seen entries to keep the mock bounded.
     // This is O(n) but only triggers when the map exceeds the cap.
-    final List<MapEntry<String, _RssiAgg>> entries =
-        _aggByRpidKey.entries.toList(growable: false);
+    final List<MapEntry<String, _RssiAgg>> entries = _aggByRpidKey.entries
+        .toList(growable: false);
     entries.sort((a, b) {
       final DateTime aSeen =
           a.value.lastSeenAt ?? DateTime.fromMillisecondsSinceEpoch(0);

--- a/packages/dart/barnard/lib/src/usecase/barnard_client.dart
+++ b/packages/dart/barnard/lib/src/usecase/barnard_client.dart
@@ -53,6 +53,13 @@ abstract class BarnardClient {
   /// The active event code when in Event Mode, null otherwise.
   String? get currentEventCode;
 
+  /// The device's own resolved display ID (first 6 hex characters of TEK).
+  ///
+  /// This is derived from the current TEK and represents how this device
+  /// would appear to others who have exchanged TEKs with it.
+  /// Returns null if not yet initialized.
+  String? get myResolvedDisplayId;
+
   Stream<BarnardEvent> get events;
   Stream<BarnardDebugEvent> get debugEvents;
 

--- a/packages/dart/barnard/test/mock_barnard_test.dart
+++ b/packages/dart/barnard/test/mock_barnard_test.dart
@@ -5,8 +5,33 @@ import "package:barnard/mock_barnard.dart";
 import "package:test/test.dart";
 
 void main() {
+  test("myResolvedDisplayId returns 6-character hex string", () {
+    final BarnardClient barnard = MockBarnard();
+
+    final String? displayId = barnard.myResolvedDisplayId;
+
+    expect(displayId, isNotNull);
+    expect(displayId!.length, equals(6));
+    // Should be valid hex characters (lowercase)
+    expect(RegExp(r"^[0-9a-f]{6}$").hasMatch(displayId), isTrue);
+  });
+
+  test("myResolvedDisplayId changes after joinEvent", () async {
+    final BarnardClient barnard = MockBarnard();
+
+    final String? initialId = barnard.myResolvedDisplayId;
+    await barnard.joinEvent("TEST-EVENT-001");
+    final String? afterJoinId = barnard.myResolvedDisplayId;
+
+    expect(initialId, isNotNull);
+    expect(afterJoinId, isNotNull);
+    // TEK changes when event code changes, so display ID should change
+    expect(afterJoinId, isNot(equals(initialId)));
+  });
+
   test("mock emits DetectionEvent and stores RSSI samples", () async {
-    final BarnardClient barnard = MockBarnard(simulatedPeerCount: 10, tickMs: 100);
+    final BarnardClient barnard =
+        MockBarnard(simulatedPeerCount: 10, tickMs: 100);
 
     final List<DetectionEvent> detections = <DetectionEvent>[];
     final StreamSubscription sub = barnard.events.listen((BarnardEvent e) {


### PR DESCRIPTION
## Summary

Adds a `myResolvedDisplayId` getter to `BarnardClient` that returns the device's own resolved display ID (first 6 hex characters of TEK). This allows the client to know how it would appear to others after TEK exchange.

## Changes

- Add `myResolvedDisplayId` getter to `BarnardClient` interface
- Implement in `BarnardBleClient` (fetches from native via `getMyResolvedDisplayId`)
- Implement in `MockBarnard` (derives from current TEK)
- Add iOS native implementation (`rpid.getCurrentDisplayId()`)
- Add Android native implementation (`BarnardCrypto.displayId(currentTek)`)
- Add unit tests for the new API

## Use Case

When displaying a list of discovered peers with their `resolvedDisplayId`, the UI can now also show "You are: XXXXXX" so users can identify their own device in the peer list.

Closes #38