### PR TITLE
feat(react-native): add Barnard RN plugin with resolvable ID support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ coverage/
 .flutter-plugins
 .flutter-plugins-dependencies
 .metadata
-.gradle/
+
+# JVM / Gradle local artifacts
+*.hprof
+**/.gradle/

--- a/examples/react-native/barnard_demo/.gitignore
+++ b/examples/react-native/barnard_demo/.gitignore
@@ -1,0 +1,56 @@
+# OSX
+.DS_Store
+
+# Xcode
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+ios/.xcode.env.local
+
+# Android/IntelliJ
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+.cxx/
+*.keystore
+!debug.keystore
+
+# node.js
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# fastlane
+ios/fastlane/report.xml
+ios/fastlane/Preview.html
+ios/fastlane/screenshots
+ios/fastlane/test_output
+
+# Bundle artifact
+*.jsbundle
+
+# Ruby / CocoaPods
+/ios/Pods/
+/vendor/bundle/
+
+# Temporary files created by Metro to check the health of the file watcher
+.metro-health-check*
+
+# testing
+/coverage

--- a/examples/react-native/barnard_demo/README.md
+++ b/examples/react-native/barnard_demo/README.md
@@ -1,0 +1,94 @@
+# Barnard Demo - React Native Example
+
+Example React Native application demonstrating the Barnard SDK for BLE-based proximity detection.
+
+## Features
+
+- BLE scanning for nearby devices
+- BLE advertising as a peripheral
+- GATT-based RPID detection
+- Real-time detection feed
+- Permission handling for iOS and Android
+
+## Prerequisites
+
+- Node.js 16+
+- React Native development environment
+- iOS: Xcode 14+ and CocoaPods
+- Android: Android Studio and SDK
+
+## Installation
+
+1. Install dependencies:
+
+```bash
+npm install
+# or
+yarn install
+```
+
+2. iOS: Install CocoaPods
+
+```bash
+cd ios && pod install && cd ..
+```
+
+## Running
+
+### iOS
+
+```bash
+npm run ios
+# or
+npx react-native run-ios
+```
+
+### Android
+
+```bash
+npm run android
+# or
+npx react-native run-android
+```
+
+## Usage
+
+1. **Grant Permissions**: When the app launches, it will request Bluetooth permissions
+2. **Start All**: Tap "Start All" to begin scanning and advertising
+3. **View Detections**: Nearby devices running the same app will appear in the detection list
+4. **Individual Controls**: Use "Start Scan" and "Start Adv" for granular control
+
+## Testing
+
+To test proximity detection:
+
+1. Install the app on two or more devices
+2. Run the app on all devices
+3. Tap "Start All" on each device
+4. Devices should detect each other and display RPIDs in the detection list
+
+## Notes
+
+- **iOS**: Requires physical device (BLE not supported in simulator)
+- **Android**: Requires physical device with BLE support
+- **Background mode**: Not supported in this MVP version
+- **Permissions**: Make sure to grant all Bluetooth permissions when prompted
+
+## Troubleshooting
+
+### iOS
+
+- If pods fail to install, try `pod repo update` then `pod install`
+- Ensure Bluetooth permissions are set in Info.plist
+- Physical device required (simulator doesn't support BLE)
+
+### Android
+
+- Ensure Android SDK is properly configured
+- Check that all Bluetooth permissions are granted
+- Try rebuilding if native modules don't link: `cd android && ./gradlew clean`
+
+## Related
+
+- [Barnard SDK](../../../packages/react-native/barnard)
+- [Barnard Spec](../../../specs/001-barnard-core-sdk/spec.md)

--- a/examples/react-native/barnard_demo/android/app/build.gradle
+++ b/examples/react-native/barnard_demo/android/app/build.gradle
@@ -1,0 +1,34 @@
+apply plugin: "com.android.application"
+apply plugin: "com.facebook.react"
+apply plugin: "kotlin-android"
+
+react {
+}
+
+def enableProguardInReleaseBuilds = false
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    namespace "network.greeting.barnard.demo"
+    
+    defaultConfig {
+        applicationId "network.greeting.barnard.demo"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled enableProguardInReleaseBuilds
+        }
+    }
+}
+
+dependencies {
+    implementation("com.facebook.react:react-android")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}")
+}
+
+apply from: file("../../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/examples/react-native/barnard_demo/android/app/src/main/AndroidManifest.xml
+++ b/examples/react-native/barnard_demo/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,37 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    
+    <!-- Bluetooth permissions for Android 12+ (API 31+) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+                     android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    
+    <!-- Legacy Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" 
+                     android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" 
+                     android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" 
+                     android:maxSdkVersion="30" />
+    
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+
+    <application
+      android:label="@string/app_name"
+      android:allowBackup="false">
+      <activity
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+        android:launchMode="singleTask"
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+    </application>
+</manifest>

--- a/examples/react-native/barnard_demo/android/app/src/main/res/values/strings.xml
+++ b/examples/react-native/barnard_demo/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Barnard Demo</string>
+</resources>

--- a/examples/react-native/barnard_demo/android/build.gradle
+++ b/examples/react-native/barnard_demo/android/build.gradle
@@ -1,0 +1,20 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = "33.0.0"
+        minSdkVersion = 21
+        compileSdkVersion = 33
+        targetSdkVersion = 33
+        kotlinVersion = "1.8.0"
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle")
+        classpath("com.facebook.react:react-native-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    }
+}

--- a/examples/react-native/barnard_demo/android/settings.gradle
+++ b/examples/react-native/barnard_demo/android/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'BarnardDemo'
+apply from: file("../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+include ':app'
+includeBuild('../../../node_modules/@react-native/gradle-plugin')

--- a/examples/react-native/barnard_demo/app.json
+++ b/examples/react-native/barnard_demo/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "BarnardDemo",
+  "displayName": "Barnard Demo"
+}

--- a/examples/react-native/barnard_demo/babel.config.js
+++ b/examples/react-native/barnard_demo/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+};

--- a/examples/react-native/barnard_demo/index.js
+++ b/examples/react-native/barnard_demo/index.js
@@ -1,0 +1,9 @@
+/**
+ * @format
+ */
+
+import {AppRegistry} from 'react-native';
+import App from './src/App';
+import {name as appName} from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/examples/react-native/barnard_demo/ios/BarnardDemo/Info.plist
+++ b/examples/react-native/barnard_demo/ios/BarnardDemo/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDevelopmentRegion</key>
+<string>en</string>
+<key>CFBundleDisplayName</key>
+<string>Barnard Demo</string>
+<key>CFBundleExecutable</key>
+<string>$(EXECUTABLE_NAME)</string>
+<key>CFBundleIdentifier</key>
+<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
+<key>CFBundleName</key>
+<string>$(PRODUCT_NAME)</string>
+<key>CFBundlePackageType</key>
+<string>APPL</string>
+<key>CFBundleShortVersionString</key>
+<string>1.0.0</string>
+<key>CFBundleVersion</key>
+<string>1</string>
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>This app uses Bluetooth to detect and communicate with nearby devices</string>
+<key>NSBluetoothPeripheralUsageDescription</key>
+<string>This app uses Bluetooth to advertise to nearby devices</string>
+</dict>
+</plist>

--- a/examples/react-native/barnard_demo/ios/Podfile
+++ b/examples/react-native/barnard_demo/ios/Podfile
@@ -1,0 +1,29 @@
+# Uncomment the next line to define a global platform for your project
+platform :ios, '14.0'
+require_relative '../../../node_modules/react-native/scripts/react_native_pods'
+require_relative '../../../node_modules/@react-native-community/cli-platform-ios/native_modules'
+
+target 'BarnardDemo' do
+  config = use_native_modules!
+
+  use_react_native!(
+    :path => '../../../node_modules/react-native',
+    # Enables Flipper.
+    #
+    # Note that if you have use_frameworks! enabled, Flipper will not work and
+    # you should disable the next line.
+    :flipper_configuration => FlipperConfiguration.enabled,
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/.."
+  )
+
+  pod 'barnard', :path => '../../../packages/react-native/barnard'
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      '../../../node_modules/react-native',
+      :mac_catalyst_enabled => false
+    )
+  end
+end

--- a/examples/react-native/barnard_demo/package.json
+++ b/examples/react-native/barnard_demo/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "barnard-demo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "start": "react-native start",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "barnard": "file:../../../packages/react-native/barnard"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "@babel/preset-env": "^7.20.0",
+    "@babel/runtime": "^7.20.0",
+    "@react-native-community/eslint-config": "^3.0.0",
+    "@tsconfig/react-native": "^3.0.0",
+    "@types/react": "^18.0.24",
+    "@types/react-native": "^0.72.0",
+    "babel-jest": "^29.2.1",
+    "eslint": "^8.19.0",
+    "jest": "^29.2.1",
+    "metro-react-native-babel-preset": "0.76.0",
+    "prettier": "^2.4.1",
+    "typescript": "5.0.4"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/examples/react-native/barnard_demo/src/App.tsx
+++ b/examples/react-native/barnard_demo/src/App.tsx
@@ -1,0 +1,339 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  Button,
+  PermissionsAndroid,
+  Platform,
+  Alert,
+} from 'react-native';
+import {
+  BarnardManager,
+  DetectionEvent,
+  BarnardCapabilities,
+  BarnardState,
+} from 'barnard';
+
+interface Detection {
+  id: string;
+  displayId: string;
+  rssi: number;
+  timestamp: string;
+  transport: string;
+}
+
+const App = () => {
+  const [manager] = useState(() => new BarnardManager());
+  const [capabilities, setCapabilities] = useState<BarnardCapabilities | null>(null);
+  const [state, setState] = useState<BarnardState>({ isScanning: false, isAdvertising: false });
+  const [detections, setDetections] = useState<Detection[]>([]);
+  const [permissionsGranted, setPermissionsGranted] = useState(false);
+
+  const requestPermissions = useCallback(async () => {
+    if (Platform.OS === 'android') {
+      if (Platform.Version >= 31) {
+        const result = await PermissionsAndroid.requestMultiple([
+          PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+          PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
+          PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+        ]);
+        const granted = Object.values(result).every(
+          status => status === PermissionsAndroid.RESULTS.GRANTED
+        );
+        setPermissionsGranted(granted);
+        if (!granted) {
+          Alert.alert('Permissions Required', 'Please grant all Bluetooth permissions');
+        }
+        return granted;
+      } else {
+        const result = await PermissionsAndroid.requestMultiple([
+          PermissionsAndroid.PERMISSIONS.BLUETOOTH,
+          PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADMIN,
+          PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
+        ]);
+        const granted = Object.values(result).every(
+          status => status === PermissionsAndroid.RESULTS.GRANTED
+        );
+        setPermissionsGranted(granted);
+        if (!granted) {
+          Alert.alert('Permissions Required', 'Please grant all Bluetooth permissions');
+        }
+        return granted;
+      }
+    }
+    setPermissionsGranted(true);
+    return true;
+  }, []);
+
+  useEffect(() => {
+    requestPermissions();
+
+    // Get capabilities
+    manager.getCapabilities().then(caps => {
+      setCapabilities(caps);
+      console.log('Capabilities:', caps);
+    });
+
+    // Subscribe to detections
+    const unsubDetection = manager.onDetection((event: DetectionEvent) => {
+      console.log('Detection:', event.displayId, event.rssi);
+      setDetections(prev => {
+        const newDetection: Detection = {
+          id: event.rpid,
+          displayId: event.displayId,
+          rssi: event.rssi,
+          timestamp: new Date(event.timestamp).toLocaleTimeString(),
+          transport: event.transport,
+        };
+        // Keep last 20 detections
+        return [newDetection, ...prev].slice(0, 20);
+      });
+    });
+
+    // Subscribe to state changes
+    const unsubState = manager.onStateChange(event => {
+      console.log('State change:', event.state);
+      setState(event.state);
+    });
+
+    // Subscribe to constraints
+    const unsubConstraint = manager.onConstraint(event => {
+      console.log('Constraint:', event.code, event.message);
+      Alert.alert('Constraint', `${event.code}: ${event.message}`);
+    });
+
+    // Subscribe to errors
+    const unsubError = manager.onError(event => {
+      console.log('Error:', event.code, event.message);
+      Alert.alert('Error', `${event.code}: ${event.message}`);
+    });
+
+    // Subscribe to debug events
+    const unsubDebug = manager.onDebug(event => {
+      console.log('Debug:', event.level, event.name, event.data);
+    });
+
+    return () => {
+      unsubDetection();
+      unsubState();
+      unsubConstraint();
+      unsubError();
+      unsubDebug();
+      manager.dispose();
+    };
+  }, [manager, requestPermissions]);
+
+  const handleStartAuto = async () => {
+    if (!permissionsGranted) {
+      const granted = await requestPermissions();
+      if (!granted) return;
+    }
+    try {
+      const result = await manager.startAuto({
+        scan: { allowDuplicates: true },
+        advertise: { formatVersion: 1 },
+      });
+      console.log('Started:', result);
+    } catch (error) {
+      console.error('Start failed:', error);
+      Alert.alert('Start Failed', String(error));
+    }
+  };
+
+  const handleStopAuto = async () => {
+    try {
+      await manager.stopAuto();
+      setDetections([]);
+    } catch (error) {
+      console.error('Stop failed:', error);
+    }
+  };
+
+  const handleStartScan = async () => {
+    if (!permissionsGranted) {
+      const granted = await requestPermissions();
+      if (!granted) return;
+    }
+    try {
+      await manager.startScan({ allowDuplicates: true });
+    } catch (error) {
+      Alert.alert('Start Scan Failed', String(error));
+    }
+  };
+
+  const handleStopScan = async () => {
+    try {
+      await manager.stopScan();
+    } catch (error) {
+      console.error('Stop scan failed:', error);
+    }
+  };
+
+  const handleStartAdvertise = async () => {
+    if (!permissionsGranted) {
+      const granted = await requestPermissions();
+      if (!granted) return;
+    }
+    try {
+      await manager.startAdvertise({ formatVersion: 1 });
+    } catch (error) {
+      Alert.alert('Start Advertise Failed', String(error));
+    }
+  };
+
+  const handleStopAdvertise = async () => {
+    try {
+      await manager.stopAdvertise();
+    } catch (error) {
+      console.error('Stop advertise failed:', error);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.title}>Barnard Demo</Text>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Capabilities</Text>
+          {capabilities && (
+            <View>
+              <Text style={styles.infoText}>
+                Transports: {capabilities.supportedTransports.join(', ')}
+              </Text>
+              <Text style={styles.infoText}>
+                GATT Fallback: {capabilities.supportsGattFallback ? 'Yes' : 'No'}
+              </Text>
+            </View>
+          )}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>State</Text>
+          <Text style={styles.infoText}>
+            Scanning: {state.isScanning ? '✓' : '✗'}
+          </Text>
+          <Text style={styles.infoText}>
+            Advertising: {state.isAdvertising ? '✓' : '✗'}
+          </Text>
+          <Text style={styles.infoText}>
+            Permissions: {permissionsGranted ? '✓' : '✗'}
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Controls</Text>
+          <View style={styles.buttonRow}>
+            <Button
+              title={state.isScanning || state.isAdvertising ? 'Stop All' : 'Start All'}
+              onPress={state.isScanning || state.isAdvertising ? handleStopAuto : handleStartAuto}
+              color={state.isScanning || state.isAdvertising ? '#dc3545' : '#28a745'}
+            />
+          </View>
+          <View style={styles.buttonRow}>
+            <Button
+              title={state.isScanning ? 'Stop Scan' : 'Start Scan'}
+              onPress={state.isScanning ? handleStopScan : handleStartScan}
+            />
+            <View style={styles.buttonSpacer} />
+            <Button
+              title={state.isAdvertising ? 'Stop Adv' : 'Start Adv'}
+              onPress={state.isAdvertising ? handleStopAdvertise : handleStartAdvertise}
+            />
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>
+            Detections ({detections.length})
+          </Text>
+          {detections.length === 0 ? (
+            <Text style={styles.emptyText}>No detections yet</Text>
+          ) : (
+            detections.map((detection, index) => (
+              <View key={`${detection.id}-${index}`} style={styles.detectionItem}>
+                <Text style={styles.detectionId}>{detection.displayId}</Text>
+                <Text style={styles.detectionInfo}>
+                  RSSI: {detection.rssi} dBm | {detection.timestamp}
+                </Text>
+              </View>
+            ))
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  scrollContent: {
+    padding: 16,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    marginBottom: 20,
+    color: '#333',
+  },
+  section: {
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: '#333',
+  },
+  infoText: {
+    fontSize: 14,
+    marginBottom: 6,
+    color: '#666',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    marginBottom: 8,
+  },
+  buttonSpacer: {
+    width: 8,
+  },
+  emptyText: {
+    fontSize: 14,
+    fontStyle: 'italic',
+    color: '#999',
+    textAlign: 'center',
+  },
+  detectionItem: {
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+    paddingVertical: 8,
+  },
+  detectionId: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#007AFF',
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  detectionInfo: {
+    fontSize: 12,
+    color: '#666',
+    marginTop: 2,
+  },
+});
+
+export default App;

--- a/examples/react-native/barnard_demo/tsconfig.json
+++ b/examples/react-native/barnard_demo/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/react-native/tsconfig.json"
+}

--- a/packages/react-native/barnard/.eslintrc.js
+++ b/packages/react-native/barnard/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  root: true,
+  extends: '@react-native-community',
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  rules: {
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
+  },
+};

--- a/packages/react-native/barnard/.gitignore
+++ b/packages/react-native/barnard/.gitignore
@@ -1,0 +1,20 @@
+# OSX
+.DS_Store
+
+# Node
+node_modules/
+npm-debug.log
+yarn-error.log
+
+# Build output
+lib/
+*.tgz
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# Testing
+coverage/

--- a/packages/react-native/barnard/README.md
+++ b/packages/react-native/barnard/README.md
@@ -1,0 +1,224 @@
+# barnard
+
+React Native plugin for Barnard SDK - BLE Scan/Advertise + GATT-based RPID detection.
+
+## Features
+
+- ✅ BLE Central role (scanning for nearby devices)
+- ✅ BLE Peripheral role (advertising + GATT server)
+- ✅ GATT-based RPID exchange
+- ✅ iOS support via CoreBluetooth
+- ✅ Android support (API 21+)
+- ✅ TypeScript API
+
+## Installation
+
+```bash
+npm install barnard
+# or
+yarn add barnard
+```
+
+### iOS Setup
+
+1. Install CocoaPods dependencies:
+
+```bash
+cd ios && pod install
+```
+
+2. Add Bluetooth permissions to `Info.plist`:
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>This app uses Bluetooth to detect nearby devices</string>
+<key>NSBluetoothPeripheralUsageDescription</key>
+<string>This app uses Bluetooth to advertise to nearby devices</string>
+```
+
+### Android Setup
+
+The plugin automatically adds the required permissions to `AndroidManifest.xml`. You need to request permissions at runtime:
+
+```typescript
+import { PermissionsAndroid, Platform } from 'react-native';
+
+async function requestBluetoothPermissions() {
+  if (Platform.OS === 'android' && Platform.Version >= 31) {
+    const granted = await PermissionsAndroid.requestMultiple([
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
+      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
+    ]);
+    return Object.values(granted).every(
+      status => status === PermissionsAndroid.RESULTS.GRANTED
+    );
+  }
+  return true;
+}
+```
+
+## Usage
+
+### Basic Example
+
+```typescript
+import { BarnardManager } from 'barnard';
+
+// Create manager instance
+const barnard = new BarnardManager();
+
+// Check capabilities
+const capabilities = await barnard.getCapabilities();
+console.log('Supported transports:', capabilities.supportedTransports);
+
+// Listen for detections
+const unsubscribe = barnard.onDetection((event) => {
+  console.log('Detected:', event.displayId);
+  console.log('RSSI:', event.rssi);
+  console.log('Transport:', event.transport);
+});
+
+// Start scanning and advertising
+await barnard.startAuto({
+  scan: { allowDuplicates: true },
+  advertise: { formatVersion: 1 },
+});
+
+// Later: cleanup
+unsubscribe();
+await barnard.dispose();
+```
+
+### Event Handling
+
+The SDK emits several event types:
+
+```typescript
+// Detection events (RPID detections)
+barnard.onDetection((event) => {
+  console.log('Detected:', event.displayId, event.rssi);
+});
+
+// State changes (scanning/advertising status)
+barnard.onStateChange((event) => {
+  console.log('State:', event.state);
+});
+
+// Constraint events (permissions, Bluetooth disabled, etc.)
+barnard.onConstraint((event) => {
+  console.log('Constraint:', event.code, event.message);
+});
+
+// Error events
+barnard.onError((event) => {
+  console.log('Error:', event.code, event.message);
+});
+
+// Debug events (troubleshooting)
+barnard.onDebug((event) => {
+  console.log('Debug:', event.level, event.name, event.data);
+});
+```
+
+### API Reference
+
+#### `BarnardManager`
+
+##### Methods
+
+- **`getCapabilities()`**: Get platform capabilities
+  - Returns: `Promise<BarnardCapabilities>`
+
+- **`getState()`**: Get current state (scanning/advertising status)
+  - Returns: `Promise<BarnardState>`
+
+- **`startScan(config?)`**: Start BLE scanning
+  - Parameters: `ScanConfig` (optional)
+  - Returns: `Promise<void>`
+
+- **`stopScan()`**: Stop BLE scanning
+  - Returns: `Promise<void>`
+
+- **`startAdvertise(config?)`**: Start BLE advertising
+  - Parameters: `AdvertiseConfig` (optional)
+  - Returns: `Promise<void>`
+
+- **`stopAdvertise()`**: Stop BLE advertising
+  - Returns: `Promise<void>`
+
+- **`startAuto(config?)`**: Start both scanning and advertising
+  - Parameters: `AutoConfig` (optional)
+  - Returns: `Promise<AutoStartResult>`
+
+- **`stopAuto()`**: Stop both scanning and advertising
+  - Returns: `Promise<void>`
+
+- **`dispose()`**: Dispose of the manager and release resources
+  - Returns: `void`
+
+##### Event Listeners
+
+- **`onDetection(callback)`**: Subscribe to detection events
+  - Returns: Unsubscribe function
+
+- **`onStateChange(callback)`**: Subscribe to state change events
+  - Returns: Unsubscribe function
+
+- **`onConstraint(callback)`**: Subscribe to constraint violation events
+  - Returns: Unsubscribe function
+
+- **`onError(callback)`**: Subscribe to error events
+  - Returns: Unsubscribe function
+
+- **`onDebug(callback)`**: Subscribe to debug events
+  - Returns: Unsubscribe function
+
+### Type Definitions
+
+```typescript
+interface BarnardCapabilities {
+  supportedTransports: TransportKind[];
+  supportsConnectionlessRpid: boolean;
+  supportsGattFallback: boolean;
+  supportsBackground: boolean;
+  supportsHighRateRssi: boolean;
+}
+
+interface BarnardState {
+  isScanning: boolean;
+  isAdvertising: boolean;
+}
+
+interface DetectionEvent {
+  type: 'detection';
+  timestamp: string;
+  transport: TransportKind;
+  formatVersion: number;
+  rpid: string;        // base64
+  displayId: string;   // hex (first 4 bytes)
+  rssi: number;
+  payloadRaw?: string; // base64
+}
+```
+
+## Security & Privacy
+
+- **No device-unique persistent identifiers on-wire**: The RPID rotates every 600 seconds using HMAC-SHA256
+- **Local seed storage**: A 32-byte random seed is generated and stored locally (UserDefaults on iOS, SharedPreferences on Android)
+- **GATT-based exchange**: RPIDs are transmitted via GATT characteristic reads, not in advertisement data
+
+## Minimum Requirements
+
+- **React Native**: 0.71+
+- **iOS**: 14.0+
+- **Android**: API 21+ (Android 5.0+)
+
+## License
+
+MIT
+
+## Related
+
+- [Barnard Spec](../../specs/001-barnard-core-sdk/spec.md)
+- [Flutter Implementation](../dart/barnard)

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -67,7 +67,7 @@ const setup = () => {
       joinEvent: (eventCode: string) => Promise<void>;
       onDetection: (callback: (event: unknown) => void) => () => void;
       onEvent: (callback: (event: unknown) => void) => () => void;
-      dispose: () => void;
+      dispose: () => Promise<void>;
     };
   };
 
@@ -144,8 +144,7 @@ describe('BarnardManager', () => {
     const callback = jest.fn();
 
     manager.onDetection(callback);
-    manager.dispose();
-    await Promise.resolve();
+    await manager.dispose();
 
     emit(listeners, 'BarnardDetection', { type: 'detection' });
 

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -151,4 +151,42 @@ describe('BarnardManager', () => {
     expect(nativeModule.dispose).toHaveBeenCalledTimes(1);
     expect(callback).not.toHaveBeenCalled();
   });
+
+  it('dispose() awaits native completion before resolving', async () => {
+    const { BarnardManager, nativeModule } = setup();
+    const manager = new BarnardManager();
+
+    let resolveNative: (() => void) | undefined;
+    const nativePending = new Promise<void>((resolve) => {
+      resolveNative = resolve;
+    });
+    nativeModule.dispose.mockReturnValueOnce(nativePending);
+
+    const disposeResult = manager.dispose();
+
+    let settled = false;
+    void disposeResult.then(() => {
+      settled = true;
+    });
+
+    // Let any microtasks run; native is still pending, so dispose must not have resolved.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    // Resolving the native side lets dispose() complete.
+    resolveNative?.();
+    await disposeResult;
+    expect(settled).toBe(true);
+  });
+
+  it('dispose() propagates native rejection to the caller', async () => {
+    const { BarnardManager, nativeModule } = setup();
+    const manager = new BarnardManager();
+
+    const nativeError = new Error('native dispose failed');
+    nativeModule.dispose.mockRejectedValueOnce(nativeError);
+
+    await expect(manager.dispose()).rejects.toThrow('native dispose failed');
+  });
 });

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -1,0 +1,155 @@
+jest.mock('react-native', () => {
+  const listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  const Barnard = {
+    getCapabilities: jest.fn().mockResolvedValue({ supportedTransports: ['ble'] }),
+    getState: jest.fn().mockResolvedValue({ isScanning: false, isAdvertising: false }),
+    getEventMode: jest.fn().mockResolvedValue({ mode: 'anonymous', eventCode: null }),
+    startScan: jest.fn().mockResolvedValue(undefined),
+    stopScan: jest.fn().mockResolvedValue(undefined),
+    startAdvertise: jest.fn().mockResolvedValue(undefined),
+    stopAdvertise: jest.fn().mockResolvedValue(undefined),
+    startAuto: jest.fn().mockResolvedValue({
+      scanningStarted: true,
+      advertisingStarted: true,
+      issues: [],
+    }),
+    stopAuto: jest.fn().mockResolvedValue(undefined),
+    joinEvent: jest.fn().mockResolvedValue(undefined),
+    leaveEvent: jest.fn().mockResolvedValue(undefined),
+    getExchangedTeks: jest.fn().mockResolvedValue([]),
+    clearTeksForEvent: jest.fn().mockResolvedValue(0),
+    clearAllTeks: jest.fn().mockResolvedValue(0),
+    dispose: jest.fn().mockResolvedValue(undefined),
+  };
+
+  class NativeEventEmitter {
+    constructor(_module: unknown) {}
+
+    addListener(eventName: string, callback: (event: unknown) => void) {
+      if (!listeners.has(eventName)) {
+        listeners.set(eventName, new Set());
+      }
+      listeners.get(eventName)?.add(callback);
+
+      return {
+        remove: () => {
+          listeners.get(eventName)?.delete(callback);
+        },
+      };
+    }
+  }
+
+  return {
+    NativeModules: { Barnard },
+    NativeEventEmitter,
+    __listeners: listeners,
+  };
+});
+
+type ListenerMap = Map<string, Set<(event: unknown) => void>>;
+
+const emit = (listeners: ListenerMap, eventName: string, payload: unknown) => {
+  for (const callback of listeners.get(eventName) ?? []) {
+    callback(payload);
+  }
+};
+
+const setup = () => {
+  jest.resetModules();
+  const reactNative = require('react-native') as {
+    NativeModules: { Barnard: Record<string, jest.Mock> };
+    __listeners: ListenerMap;
+  };
+  const { BarnardManager } = require('../src/BarnardManager') as {
+    BarnardManager: new () => {
+      getEventMode: () => Promise<unknown>;
+      joinEvent: (eventCode: string) => Promise<void>;
+      onDetection: (callback: (event: unknown) => void) => () => void;
+      onEvent: (callback: (event: unknown) => void) => () => void;
+      dispose: () => void;
+    };
+  };
+
+  return {
+    BarnardManager,
+    nativeModule: reactNative.NativeModules.Barnard,
+    listeners: reactNative.__listeners,
+  };
+};
+
+describe('BarnardManager', () => {
+  it('delegates getEventMode to native module', async () => {
+    const { BarnardManager, nativeModule } = setup();
+    nativeModule.getEventMode.mockResolvedValueOnce({ mode: 'event', eventCode: 'ETHGLOBAL' });
+
+    const manager = new BarnardManager();
+
+    await expect(manager.getEventMode()).resolves.toEqual({
+      mode: 'event',
+      eventCode: 'ETHGLOBAL',
+    });
+    expect(nativeModule.getEventMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards joinEvent argument to native module', async () => {
+    const { BarnardManager, nativeModule } = setup();
+    const manager = new BarnardManager();
+
+    await manager.joinEvent('ETHGLOBAL');
+
+    expect(nativeModule.joinEvent).toHaveBeenCalledWith('ETHGLOBAL');
+    expect(nativeModule.joinEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops receiving detection events after unsubscribe', () => {
+    const { BarnardManager, listeners } = setup();
+    const manager = new BarnardManager();
+    const callback = jest.fn();
+
+    const unsubscribe = manager.onDetection(callback);
+
+    emit(listeners, 'BarnardDetection', { type: 'detection', displayId: 'abc123' });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    emit(listeners, 'BarnardDetection', { type: 'detection', displayId: 'def456' });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes and unsubscribes all channels via onEvent', () => {
+    const { BarnardManager, listeners } = setup();
+    const manager = new BarnardManager();
+    const callback = jest.fn();
+
+    const unsubscribe = manager.onEvent(callback);
+
+    emit(listeners, 'BarnardDetection', { type: 'detection' });
+    emit(listeners, 'BarnardState', { type: 'state' });
+    emit(listeners, 'BarnardConstraint', { type: 'constraint' });
+
+    expect(callback).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    emit(listeners, 'BarnardError', { type: 'error' });
+    emit(listeners, 'BarnardDebug', { type: 'debug' });
+
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  it('calls native dispose and removes active subscriptions', async () => {
+    const { BarnardManager, nativeModule, listeners } = setup();
+    const manager = new BarnardManager();
+    const callback = jest.fn();
+
+    manager.onDetection(callback);
+    manager.dispose();
+    await Promise.resolve();
+
+    emit(listeners, 'BarnardDetection', { type: 'detection' });
+
+    expect(nativeModule.dispose).toHaveBeenCalledTimes(1);
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react-native/barnard/android/build.gradle
+++ b/packages/react-native/barnard/android/build.gradle
@@ -18,10 +18,15 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 33)
+    namespace 'network.greeting.barnard'
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 33)
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 
     buildTypes {
@@ -39,10 +44,19 @@ android {
         jvmTarget = '1.8'
     }
 
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
+
     sourceSets {
         main {
             java {
                 srcDirs += 'src/main/kotlin'
+            }
+        }
+        test {
+            java {
+                srcDirs += 'src/test/kotlin'
             }
         }
     }
@@ -56,4 +70,7 @@ repositories {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'com.facebook.react:react-native:+'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
 }

--- a/packages/react-native/barnard/android/build.gradle
+++ b/packages/react-native/barnard/android/build.gradle
@@ -1,0 +1,59 @@
+buildscript {
+    ext.kotlin_version = '1.8.0'
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+android {
+    compileSdkVersion safeExtGet('compileSdkVersion', 33)
+
+    defaultConfig {
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 33)
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main {
+            java {
+                srcDirs += 'src/main/kotlin'
+            }
+        }
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'com.facebook.react:react-native:+'
+}

--- a/packages/react-native/barnard/android/src/main/AndroidManifest.xml
+++ b/packages/react-native/barnard/android/src/main/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="network.greeting.barnard">
+    
+    <!-- Bluetooth permissions for Android 12+ (API 31+) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+                     android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    
+    <!-- Legacy Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" 
+                     android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" 
+                     android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" 
+                     android:maxSdkVersion="30" />
+    
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+</manifest>

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -1,0 +1,673 @@
+package network.greeting.barnard
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCallback
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.ParcelUuid
+import android.util.Base64
+import android.util.Log
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.UUID
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+private const val TAG = "BarnardBLE"
+
+internal class BarnardController(
+    private val appContext: Context
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    var onEvent: ((String, WritableMap) -> Unit)? = null
+    var onDebugEvent: ((String, WritableMap) -> Unit)? = null
+
+    private val serviceUuid: UUID = UUID.fromString("0000B001-0000-1000-8000-00805F9B34FB")
+    private val rpidCharUuid: UUID = UUID.fromString("0000B002-0000-1000-8000-00805F9B34FB")
+    
+    // RPID security parameters
+    private val rotationSeconds = 600L
+    private val seedSizeBytes = 32
+
+    private val bluetoothManager: BluetoothManager? =
+        appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+    private val adapter: BluetoothAdapter? = bluetoothManager?.adapter
+
+    private var gattServer: BluetoothGattServer? = null
+
+    private var isScanning: Boolean = false
+    private var isAdvertising: Boolean = false
+    private var allowDuplicates: Boolean = true
+    private var formatVersion: Int = 1
+    private var eventCode: String? = null
+
+    private val discoveredRssi: MutableMap<String, Int> = mutableMapOf()
+    private val discoveredAt: MutableMap<String, Long> = mutableMapOf()
+
+    private val connectQueue: ArrayDeque<BluetoothDevice> = ArrayDeque()
+    private val lastConnectAttemptAtMs: MutableMap<String, Long> = mutableMapOf()
+    private var activeGatt: BluetoothGatt? = null
+
+    private val maxConnectQueue: Int = 20
+    private val cooldownPerPeerMs: Long = 10_000
+
+    private val prefs: SharedPreferences =
+        appContext.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+
+    fun dispose() {
+        stopScan()
+        stopAdvertise()
+        onEvent = null
+        onDebugEvent = null
+    }
+
+    fun getCapabilities(): WritableMap {
+        val map = Arguments.createMap()
+        val transports = Arguments.createArray()
+        transports.pushString("ble")
+        map.putArray("supportedTransports", transports)
+        map.putBoolean("supportsConnectionlessRpid", false)
+        map.putBoolean("supportsGattFallback", true)
+        map.putBoolean("supportsBackground", false)
+        map.putBoolean("supportsHighRateRssi", false)
+        return map
+    }
+
+    fun getState(): WritableMap {
+        val map = Arguments.createMap()
+        map.putBoolean("isScanning", isScanning)
+        map.putBoolean("isAdvertising", isAdvertising)
+        map.putString("eventMode", if (eventCode == null) "anonymous" else "event")
+        if (eventCode != null) {
+            map.putString("eventCode", eventCode)
+        } else {
+            map.putNull("eventCode")
+        }
+        return map
+    }
+
+    fun getEventMode(): WritableMap {
+        val map = Arguments.createMap()
+        map.putString("mode", if (eventCode == null) "anonymous" else "event")
+        if (eventCode != null) {
+            map.putString("eventCode", eventCode)
+        } else {
+            map.putNull("eventCode")
+        }
+        return map
+    }
+
+    fun joinEvent(code: String) {
+        eventCode = code
+        emitState("join_event")
+        val debugData = Arguments.createMap()
+        debugData.putString("eventCode", code)
+        emitDebug("info", "join_event", debugData)
+    }
+
+    fun leaveEvent() {
+        eventCode = null
+        emitState("leave_event")
+        emitDebug("info", "leave_event", null)
+    }
+
+    fun getExchangedTeks(eventCode: String): com.facebook.react.bridge.WritableArray {
+        // Not yet implemented on Android in this branch; keep API parity with iOS.
+        return Arguments.createArray()
+    }
+
+    fun clearTeksForEvent(eventCode: String): Int {
+        // Not yet implemented on Android in this branch; keep API parity with iOS.
+        return 0
+    }
+
+    fun clearAllTeks(): Int {
+        // Not yet implemented on Android in this branch; keep API parity with iOS.
+        return 0
+    }
+
+    fun startScan(allowDuplicates: Boolean) {
+        this.allowDuplicates = allowDuplicates
+        val a = adapter ?: run {
+            emitConstraint("bluetooth_unavailable", "BluetoothAdapter is null")
+            return
+        }
+        if (!a.isEnabled) {
+            emitConstraint("bluetooth_off", "Bluetooth is disabled")
+            return
+        }
+        if (!hasScanPermission()) {
+            emitConstraint("permission_denied", "Missing BLUETOOTH_SCAN permission", requiredAction = "grant_permission")
+            return
+        }
+        val s = adapter?.bluetoothLeScanner ?: run {
+            emitError("scan_failed", "BluetoothLeScanner is null", recoverable = true)
+            return
+        }
+        if (isScanning) return
+
+        // Stop any previous scan first
+        scanCallback?.let { cb ->
+            try {
+                s.stopScan(cb)
+            } catch (e: Exception) {
+                Log.w(TAG, "stopScan before start failed: ${e.message}")
+            }
+        }
+
+        val settings = ScanSettings.Builder()
+            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+            .setReportDelay(0)
+            .build()
+
+        // Create fresh callback
+        val cb = createScanCallback()
+        scanCallback = cb
+
+        // Filter by Barnard service UUID for efficiency
+        val filter = ScanFilter.Builder()
+            .setServiceUuid(ParcelUuid(serviceUuid))
+            .build()
+
+        Log.i(TAG, "Starting BLE scan with scanner: $s, callback: $cb, filter: $serviceUuid")
+        s.startScan(listOf(filter), settings, cb)
+        isScanning = true
+
+        // Flush any pending results
+        s.flushPendingScanResults(cb)
+        Log.i(TAG, "BLE scan started (LOW_LATENCY, service UUID filter)")
+        emitState("scan_start")
+        
+        val debugData = Arguments.createMap()
+        debugData.putBoolean("allowDuplicates", allowDuplicates)
+        emitDebug("info", "scan_start", debugData)
+    }
+
+    fun stopScan() {
+        if (!isScanning) return
+        scanCallback?.let { cb ->
+            if (hasScanPermission()) {
+                adapter?.bluetoothLeScanner?.stopScan(cb)
+            }
+        }
+        scanCallback = null
+        isScanning = false
+        connectQueue.clear()
+        activeGatt?.close()
+        activeGatt = null
+        emitState("scan_stop")
+        emitDebug("info", "scan_stop", null)
+    }
+
+    fun startAdvertise(formatVersion: Int) {
+        this.formatVersion = formatVersion
+        val a = adapter ?: run {
+            emitConstraint("bluetooth_unavailable", "BluetoothAdapter is null")
+            return
+        }
+        if (!a.isEnabled) {
+            emitConstraint("bluetooth_off", "Bluetooth is disabled")
+            return
+        }
+        if (!hasAdvertisePermission()) {
+            emitConstraint("permission_denied", "Missing BLUETOOTH_ADVERTISE permission", requiredAction = "grant_permission")
+            return
+        }
+        if (!a.isMultipleAdvertisementSupported) {
+            emitConstraint("advertise_unsupported", "Multiple advertisement not supported")
+            return
+        }
+        val adv = a.bluetoothLeAdvertiser ?: run {
+            emitError("advertise_failed", "BluetoothLeAdvertiser is null", recoverable = true)
+            return
+        }
+        if (isAdvertising) return
+
+        ensureGattServer()
+
+        val settings = AdvertiseSettings.Builder()
+            .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
+            .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
+            .setConnectable(true)
+            .build()
+        val data = AdvertiseData.Builder()
+            .addServiceUuid(ParcelUuid(serviceUuid))
+            .setIncludeDeviceName(false)
+            .build()
+        adv.startAdvertising(settings, data, advertiseCallback)
+        isAdvertising = true
+        emitState("advertise_start")
+        
+        val debugData = Arguments.createMap()
+        debugData.putInt("formatVersion", formatVersion)
+        debugData.putString("serviceUuid", serviceUuid.toString())
+        debugData.putString("localName", "BNRD")
+        emitDebug("info", "advertise_start", debugData)
+    }
+
+    fun stopAdvertise() {
+        if (!isAdvertising) return
+        if (hasAdvertisePermission()) {
+            adapter?.bluetoothLeAdvertiser?.stopAdvertising(advertiseCallback)
+        }
+        isAdvertising = false
+        gattServer?.close()
+        gattServer = null
+        emitState("advertise_stop")
+        emitDebug("info", "advertise_stop", null)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun ensureGattServer() {
+        if (gattServer != null) return
+        if (!hasConnectPermission()) {
+            emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
+            return
+        }
+        val manager = bluetoothManager ?: return
+        val server = manager.openGattServer(appContext, gattServerCallback)
+        val service = BluetoothGattService(serviceUuid, BluetoothGattService.SERVICE_TYPE_PRIMARY)
+        val ch = BluetoothGattCharacteristic(
+            rpidCharUuid,
+            BluetoothGattCharacteristic.PROPERTY_READ,
+            BluetoothGattCharacteristic.PERMISSION_READ,
+        )
+        service.addCharacteristic(ch)
+        server.addService(service)
+        gattServer = server
+        emitDebug("info", "gatt_server_started", null)
+    }
+
+    private fun computePayload(nowMs: Long): ByteArray {
+        val window = (nowMs / 1000L) / rotationSeconds
+        val seed = getOrCreateSeed()
+
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(seed, "HmacSHA256"))
+        val msg = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(window).array()
+        val digest = mac.doFinal(msg)
+
+        val out = ByteArray(17)
+        out[0] = (formatVersion and 0xFF).toByte()
+        System.arraycopy(digest, 0, out, 1, 16)
+        return out
+    }
+
+    private fun getOrCreateSeed(): ByteArray {
+        val key = "rpidSeed"
+        val existing = prefs.getString(key, null)
+        if (existing != null) {
+            val bytes = Base64.decode(existing, Base64.DEFAULT)
+            if (bytes.size >= seedSizeBytes) return bytes
+        }
+        val bytes = ByteArray(seedSizeBytes)
+        java.security.SecureRandom().nextBytes(bytes)
+        prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
+        return bytes
+    }
+
+    private fun emitState(reasonCode: String?) {
+        val payload = Arguments.createMap()
+        payload.putString("type", "state")
+        payload.putString("timestamp", BarnardIso8601.now())
+        val state = Arguments.createMap()
+        state.putBoolean("isScanning", isScanning)
+        state.putBoolean("isAdvertising", isAdvertising)
+        state.putString("eventMode", if (eventCode == null) "anonymous" else "event")
+        if (eventCode != null) {
+            state.putString("eventCode", eventCode)
+        } else {
+            state.putNull("eventCode")
+        }
+        payload.putMap("state", state)
+        if (reasonCode != null) {
+            payload.putString("reasonCode", reasonCode)
+        }
+        mainHandler.post { onEvent?.invoke("BarnardState", payload) }
+    }
+
+    private fun emitConstraint(code: String, message: String?, requiredAction: String? = null) {
+        val payload = Arguments.createMap()
+        payload.putString("type", "constraint")
+        payload.putString("timestamp", BarnardIso8601.now())
+        payload.putString("code", code)
+        if (message != null) {
+            payload.putString("message", message)
+        }
+        if (requiredAction != null) {
+            payload.putString("requiredAction", requiredAction)
+        }
+        mainHandler.post { onEvent?.invoke("BarnardConstraint", payload) }
+    }
+
+    private fun emitError(code: String, message: String, recoverable: Boolean? = null) {
+        val payload = Arguments.createMap()
+        payload.putString("type", "error")
+        payload.putString("timestamp", BarnardIso8601.now())
+        payload.putString("code", code)
+        payload.putString("message", message)
+        if (recoverable != null) {
+            payload.putBoolean("recoverable", recoverable)
+        }
+        mainHandler.post { onEvent?.invoke("BarnardError", payload) }
+    }
+
+    private fun emitDetection(timestampMs: Long, rssi: Int, payloadBytes: ByteArray) {
+        if (payloadBytes.size != 17) {
+            val debugData = Arguments.createMap()
+            debugData.putInt("length", payloadBytes.size)
+            emitDebug("warn", "payload_invalid_length", debugData)
+            return
+        }
+        val version = payloadBytes[0].toInt() and 0xFF
+        if (version != 1) {
+            val debugData = Arguments.createMap()
+            debugData.putInt("formatVersion", version)
+            emitDebug("warn", "payload_unsupported_version", debugData)
+            return
+        }
+        val rpid = payloadBytes.copyOfRange(1, 17)
+        val displayId = rpid.copyOfRange(0, 4).joinToString("") { b -> "%02x".format(b) }
+        
+        val payload = Arguments.createMap()
+        payload.putString("type", "detection")
+        payload.putString("timestamp", BarnardIso8601.fromMs(timestampMs))
+        payload.putString("transport", "ble")
+        payload.putInt("formatVersion", version)
+        payload.putString("rpid", Base64.encodeToString(rpid, Base64.NO_WRAP))
+        payload.putString("displayId", displayId)
+        payload.putInt("rssi", rssi)
+        payload.putString("payloadRaw", Base64.encodeToString(payloadBytes, Base64.NO_WRAP))
+        
+        mainHandler.post { onEvent?.invoke("BarnardDetection", payload) }
+    }
+
+    private fun emitDebug(level: String, name: String, data: WritableMap?) {
+        val payload = Arguments.createMap()
+        payload.putString("type", "debug")
+        payload.putString("timestamp", BarnardIso8601.now())
+        payload.putString("level", level)
+        payload.putString("name", name)
+        if (data != null) {
+            payload.putMap("data", data)
+        }
+        mainHandler.post { onDebugEvent?.invoke("BarnardDebug", payload) }
+    }
+
+    private fun hasScanPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < 31) return true
+        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun hasAdvertisePermission(): Boolean {
+        if (Build.VERSION.SDK_INT < 31) return true
+        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_ADVERTISE) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun hasConnectPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < 31) return true
+        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private val advertiseCallback = object : AdvertiseCallback() {
+        override fun onStartFailure(errorCode: Int) {
+            emitError("advertise_failed", "errorCode=$errorCode", recoverable = true)
+            isAdvertising = false
+            emitState("advertise_failed")
+        }
+
+        override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
+            emitDebug("info", "advertise_started", null)
+        }
+    }
+
+    private var scanCallback: ScanCallback? = null
+
+    private fun createScanCallback(): ScanCallback {
+        return object : ScanCallback() {
+            override fun onScanFailed(errorCode: Int) {
+                Log.e(TAG, "onScanFailed: errorCode=$errorCode")
+                emitError("scan_failed", "errorCode=$errorCode", recoverable = true)
+                isScanning = false
+                emitState("scan_failed")
+            }
+
+            override fun onScanResult(callbackType: Int, result: ScanResult) {
+                Log.d(TAG, "onScanResult: ${result.device?.address} name=${result.scanRecord?.deviceName} rssi=${result.rssi}")
+                handleScanResult(result)
+            }
+
+            override fun onBatchScanResults(results: MutableList<ScanResult>) {
+                Log.d(TAG, "onBatchScanResults: ${results.size} results")
+                for (r in results) handleScanResult(r)
+            }
+        }
+    }
+
+    private fun handleScanResult(result: ScanResult) {
+        val device = result.device ?: return
+        val address = device.address ?: return
+        if (!isBarnardScanResult(result)) {
+            val debugData = Arguments.createMap()
+            debugData.putString("address", address)
+            result.scanRecord?.deviceName?.let { debugData.putString("name", it) }
+            debugData.putBoolean("hasService", result.scanRecord?.serviceUuids?.any { it.uuid == serviceUuid } == true)
+            debugData.putBoolean("isConnectable", isConnectableResult(result))
+            emitDebug("trace", "scan_ignored", debugData)
+            return
+        }
+        val nowMs = System.currentTimeMillis()
+        if (!allowDuplicates) {
+            val last = discoveredAt[address]
+            if (last != null && nowMs - last < 2_000) return
+        }
+        discoveredRssi[address] = result.rssi
+        discoveredAt[address] = nowMs
+
+        val debugData = Arguments.createMap()
+        debugData.putString("id", address)
+        debugData.putInt("rssi", result.rssi)
+        result.scanRecord?.deviceName?.let { debugData.putString("name", it) }
+        emitDebug("trace", "ble_discovery_result", debugData)
+
+        enqueueConnect(device)
+    }
+
+    private fun isBarnardScanResult(result: ScanResult): Boolean {
+        val record = result.scanRecord ?: return false
+        val uuids = record.serviceUuids
+        val hasService = uuids?.any { it.uuid == serviceUuid } == true
+        val name = record.deviceName
+        val isBnrd = name == "BNRD"
+        Log.d(TAG, "isBarnardScanResult: addr=${result.device?.address} name=$name hasService=$hasService isBnrd=$isBnrd uuids=$uuids")
+        // 1. Service UUID match (reliable for Android-to-Android).
+        if (hasService) return true
+        // 2. Local Name fallback for iOS foreground advertise.
+        if (isBnrd) return true
+        return false
+    }
+
+    private fun isConnectableResult(result: ScanResult): Boolean {
+        return if (Build.VERSION.SDK_INT >= 26) {
+            result.isConnectable
+        } else {
+            true
+        }
+    }
+
+    private fun enqueueConnect(device: BluetoothDevice) {
+        val address = device.address ?: return
+        // Skip if already in queue or currently connecting.
+        if (connectQueue.any { it.address == address }) return
+        if (activeGatt?.device?.address == address) return
+
+        if (connectQueue.size >= maxConnectQueue) {
+            val debugData = Arguments.createMap()
+            debugData.putInt("max", maxConnectQueue)
+            emitDebug("warn", "connect_queue_full", debugData)
+            return
+        }
+        connectQueue.add(device)
+        pumpConnectQueue()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun pumpConnectQueue() {
+        if (activeGatt != null) return
+        val device = connectQueue.removeFirstOrNull() ?: return
+        val nowMs = System.currentTimeMillis()
+        val key = device.address ?: ""
+        val last = lastConnectAttemptAtMs[key]
+        if (last != null && nowMs - last < cooldownPerPeerMs) {
+            connectQueue.add(device)
+            return
+        }
+        if (!hasConnectPermission()) {
+            emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
+            return
+        }
+        lastConnectAttemptAtMs[key] = nowMs
+        activeGatt =
+            if (Build.VERSION.SDK_INT >= 23) {
+                device.connectGatt(appContext, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+            } else {
+                @Suppress("DEPRECATION")
+                device.connectGatt(appContext, false, gattCallback)
+            }
+        val debugData = Arguments.createMap()
+        debugData.putString("address", device.address)
+        emitDebug("trace", "connect_attempt", debugData)
+    }
+
+    private val gattCallback = object : BluetoothGattCallback() {
+        @SuppressLint("MissingPermission")
+        override fun onConnectionStateChange(gatt: BluetoothGatt, status: Int, newState: Int) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                emitError("connect_failed", "status=$status", recoverable = true)
+                gatt.close()
+                activeGatt = null
+                pumpConnectQueue()
+                return
+            }
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                val debugData = Arguments.createMap()
+                debugData.putString("address", gatt.device.address)
+                emitDebug("trace", "connected", debugData)
+                gatt.discoverServices()
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                gatt.close()
+                activeGatt = null
+                pumpConnectQueue()
+            }
+        }
+
+        override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                emitError("service_discovery_failed", "status=$status", recoverable = true)
+                gatt.disconnect()
+                return
+            }
+            val svc = gatt.getService(serviceUuid)
+            if (svc == null) {
+                emitError("service_not_found", "Barnard service not found", recoverable = true)
+                gatt.disconnect()
+                return
+            }
+            val ch = svc.getCharacteristic(rpidCharUuid)
+            if (ch == null) {
+                emitError("characteristic_not_found", "RPID characteristic not found", recoverable = true)
+                gatt.disconnect()
+                return
+            }
+            if (!hasConnectPermission()) {
+                emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
+                gatt.disconnect()
+                return
+            }
+            @SuppressLint("MissingPermission")
+            gatt.readCharacteristic(ch)
+        }
+
+        override fun onCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
+            val value = characteristic.value ?: ByteArray(0)
+            handleRead(gatt, status, value)
+        }
+
+        override fun onCharacteristicRead(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray,
+            status: Int
+        ) {
+            handleRead(gatt, status, value)
+        }
+
+        private fun handleRead(gatt: BluetoothGatt, status: Int, value: ByteArray) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                emitError("read_failed", "status=$status", recoverable = true)
+                gatt.disconnect()
+                return
+            }
+            val address = gatt.device.address ?: ""
+            val rssi = discoveredRssi[address] ?: 0
+            val ts = discoveredAt[address] ?: System.currentTimeMillis()
+            emitDetection(ts, rssi, value)
+            gatt.disconnect()
+        }
+    }
+
+    private val gattServerCallback = object : BluetoothGattServerCallback() {
+        @SuppressLint("MissingPermission")
+        override fun onCharacteristicReadRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            offset: Int,
+            characteristic: BluetoothGattCharacteristic
+        ) {
+            val server = gattServer ?: return
+            val payload = computePayload(System.currentTimeMillis())
+            val slice =
+                if (offset <= 0) payload
+                else if (offset >= payload.size) ByteArray(0)
+                else payload.copyOfRange(offset, payload.size)
+            server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+            
+            val debugData = Arguments.createMap()
+            debugData.putInt("bytes", payload.size)
+            debugData.putInt("formatVersion", payload[0].toInt() and 0xFF)
+            debugData.putString("displayId", displayIdForPayload(payload))
+            emitDebug("trace", "gatt_read_rpid", debugData)
+        }
+    }
+
+    private fun displayIdForPayload(payload: ByteArray): String {
+        if (payload.size < 5) return ""
+        return payload.copyOfRange(1, 5).joinToString("") { b -> "%02x".format(b) }
+    }
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -15,8 +15,6 @@ import android.bluetooth.BluetoothProfile
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
-import android.bluetooth.le.BluetoothLeAdvertiser
-import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
@@ -31,12 +29,9 @@ import android.os.ParcelUuid
 import android.util.Base64
 import android.util.Log
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.util.UUID
-import javax.crypto.Mac
-import javax.crypto.spec.SecretKeySpec
 
 private const val TAG = "BarnardBLE"
 
@@ -48,12 +43,14 @@ internal class BarnardController(
     var onEvent: ((String, WritableMap) -> Unit)? = null
     var onDebugEvent: ((String, WritableMap) -> Unit)? = null
 
+    // MARK: - UUIDs
+
     private val serviceUuid: UUID = UUID.fromString("0000B001-0000-1000-8000-00805F9B34FB")
     private val rpidCharUuid: UUID = UUID.fromString("0000B002-0000-1000-8000-00805F9B34FB")
-    
-    // RPID security parameters
-    private val rotationSeconds = 600L
-    private val seedSizeBytes = 32
+    private val tekCharUuid: UUID = UUID.fromString("0000B003-0000-1000-8000-00805F9B34FB")
+    private val eventCodeHashCharUuid: UUID = UUID.fromString("0000B004-0000-1000-8000-00805F9B34FB")
+
+    // MARK: - Bluetooth
 
     private val bluetoothManager: BluetoothManager? =
         appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
@@ -61,14 +58,28 @@ internal class BarnardController(
 
     private var gattServer: BluetoothGattServer? = null
 
+    // MARK: - State
+
     private var isScanning: Boolean = false
     private var isAdvertising: Boolean = false
     private var allowDuplicates: Boolean = true
     private var formatVersion: Int = 1
+    private var debugOriginalName: String? = null
+
+    // MARK: - Event Mode
+
     private var eventCode: String? = null
+    private var currentTek: ByteArray = ByteArray(16)
+
+    private val tekStorage: BarnardTekStorage by lazy { BarnardTekStorage(appContext) }
+
+    // MARK: - Discovery State
 
     private val discoveredRssi: MutableMap<String, Int> = mutableMapOf()
     private val discoveredAt: MutableMap<String, Long> = mutableMapOf()
+    private val lastDiscoveryNameById: MutableMap<String, String> = mutableMapOf()
+
+    // MARK: - Connection Queue
 
     private val connectQueue: ArrayDeque<BluetoothDevice> = ArrayDeque()
     private val lastConnectAttemptAtMs: MutableMap<String, Long> = mutableMapOf()
@@ -77,83 +88,185 @@ internal class BarnardController(
     private val maxConnectQueue: Int = 20
     private val cooldownPerPeerMs: Long = 10_000
 
+    // MARK: - Central GATT State
+
+    private data class GattReadValues(
+        var eventCodeHash: ByteArray? = null,
+        var rpid: ByteArray? = null,
+        var tek: ByteArray? = null
+    )
+
+    private val peripheralReadValues: MutableMap<String, GattReadValues> = mutableMapOf()
+
+    // MARK: - Storage
+
     private val prefs: SharedPreferences =
         appContext.getSharedPreferences("barnard", Context.MODE_PRIVATE)
 
+    init {
+        initializeTek()
+    }
+
+    private fun isDebugBuild(): Boolean {
+        return BuildConfig.BUILD_TYPE != "release"
+    }
+
+    private fun initializeTek() {
+        eventCode = prefs.getString("eventCode", null)
+
+        val deviceSecret = getOrCreateDeviceSecret()
+        currentTek = if (eventCode != null) {
+            BarnardCrypto.deriveTekForEvent(deviceSecret, eventCode!!)
+        } else {
+            BarnardCrypto.deriveTekForAnonymous(deviceSecret)
+        }
+    }
+
     fun dispose() {
-        stopScan()
-        stopAdvertise()
+        stopScanInternal()
+        stopAdvertiseInternal()
         onEvent = null
         onDebugEvent = null
     }
 
     fun getCapabilities(): WritableMap {
-        val map = Arguments.createMap()
-        val transports = Arguments.createArray()
-        transports.pushString("ble")
-        map.putArray("supportedTransports", transports)
-        map.putBoolean("supportsConnectionlessRpid", false)
-        map.putBoolean("supportsGattFallback", true)
-        map.putBoolean("supportsBackground", false)
-        map.putBoolean("supportsHighRateRssi", false)
-        return map
+        val transports = Arguments.createArray().apply {
+            pushString("ble")
+        }
+        return Arguments.createMap().apply {
+            putArray("supportedTransports", transports)
+            putBoolean("supportsConnectionlessRpid", false)
+            putBoolean("supportsGattFallback", true)
+            putBoolean("supportsBackground", false)
+            putBoolean("supportsHighRateRssi", false)
+        }
     }
 
     fun getState(): WritableMap {
-        val map = Arguments.createMap()
-        map.putBoolean("isScanning", isScanning)
-        map.putBoolean("isAdvertising", isAdvertising)
-        map.putString("eventMode", if (eventCode == null) "anonymous" else "event")
-        if (eventCode != null) {
-            map.putString("eventCode", eventCode)
-        } else {
-            map.putNull("eventCode")
+        return Arguments.createMap().apply {
+            putBoolean("isScanning", isScanning)
+            putBoolean("isAdvertising", isAdvertising)
+            putString("eventMode", if (isEventMode) "event" else "anonymous")
+            if (eventCode != null) {
+                putString("eventCode", eventCode)
+            } else {
+                putNull("eventCode")
+            }
         }
-        return map
     }
 
     fun getEventMode(): WritableMap {
-        val map = Arguments.createMap()
-        map.putString("mode", if (eventCode == null) "anonymous" else "event")
-        if (eventCode != null) {
-            map.putString("eventCode", eventCode)
-        } else {
-            map.putNull("eventCode")
+        return Arguments.createMap().apply {
+            putString("mode", if (isEventMode) "event" else "anonymous")
+            if (eventCode != null) {
+                putString("eventCode", eventCode)
+            } else {
+                putNull("eventCode")
+            }
         }
-        return map
-    }
-
-    fun joinEvent(code: String) {
-        eventCode = code
-        emitState("join_event")
-        val debugData = Arguments.createMap()
-        debugData.putString("eventCode", code)
-        emitDebug("info", "join_event", debugData)
-    }
-
-    fun leaveEvent() {
-        eventCode = null
-        emitState("leave_event")
-        emitDebug("info", "leave_event", null)
-    }
-
-    fun getExchangedTeks(eventCode: String): com.facebook.react.bridge.WritableArray {
-        // Not yet implemented on Android in this branch; keep API parity with iOS.
-        return Arguments.createArray()
-    }
-
-    fun clearTeksForEvent(eventCode: String): Int {
-        // Not yet implemented on Android in this branch; keep API parity with iOS.
-        return 0
-    }
-
-    fun clearAllTeks(): Int {
-        // Not yet implemented on Android in this branch; keep API parity with iOS.
-        return 0
     }
 
     fun startScan(allowDuplicates: Boolean) {
         this.allowDuplicates = allowDuplicates
+        startScanInternal()
+    }
+
+    fun stopScan() {
+        stopScanInternal()
+    }
+
+    fun startAdvertise(formatVersion: Int) {
+        this.formatVersion = formatVersion
+        startAdvertiseInternal()
+    }
+
+    fun stopAdvertise() {
+        stopAdvertiseInternal()
+    }
+
+    fun joinEvent(code: String) {
+        eventCode = code
+        prefs.edit().putString("eventCode", code).apply()
+
+        val deviceSecret = getOrCreateDeviceSecret()
+        currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret, code)
+
+        rebuildGattServerIfNeeded()
+
+        emitState("join_event")
+        emitDebug(
+            "info",
+            "join_event",
+            mapOf(
+                "eventCode" to code,
+                "displayId" to BarnardCrypto.displayId(currentTek)
+            )
+        )
+    }
+
+    fun leaveEvent() {
+        eventCode = null
+        prefs.edit().remove("eventCode").apply()
+
+        val deviceSecret = getOrCreateDeviceSecret()
+        currentTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret)
+
+        rebuildGattServerIfNeeded()
+
+        emitState("leave_event")
+        emitDebug("info", "leave_event", null)
+    }
+
+    fun getExchangedTeks(eventCode: String): WritableArray {
+        val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+        val entries = tekStorage.getEntries(eventCodeHash)
+        return Arguments.createArray().apply {
+            entries.forEach { entry ->
+                pushMap(toWritableMap(entry.toMap()))
+            }
+        }
+    }
+
+    fun clearTeksForEvent(eventCode: String): Int {
+        val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+        val count = tekStorage.clear(eventCodeHash)
+        emitDebug(
+            "info",
+            "clear_teks_for_event",
+            mapOf("eventCode" to eventCode, "count" to count)
+        )
+        return count
+    }
+
+    fun clearAllTeks(): Int {
+        val count = tekStorage.clearAll()
+        emitDebug("info", "clear_all_teks", mapOf("count" to count))
+        return count
+    }
+
+    private val isEventMode: Boolean
+        get() = eventCode != null
+
+    private fun getEventCodeHash(): ByteArray {
+        val code = eventCode ?: return ByteArray(0)
+        return BarnardCrypto.computeEventCodeHash(code)
+    }
+
+    private fun getOrCreateDeviceSecret(): ByteArray {
+        val key = "rpidSeed"
+        val existing = prefs.getString(key, null)
+        if (existing != null) {
+            val bytes = Base64.decode(existing, Base64.DEFAULT)
+            if (bytes.size >= 32) return bytes
+        }
+        val bytes = BarnardCrypto.generateRandomBytes(32)
+        prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
+        return bytes
+    }
+
+    // MARK: - Scan Control
+
+    private fun startScanInternal() {
         val a = adapter ?: run {
             emitConstraint("bluetooth_unavailable", "BluetoothAdapter is null")
             return
@@ -163,19 +276,22 @@ internal class BarnardController(
             return
         }
         if (!hasScanPermission()) {
-            emitConstraint("permission_denied", "Missing BLUETOOTH_SCAN permission", requiredAction = "grant_permission")
+            emitConstraint(
+                "permission_denied",
+                "Missing BLUETOOTH_SCAN permission",
+                requiredAction = "grant_permission"
+            )
             return
         }
-        val s = adapter?.bluetoothLeScanner ?: run {
+        val scanner = adapter?.bluetoothLeScanner ?: run {
             emitError("scan_failed", "BluetoothLeScanner is null", recoverable = true)
             return
         }
         if (isScanning) return
 
-        // Stop any previous scan first
         scanCallback?.let { cb ->
             try {
-                s.stopScan(cb)
+                scanner.stopScan(cb)
             } catch (e: Exception) {
                 Log.w(TAG, "stopScan before start failed: ${e.message}")
             }
@@ -186,30 +302,24 @@ internal class BarnardController(
             .setReportDelay(0)
             .build()
 
-        // Create fresh callback
         val cb = createScanCallback()
         scanCallback = cb
 
-        // Filter by Barnard service UUID for efficiency
         val filter = ScanFilter.Builder()
             .setServiceUuid(ParcelUuid(serviceUuid))
             .build()
 
-        Log.i(TAG, "Starting BLE scan with scanner: $s, callback: $cb, filter: $serviceUuid")
-        s.startScan(listOf(filter), settings, cb)
+        Log.i(TAG, "Starting BLE scan with scanner: $scanner, callback: $cb, filter: $serviceUuid")
+        scanner.startScan(listOf(filter), settings, cb)
         isScanning = true
 
-        // Flush any pending results
-        s.flushPendingScanResults(cb)
+        scanner.flushPendingScanResults(cb)
         Log.i(TAG, "BLE scan started (LOW_LATENCY, service UUID filter)")
         emitState("scan_start")
-        
-        val debugData = Arguments.createMap()
-        debugData.putBoolean("allowDuplicates", allowDuplicates)
-        emitDebug("info", "scan_start", debugData)
+        emitDebug("info", "scan_start", mapOf("allowDuplicates" to allowDuplicates))
     }
 
-    fun stopScan() {
+    private fun stopScanInternal() {
         if (!isScanning) return
         scanCallback?.let { cb ->
             if (hasScanPermission()) {
@@ -221,12 +331,20 @@ internal class BarnardController(
         connectQueue.clear()
         activeGatt?.close()
         activeGatt = null
+
+        discoveredRssi.clear()
+        discoveredAt.clear()
+        lastDiscoveryNameById.clear()
+        lastConnectAttemptAtMs.clear()
+        peripheralReadValues.clear()
+
         emitState("scan_stop")
         emitDebug("info", "scan_stop", null)
     }
 
-    fun startAdvertise(formatVersion: Int) {
-        this.formatVersion = formatVersion
+    // MARK: - Advertise Control
+
+    private fun startAdvertiseInternal() {
         val a = adapter ?: run {
             emitConstraint("bluetooth_unavailable", "BluetoothAdapter is null")
             return
@@ -236,14 +354,27 @@ internal class BarnardController(
             return
         }
         if (!hasAdvertisePermission()) {
-            emitConstraint("permission_denied", "Missing BLUETOOTH_ADVERTISE permission", requiredAction = "grant_permission")
+            emitConstraint(
+                "permission_denied",
+                "Missing BLUETOOTH_ADVERTISE permission",
+                requiredAction = "grant_permission"
+            )
             return
         }
         if (!a.isMultipleAdvertisementSupported) {
             emitConstraint("advertise_unsupported", "Multiple advertisement not supported")
             return
         }
-        val adv = a.bluetoothLeAdvertiser ?: run {
+        if (!hasConnectPermission()) {
+            emitConstraint(
+                "permission_denied",
+                "Missing BLUETOOTH_CONNECT permission",
+                requiredAction = "grant_permission"
+            )
+            return
+        }
+
+        val advertiser = a.bluetoothLeAdvertiser ?: run {
             emitError("advertise_failed", "BluetoothLeAdvertiser is null", recoverable = true)
             return
         }
@@ -251,30 +382,63 @@ internal class BarnardController(
 
         ensureGattServer()
 
+        val localName = if (isDebugBuild()) {
+            val deviceSecret = getOrCreateDeviceSecret()
+            val tail = if (deviceSecret.size >= 2) {
+                deviceSecret.copyOfRange(deviceSecret.size - 2, deviceSecret.size)
+            } else {
+                deviceSecret
+            }
+            val suffix = tail.joinToString("") { "%02x".format(it) }.uppercase()
+            val debugName = "BND-" + if (suffix.isEmpty()) "DEAD" else suffix
+            if (debugOriginalName == null && !a.name.isNullOrEmpty()) {
+                debugOriginalName = a.name
+            }
+            if (a.name != debugName) {
+                a.name = debugName
+            }
+            debugName
+        } else {
+            "BNRD"
+        }
+
         val settings = AdvertiseSettings.Builder()
             .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
             .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
             .setConnectable(true)
             .build()
+
         val data = AdvertiseData.Builder()
             .addServiceUuid(ParcelUuid(serviceUuid))
-            .setIncludeDeviceName(false)
+            .setIncludeDeviceName(isDebugBuild())
             .build()
-        adv.startAdvertising(settings, data, advertiseCallback)
+
+        advertiser.startAdvertising(settings, data, advertiseCallback)
         isAdvertising = true
         emitState("advertise_start")
-        
-        val debugData = Arguments.createMap()
-        debugData.putInt("formatVersion", formatVersion)
-        debugData.putString("serviceUuid", serviceUuid.toString())
-        debugData.putString("localName", "BNRD")
-        emitDebug("info", "advertise_start", debugData)
+        emitDebug(
+            "info",
+            "advertise_start",
+            mapOf(
+                "formatVersion" to formatVersion,
+                "serviceUuid" to serviceUuid.toString(),
+                "localName" to localName,
+                "eventMode" to isEventMode
+            )
+        )
     }
 
-    fun stopAdvertise() {
+    private fun stopAdvertiseInternal() {
         if (!isAdvertising) return
         if (hasAdvertisePermission()) {
             adapter?.bluetoothLeAdvertiser?.stopAdvertising(advertiseCallback)
+        }
+        if (BuildConfig.DEBUG) {
+            val original = debugOriginalName
+            if (original != null && adapter?.name != original) {
+                adapter?.name = original
+            }
+            debugOriginalName = null
         }
         isAdvertising = false
         gattServer?.close()
@@ -283,142 +447,198 @@ internal class BarnardController(
         emitDebug("info", "advertise_stop", null)
     }
 
+    // MARK: - GATT Server
+
     @SuppressLint("MissingPermission")
     private fun ensureGattServer() {
         if (gattServer != null) return
+        buildAndAddGattServer()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun rebuildGattServerIfNeeded() {
+        if (!hasConnectPermission()) return
+        gattServer?.close()
+        gattServer = null
+        if (isAdvertising) {
+            buildAndAddGattServer()
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun buildAndAddGattServer() {
         if (!hasConnectPermission()) {
-            emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
+            emitConstraint(
+                "permission_denied",
+                "Missing BLUETOOTH_CONNECT permission",
+                requiredAction = "grant_permission"
+            )
             return
         }
         val manager = bluetoothManager ?: return
         val server = manager.openGattServer(appContext, gattServerCallback)
+
         val service = BluetoothGattService(serviceUuid, BluetoothGattService.SERVICE_TYPE_PRIMARY)
-        val ch = BluetoothGattCharacteristic(
+
+        val rpidCh = BluetoothGattCharacteristic(
             rpidCharUuid,
             BluetoothGattCharacteristic.PROPERTY_READ,
             BluetoothGattCharacteristic.PERMISSION_READ,
         )
-        service.addCharacteristic(ch)
+        service.addCharacteristic(rpidCh)
+
+        val tekCh = BluetoothGattCharacteristic(
+            tekCharUuid,
+            BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_WRITE,
+            BluetoothGattCharacteristic.PERMISSION_READ or BluetoothGattCharacteristic.PERMISSION_WRITE,
+        )
+        service.addCharacteristic(tekCh)
+
+        val eventCodeHashCh = BluetoothGattCharacteristic(
+            eventCodeHashCharUuid,
+            BluetoothGattCharacteristic.PROPERTY_READ,
+            BluetoothGattCharacteristic.PERMISSION_READ,
+        )
+        service.addCharacteristic(eventCodeHashCh)
+
         server.addService(service)
         gattServer = server
-        emitDebug("info", "gatt_server_started", null)
+        emitDebug(
+            "info",
+            "gatt_server_started",
+            mapOf("characteristics" to listOf("RPID", "TEK", "EventCodeHash"))
+        )
     }
+
+    // MARK: - RPID Payload Generation
 
     private fun computePayload(nowMs: Long): ByteArray {
-        val window = (nowMs / 1000L) / rotationSeconds
-        val seed = getOrCreateSeed()
+        val enin = BarnardCrypto.calculateEnin(nowMs)
+        val rpik = BarnardCrypto.deriveRpik(currentTek)
+        val rpi = BarnardCrypto.generateRpi(rpik, enin)
 
-        val mac = Mac.getInstance("HmacSHA256")
-        mac.init(SecretKeySpec(seed, "HmacSHA256"))
-        val msg = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(window).array()
-        val digest = mac.doFinal(msg)
-
-        val out = ByteArray(17)
-        out[0] = (formatVersion and 0xFF).toByte()
-        System.arraycopy(digest, 0, out, 1, 16)
-        return out
+        val payload = ByteArray(17)
+        payload[0] = (formatVersion and 0xFF).toByte()
+        System.arraycopy(rpi, 0, payload, 1, 16)
+        return payload
     }
 
-    private fun getOrCreateSeed(): ByteArray {
-        val key = "rpidSeed"
-        val existing = prefs.getString(key, null)
-        if (existing != null) {
-            val bytes = Base64.decode(existing, Base64.DEFAULT)
-            if (bytes.size >= seedSizeBytes) return bytes
-        }
-        val bytes = ByteArray(seedSizeBytes)
-        java.security.SecureRandom().nextBytes(bytes)
-        prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
-        return bytes
-    }
+    // MARK: - Event Emission
 
     private fun emitState(reasonCode: String?) {
-        val payload = Arguments.createMap()
-        payload.putString("type", "state")
-        payload.putString("timestamp", BarnardIso8601.now())
-        val state = Arguments.createMap()
-        state.putBoolean("isScanning", isScanning)
-        state.putBoolean("isAdvertising", isAdvertising)
-        state.putString("eventMode", if (eventCode == null) "anonymous" else "event")
-        if (eventCode != null) {
-            state.putString("eventCode", eventCode)
-        } else {
-            state.putNull("eventCode")
-        }
-        payload.putMap("state", state)
-        if (reasonCode != null) {
-            payload.putString("reasonCode", reasonCode)
+        val payload = Arguments.createMap().apply {
+            putString("type", "state")
+            putString("timestamp", BarnardIso8601.now())
+            putMap("state", getState())
+            if (reasonCode != null) {
+                putString("reasonCode", reasonCode)
+            }
         }
         mainHandler.post { onEvent?.invoke("BarnardState", payload) }
     }
 
     private fun emitConstraint(code: String, message: String?, requiredAction: String? = null) {
-        val payload = Arguments.createMap()
-        payload.putString("type", "constraint")
-        payload.putString("timestamp", BarnardIso8601.now())
-        payload.putString("code", code)
-        if (message != null) {
-            payload.putString("message", message)
-        }
-        if (requiredAction != null) {
-            payload.putString("requiredAction", requiredAction)
+        val payload = Arguments.createMap().apply {
+            putString("type", "constraint")
+            putString("timestamp", BarnardIso8601.now())
+            putString("code", code)
+            if (message != null) {
+                putString("message", message)
+            }
+            if (requiredAction != null) {
+                putString("requiredAction", requiredAction)
+            }
         }
         mainHandler.post { onEvent?.invoke("BarnardConstraint", payload) }
     }
 
     private fun emitError(code: String, message: String, recoverable: Boolean? = null) {
-        val payload = Arguments.createMap()
-        payload.putString("type", "error")
-        payload.putString("timestamp", BarnardIso8601.now())
-        payload.putString("code", code)
-        payload.putString("message", message)
-        if (recoverable != null) {
-            payload.putBoolean("recoverable", recoverable)
+        val payload = Arguments.createMap().apply {
+            putString("type", "error")
+            putString("timestamp", BarnardIso8601.now())
+            putString("code", code)
+            putString("message", message)
+            if (recoverable != null) {
+                putBoolean("recoverable", recoverable)
+            }
         }
         mainHandler.post { onEvent?.invoke("BarnardError", payload) }
     }
 
-    private fun emitDetection(timestampMs: Long, rssi: Int, payloadBytes: ByteArray) {
+    private fun emitDetection(
+        timestampMs: Long,
+        rssi: Int,
+        payloadBytes: ByteArray,
+        resolvedTek: ByteArray? = null,
+        debugLocalName: String? = null
+    ) {
         if (payloadBytes.size != 17) {
-            val debugData = Arguments.createMap()
-            debugData.putInt("length", payloadBytes.size)
-            emitDebug("warn", "payload_invalid_length", debugData)
+            emitDebug("warn", "payload_invalid_length", mapOf("length" to payloadBytes.size))
             return
         }
         val version = payloadBytes[0].toInt() and 0xFF
         if (version != 1) {
-            val debugData = Arguments.createMap()
-            debugData.putInt("formatVersion", version)
-            emitDebug("warn", "payload_unsupported_version", debugData)
+            emitDebug("warn", "payload_unsupported_version", mapOf("formatVersion" to version))
             return
         }
         val rpid = payloadBytes.copyOfRange(1, 17)
         val displayId = rpid.copyOfRange(0, 4).joinToString("") { b -> "%02x".format(b) }
-        
-        val payload = Arguments.createMap()
-        payload.putString("type", "detection")
-        payload.putString("timestamp", BarnardIso8601.fromMs(timestampMs))
-        payload.putString("transport", "ble")
-        payload.putInt("formatVersion", version)
-        payload.putString("rpid", Base64.encodeToString(rpid, Base64.NO_WRAP))
-        payload.putString("displayId", displayId)
-        payload.putInt("rssi", rssi)
-        payload.putString("payloadRaw", Base64.encodeToString(payloadBytes, Base64.NO_WRAP))
-        
+
+        var resolvedTekToEmit = resolvedTek
+        var resolvedDisplayId: String? = null
+
+        if (resolvedTekToEmit == null && isEventMode) {
+            val eventCodeHash = getEventCodeHash()
+            val knownTeks = tekStorage.getTeks(eventCodeHash)
+
+            resolvedTekToEmit = BarnardCrypto.resolveRpi(rpid, knownTeks)
+            if (resolvedTekToEmit != null) {
+                tekStorage.updateLastSeen(resolvedTekToEmit, eventCodeHash)
+            }
+        }
+
+        if (resolvedTekToEmit != null) {
+            resolvedDisplayId = BarnardCrypto.displayId(resolvedTekToEmit)
+        }
+
+        val payload = Arguments.createMap().apply {
+            putString("type", "detection")
+            putString("timestamp", BarnardIso8601.fromMs(timestampMs))
+            putString("transport", "ble")
+            putInt("formatVersion", version)
+            putString("rpid", Base64.encodeToString(rpid, Base64.NO_WRAP))
+            putString("displayId", displayId)
+            putInt("rssi", rssi)
+            putNull("rssiSummary")
+            putString("payloadRaw", Base64.encodeToString(payloadBytes, Base64.NO_WRAP))
+            if (resolvedTekToEmit != null) {
+                putString("resolvedTek", Base64.encodeToString(resolvedTekToEmit, Base64.NO_WRAP))
+            }
+            if (resolvedDisplayId != null) {
+                putString("resolvedDisplayId", resolvedDisplayId)
+            }
+            if (isDebugBuild() && debugLocalName != null) {
+                putString("debugLocalName", debugLocalName)
+            }
+        }
+
         mainHandler.post { onEvent?.invoke("BarnardDetection", payload) }
     }
 
-    private fun emitDebug(level: String, name: String, data: WritableMap?) {
-        val payload = Arguments.createMap()
-        payload.putString("type", "debug")
-        payload.putString("timestamp", BarnardIso8601.now())
-        payload.putString("level", level)
-        payload.putString("name", name)
-        if (data != null) {
-            payload.putMap("data", data)
+    private fun emitDebug(level: String, name: String, data: Map<String, Any?>?) {
+        val payload = Arguments.createMap().apply {
+            putString("type", "debug")
+            putString("timestamp", BarnardIso8601.now())
+            putString("level", level)
+            putString("name", name)
+            if (data != null) {
+                putMap("data", toWritableMap(data))
+            }
         }
         mainHandler.post { onDebugEvent?.invoke("BarnardDebug", payload) }
     }
+
+    // MARK: - Permissions
 
     private fun hasScanPermission(): Boolean {
         if (Build.VERSION.SDK_INT < 31) return true
@@ -435,6 +655,8 @@ internal class BarnardController(
         return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
     }
 
+    // MARK: - Advertise Callback
+
     private val advertiseCallback = object : AdvertiseCallback() {
         override fun onStartFailure(errorCode: Int) {
             emitError("advertise_failed", "errorCode=$errorCode", recoverable = true)
@@ -446,6 +668,8 @@ internal class BarnardController(
             emitDebug("info", "advertise_started", null)
         }
     }
+
+    // MARK: - Scan Callback
 
     private var scanCallback: ScanCallback? = null
 
@@ -474,27 +698,42 @@ internal class BarnardController(
         val device = result.device ?: return
         val address = device.address ?: return
         if (!isBarnardScanResult(result)) {
-            val debugData = Arguments.createMap()
-            debugData.putString("address", address)
-            result.scanRecord?.deviceName?.let { debugData.putString("name", it) }
-            debugData.putBoolean("hasService", result.scanRecord?.serviceUuids?.any { it.uuid == serviceUuid } == true)
-            debugData.putBoolean("isConnectable", isConnectableResult(result))
-            emitDebug("trace", "scan_ignored", debugData)
+            emitDebug(
+                "trace",
+                "scan_ignored",
+                mapOf(
+                    "address" to address,
+                    "name" to result.scanRecord?.deviceName,
+                    "hasService" to (result.scanRecord?.serviceUuids?.any { it.uuid == serviceUuid } == true),
+                    "isConnectable" to isConnectableResult(result)
+                )
+            )
             return
         }
+
         val nowMs = System.currentTimeMillis()
         if (!allowDuplicates) {
             val last = discoveredAt[address]
             if (last != null && nowMs - last < 2_000) return
         }
+
         discoveredRssi[address] = result.rssi
         discoveredAt[address] = nowMs
+        if (isDebugBuild()) {
+            result.scanRecord?.deviceName?.let { name ->
+                if (name.isNotEmpty()) lastDiscoveryNameById[address] = name
+            }
+        }
 
-        val debugData = Arguments.createMap()
-        debugData.putString("id", address)
-        debugData.putInt("rssi", result.rssi)
-        result.scanRecord?.deviceName?.let { debugData.putString("name", it) }
-        emitDebug("trace", "ble_discovery_result", debugData)
+        emitDebug(
+            "trace",
+            "ble_discovery_result",
+            mapOf(
+                "id" to address,
+                "rssi" to result.rssi,
+                "name" to result.scanRecord?.deviceName
+            )
+        )
 
         enqueueConnect(device)
     }
@@ -504,11 +743,12 @@ internal class BarnardController(
         val uuids = record.serviceUuids
         val hasService = uuids?.any { it.uuid == serviceUuid } == true
         val name = record.deviceName
-        val isBnrd = name == "BNRD"
-        Log.d(TAG, "isBarnardScanResult: addr=${result.device?.address} name=$name hasService=$hasService isBnrd=$isBnrd uuids=$uuids")
-        // 1. Service UUID match (reliable for Android-to-Android).
+        val isBnrd = name == "BNRD" || (isDebugBuild() && name?.startsWith("BND-") == true)
+        Log.d(
+            TAG,
+            "isBarnardScanResult: addr=${result.device?.address} name=$name hasService=$hasService isBnrd=$isBnrd uuids=$uuids"
+        )
         if (hasService) return true
-        // 2. Local Name fallback for iOS foreground advertise.
         if (isBnrd) return true
         return false
     }
@@ -521,16 +761,15 @@ internal class BarnardController(
         }
     }
 
+    // MARK: - Connection Queue
+
     private fun enqueueConnect(device: BluetoothDevice) {
         val address = device.address ?: return
-        // Skip if already in queue or currently connecting.
         if (connectQueue.any { it.address == address }) return
         if (activeGatt?.device?.address == address) return
 
         if (connectQueue.size >= maxConnectQueue) {
-            val debugData = Arguments.createMap()
-            debugData.putInt("max", maxConnectQueue)
-            emitDebug("warn", "connect_queue_full", debugData)
+            emitDebug("warn", "connect_queue_full", mapOf("max" to maxConnectQueue))
             return
         }
         connectQueue.add(device)
@@ -549,10 +788,16 @@ internal class BarnardController(
             return
         }
         if (!hasConnectPermission()) {
-            emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
+            emitConstraint(
+                "permission_denied",
+                "Missing BLUETOOTH_CONNECT permission",
+                requiredAction = "grant_permission"
+            )
             return
         }
         lastConnectAttemptAtMs[key] = nowMs
+        peripheralReadValues[key] = GattReadValues()
+
         activeGatt =
             if (Build.VERSION.SDK_INT >= 23) {
                 device.connectGatt(appContext, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
@@ -560,10 +805,28 @@ internal class BarnardController(
                 @Suppress("DEPRECATION")
                 device.connectGatt(appContext, false, gattCallback)
             }
-        val debugData = Arguments.createMap()
-        debugData.putString("address", device.address)
-        emitDebug("trace", "connect_attempt", debugData)
+        emitDebug("trace", "connect_attempt", mapOf("address" to device.address))
     }
+
+    // MARK: - GATT Exchange Logic
+
+    private fun shouldExchangeTek(remoteEventCodeHash: ByteArray?): Boolean {
+        if (!isEventMode) return false
+        if (remoteEventCodeHash == null || remoteEventCodeHash.isEmpty()) return false
+
+        val myHash = getEventCodeHash()
+        return myHash.contentEquals(remoteEventCodeHash)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun finishConnection(gatt: BluetoothGatt) {
+        val address = gatt.device?.address ?: ""
+        peripheralReadValues.remove(address)
+        lastDiscoveryNameById.remove(address)
+        gatt.disconnect()
+    }
+
+    // MARK: - GATT Client Callback
 
     private val gattCallback = object : BluetoothGattCallback() {
         @SuppressLint("MissingPermission")
@@ -571,52 +834,60 @@ internal class BarnardController(
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 emitError("connect_failed", "status=$status", recoverable = true)
                 gatt.close()
+                val address = gatt.device?.address ?: ""
+                peripheralReadValues.remove(address)
+                lastDiscoveryNameById.remove(address)
                 activeGatt = null
                 pumpConnectQueue()
                 return
             }
             if (newState == BluetoothProfile.STATE_CONNECTED) {
-                val debugData = Arguments.createMap()
-                debugData.putString("address", gatt.device.address)
-                emitDebug("trace", "connected", debugData)
+                emitDebug("trace", "connected", mapOf("address" to gatt.device.address))
                 gatt.discoverServices()
             } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                val address = gatt.device?.address ?: ""
+                peripheralReadValues.remove(address)
+                lastDiscoveryNameById.remove(address)
                 gatt.close()
                 activeGatt = null
                 pumpConnectQueue()
             }
         }
 
+        @SuppressLint("MissingPermission")
         override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 emitError("service_discovery_failed", "status=$status", recoverable = true)
-                gatt.disconnect()
+                finishConnection(gatt)
                 return
             }
             val svc = gatt.getService(serviceUuid)
             if (svc == null) {
                 emitError("service_not_found", "Barnard service not found", recoverable = true)
-                gatt.disconnect()
+                finishConnection(gatt)
                 return
             }
-            val ch = svc.getCharacteristic(rpidCharUuid)
-            if (ch == null) {
-                emitError("characteristic_not_found", "RPID characteristic not found", recoverable = true)
-                gatt.disconnect()
-                return
+
+            val eventCodeHashCh = svc.getCharacteristic(eventCodeHashCharUuid)
+            if (eventCodeHashCh != null && hasConnectPermission()) {
+                gatt.readCharacteristic(eventCodeHashCh)
+            } else {
+                val rpidCh = svc.getCharacteristic(rpidCharUuid)
+                if (rpidCh != null && hasConnectPermission()) {
+                    gatt.readCharacteristic(rpidCh)
+                } else {
+                    finishConnection(gatt)
+                }
             }
-            if (!hasConnectPermission()) {
-                emitConstraint("permission_denied", "Missing BLUETOOTH_CONNECT permission", requiredAction = "grant_permission")
-                gatt.disconnect()
-                return
-            }
-            @SuppressLint("MissingPermission")
-            gatt.readCharacteristic(ch)
         }
 
-        override fun onCharacteristicRead(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic, status: Int) {
+        override fun onCharacteristicRead(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            status: Int
+        ) {
             val value = characteristic.value ?: ByteArray(0)
-            handleRead(gatt, status, value)
+            handleCharacteristicRead(gatt, characteristic.uuid, status, value)
         }
 
         override fun onCharacteristicRead(
@@ -625,22 +896,143 @@ internal class BarnardController(
             value: ByteArray,
             status: Int
         ) {
-            handleRead(gatt, status, value)
+            handleCharacteristicRead(gatt, characteristic.uuid, status, value)
         }
 
-        private fun handleRead(gatt: BluetoothGatt, status: Int, value: ByteArray) {
-            if (status != BluetoothGatt.GATT_SUCCESS) {
-                emitError("read_failed", "status=$status", recoverable = true)
-                gatt.disconnect()
+        @SuppressLint("MissingPermission")
+        private fun handleCharacteristicRead(gatt: BluetoothGatt, uuid: UUID, status: Int, value: ByteArray) {
+            val address = gatt.device?.address ?: ""
+            val svc = gatt.getService(serviceUuid) ?: run {
+                finishConnection(gatt)
                 return
             }
-            val address = gatt.device.address ?: ""
-            val rssi = discoveredRssi[address] ?: 0
-            val ts = discoveredAt[address] ?: System.currentTimeMillis()
-            emitDetection(ts, rssi, value)
-            gatt.disconnect()
+
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                emitError("read_failed", "status=$status uuid=$uuid", recoverable = true)
+                finishConnection(gatt)
+                return
+            }
+
+            when (uuid) {
+                eventCodeHashCharUuid -> {
+                    peripheralReadValues[address]?.eventCodeHash = value
+                    emitDebug(
+                        "trace",
+                        "gatt_read_event_code_hash",
+                        mapOf(
+                            "address" to address,
+                            "bytes" to value.size,
+                            "isEmpty" to value.isEmpty()
+                        )
+                    )
+                    val rpidCh = svc.getCharacteristic(rpidCharUuid)
+                    if (rpidCh != null && hasConnectPermission()) {
+                        gatt.readCharacteristic(rpidCh)
+                    } else {
+                        finishConnection(gatt)
+                    }
+                }
+
+                rpidCharUuid -> {
+                    peripheralReadValues[address]?.rpid = value
+                    emitDebug(
+                        "trace",
+                        "gatt_read_rpid",
+                        mapOf(
+                            "address" to address,
+                            "bytes" to value.size
+                        )
+                    )
+                    val remoteHash = peripheralReadValues[address]?.eventCodeHash
+                    if (shouldExchangeTek(remoteHash)) {
+                        val tekCh = svc.getCharacteristic(tekCharUuid)
+                        if (tekCh != null && hasConnectPermission()) {
+                            gatt.readCharacteristic(tekCh)
+                        } else {
+                            completeGattExchange(gatt)
+                        }
+                    } else {
+                        completeGattExchange(gatt)
+                    }
+                }
+
+                tekCharUuid -> {
+                    peripheralReadValues[address]?.tek = value
+                    emitDebug(
+                        "trace",
+                        "gatt_read_tek",
+                        mapOf(
+                            "address" to address,
+                            "bytes" to value.size
+                        )
+                    )
+                    val remoteHash = peripheralReadValues[address]?.eventCodeHash
+                    if (value.size == 16 && remoteHash != null && remoteHash.size == 8) {
+                        val entry = TekEntry(
+                            tek = value,
+                            eventCodeHash = remoteHash,
+                            exchangedAt = System.currentTimeMillis(),
+                            lastSeenAt = System.currentTimeMillis()
+                        )
+                        tekStorage.store(entry)
+                        emitDebug("info", "tek_received", mapOf("displayId" to BarnardCrypto.displayId(value)))
+                    }
+                    val tekCh = svc.getCharacteristic(tekCharUuid)
+                    if (tekCh != null && hasConnectPermission()) {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            gatt.writeCharacteristic(
+                                tekCh,
+                                currentTek,
+                                BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+                            )
+                        } else {
+                            tekCh.value = currentTek
+                            gatt.writeCharacteristic(tekCh)
+                        }
+                    } else {
+                        completeGattExchange(gatt)
+                    }
+                }
+            }
+        }
+
+        @SuppressLint("MissingPermission")
+        override fun onCharacteristicWrite(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            status: Int
+        ) {
+            if (status != BluetoothGatt.GATT_SUCCESS) {
+                emitError("write_failed", "status=$status", recoverable = true)
+            } else {
+                emitDebug(
+                    "trace",
+                    "gatt_write_tek",
+                    mapOf(
+                        "address" to (gatt.device?.address ?: ""),
+                        "displayId" to BarnardCrypto.displayId(currentTek)
+                    )
+                )
+            }
+            completeGattExchange(gatt)
+        }
+
+        private fun completeGattExchange(gatt: BluetoothGatt) {
+            val address = gatt.device?.address ?: ""
+            val values = peripheralReadValues[address]
+
+            val rpidData = values?.rpid
+            if (rpidData != null) {
+                val rssi = discoveredRssi[address] ?: 0
+                val ts = discoveredAt[address] ?: System.currentTimeMillis()
+                emitDetection(ts, rssi, rpidData, values?.tek, lastDiscoveryNameById[address])
+            }
+
+            finishConnection(gatt)
         }
     }
+
+    // MARK: - GATT Server Callback
 
     private val gattServerCallback = object : BluetoothGattServerCallback() {
         @SuppressLint("MissingPermission")
@@ -651,23 +1043,181 @@ internal class BarnardController(
             characteristic: BluetoothGattCharacteristic
         ) {
             val server = gattServer ?: return
-            val payload = computePayload(System.currentTimeMillis())
-            val slice =
-                if (offset <= 0) payload
-                else if (offset >= payload.size) ByteArray(0)
-                else payload.copyOfRange(offset, payload.size)
-            server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
-            
-            val debugData = Arguments.createMap()
-            debugData.putInt("bytes", payload.size)
-            debugData.putInt("formatVersion", payload[0].toInt() and 0xFF)
-            debugData.putString("displayId", displayIdForPayload(payload))
-            emitDebug("trace", "gatt_read_rpid", debugData)
+
+            when (characteristic.uuid) {
+                rpidCharUuid -> {
+                    val payload = computePayload(System.currentTimeMillis())
+                    val slice =
+                        if (offset <= 0) payload
+                        else if (offset >= payload.size) ByteArray(0)
+                        else payload.copyOfRange(offset, payload.size)
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+                    emitDebug(
+                        "trace",
+                        "gatt_read_rpid",
+                        mapOf(
+                            "bytes" to payload.size,
+                            "formatVersion" to (payload[0].toInt() and 0xFF),
+                            "displayId" to displayIdForPayload(payload)
+                        )
+                    )
+                }
+
+                tekCharUuid -> {
+                    if (isEventMode) {
+                        val slice =
+                            if (offset <= 0) currentTek
+                            else if (offset >= currentTek.size) ByteArray(0)
+                            else currentTek.copyOfRange(offset, currentTek.size)
+                        server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+                        emitDebug(
+                            "trace",
+                            "gatt_respond_tek_read",
+                            mapOf("displayId" to BarnardCrypto.displayId(currentTek))
+                        )
+                    } else {
+                        server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+                        emitDebug(
+                            "trace",
+                            "gatt_reject_tek_read",
+                            mapOf("reason" to "anonymous_mode")
+                        )
+                    }
+                }
+
+                eventCodeHashCharUuid -> {
+                    val hash = getEventCodeHash()
+                    val slice =
+                        if (offset <= 0) hash
+                        else if (offset >= hash.size) ByteArray(0)
+                        else hash.copyOfRange(offset, hash.size)
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+                    emitDebug(
+                        "trace",
+                        "gatt_respond_event_code_hash",
+                        mapOf(
+                            "bytes" to hash.size,
+                            "isEmpty" to hash.isEmpty()
+                        )
+                    )
+                }
+
+                else -> {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED, offset, null)
+                }
+            }
+        }
+
+        @SuppressLint("MissingPermission")
+        override fun onCharacteristicWriteRequest(
+            device: BluetoothDevice,
+            requestId: Int,
+            characteristic: BluetoothGattCharacteristic,
+            preparedWrite: Boolean,
+            responseNeeded: Boolean,
+            offset: Int,
+            value: ByteArray?
+        ) {
+            val server = gattServer ?: return
+
+            if (characteristic.uuid != tekCharUuid) {
+                if (responseNeeded) {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+                }
+                return
+            }
+
+            if (value == null || value.size != 16) {
+                if (responseNeeded) {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_ATTRIBUTE_LENGTH, offset, null)
+                }
+                return
+            }
+
+            if (!isEventMode) {
+                if (responseNeeded) {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_WRITE_NOT_PERMITTED, offset, null)
+                }
+                emitDebug("trace", "gatt_reject_tek_write", mapOf("reason" to "anonymous_mode"))
+                return
+            }
+
+            val eventCodeHash = getEventCodeHash()
+            val entry = TekEntry(
+                tek = value,
+                eventCodeHash = eventCodeHash,
+                exchangedAt = System.currentTimeMillis(),
+                lastSeenAt = System.currentTimeMillis()
+            )
+            tekStorage.store(entry)
+
+            if (responseNeeded) {
+                server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, null)
+            }
+            emitDebug(
+                "info",
+                "tek_received_via_write",
+                mapOf("displayId" to BarnardCrypto.displayId(value))
+            )
         }
     }
 
     private fun displayIdForPayload(payload: ByteArray): String {
         if (payload.size < 5) return ""
         return payload.copyOfRange(1, 5).joinToString("") { b -> "%02x".format(b) }
+    }
+
+    private fun toWritableMap(map: Map<*, *>): WritableMap {
+        val out = Arguments.createMap()
+        map.forEach { (k, v) ->
+            putDynamic(out, k?.toString() ?: return@forEach, v)
+        }
+        return out
+    }
+
+    private fun toWritableArray(list: List<*>): WritableArray {
+        val out = Arguments.createArray()
+        list.forEach { value ->
+            when (value) {
+                null -> out.pushNull()
+                is String -> out.pushString(value)
+                is Boolean -> out.pushBoolean(value)
+                is Int -> out.pushInt(value)
+                is Long -> {
+                    if (value in Int.MIN_VALUE..Int.MAX_VALUE) {
+                        out.pushInt(value.toInt())
+                    } else {
+                        out.pushDouble(value.toDouble())
+                    }
+                }
+                is Float -> out.pushDouble(value.toDouble())
+                is Double -> out.pushDouble(value)
+                is Map<*, *> -> out.pushMap(toWritableMap(value))
+                is List<*> -> out.pushArray(toWritableArray(value))
+                else -> out.pushString(value.toString())
+            }
+        }
+        return out
+    }
+
+    private fun putDynamic(map: WritableMap, key: String, value: Any?) {
+        when (value) {
+            null -> map.putNull(key)
+            is String -> map.putString(key, value)
+            is Boolean -> map.putBoolean(key, value)
+            is Int -> map.putInt(key, value)
+            is Long -> {
+                if (value in Int.MIN_VALUE..Int.MAX_VALUE) {
+                    map.putInt(key, value.toInt())
+                } else {
+                    map.putDouble(key, value.toDouble())
+                }
+            }
+            is Float -> map.putDouble(key, value.toDouble())
+            is Double -> map.putDouble(key, value)
+            is Map<*, *> -> map.putMap(key, toWritableMap(value))
+            is List<*> -> map.putArray(key, toWritableArray(value))
+            else -> map.putString(key, value.toString())
+        }
     }
 }

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
@@ -1,0 +1,215 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.MessageDigest
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * GAEN v1.2-compatible cryptographic utilities for Resolvable ID.
+ *
+ * Key derivation chain:
+ * ```
+ * DeviceSecret (32 bytes)
+ *      |
+ *      +-- Anonymous Mode: TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)
+ *      |
+ *      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
+ *                           |
+ *                           v
+ *                      RPIK = HKDF(TEK, "EN-RPIK", 16)
+ *                           |
+ *                           v
+ *                      RPI = AES128-ECB(RPIK, PaddedData)
+ * ```
+ */
+object BarnardCrypto {
+
+    // MARK: - TEK Derivation
+
+    /**
+     * Derive TEK for Event Mode from DeviceSecret and EventCode.
+     *
+     * `TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`
+     */
+    fun deriveTekForEvent(deviceSecret: ByteArray, eventCode: String): ByteArray {
+        val eventCodeBytes = eventCode.toByteArray(Charsets.UTF_8)
+        val combined = deviceSecret + eventCodeBytes
+        return hkdfSha256(combined, "barnard-tek".toByteArray(Charsets.UTF_8), 16)
+    }
+
+    /**
+     * Derive TEK for Anonymous Mode from DeviceSecret.
+     *
+     * `TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)`
+     */
+    fun deriveTekForAnonymous(deviceSecret: ByteArray): ByteArray {
+        return hkdfSha256(deviceSecret, "barnard-tek-anonymous".toByteArray(Charsets.UTF_8), 16)
+    }
+
+    // MARK: - RPIK Derivation
+
+    /**
+     * Derive RPIK (Rolling Proximity Identifier Key) from TEK.
+     *
+     * `RPIK = HKDF(TEK, "EN-RPIK", 16)`
+     */
+    fun deriveRpik(tek: ByteArray): ByteArray {
+        if (tek.size != 16) return ByteArray(16)
+        return hkdfSha256(tek, "EN-RPIK".toByteArray(Charsets.UTF_8), 16)
+    }
+
+    // MARK: - RPI Generation
+
+    /**
+     * Generate RPI from RPIK and ENIN.
+     *
+     * `RPI = AES128-ECB(RPIK, PaddedData)`
+     *
+     * Where PaddedData = "EN-RPI" (6 bytes) + 0x000000000000 (6 bytes) + ENIN (4 bytes big-endian)
+     */
+    fun generateRpi(rpik: ByteArray, enin: UInt): ByteArray {
+        if (rpik.size != 16) return ByteArray(16)
+
+        // Build PaddedData: "EN-RPI" + 6 zero bytes + ENIN (4 bytes big-endian)
+        val paddedData = ByteArray(16)
+
+        // "EN-RPI" (6 bytes)
+        val prefix = "EN-RPI".toByteArray(Charsets.UTF_8)
+        System.arraycopy(prefix, 0, paddedData, 0, 6)
+
+        // 6 zero bytes (already initialized to 0)
+
+        // ENIN as 4 bytes big-endian at offset 12
+        val eninBytes = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(enin.toInt()).array()
+        System.arraycopy(eninBytes, 0, paddedData, 12, 4)
+
+        // AES-128-ECB encryption
+        return aes128EcbEncrypt(rpik, paddedData)
+    }
+
+    /**
+     * AES-128-ECB encryption of a single 16-byte block.
+     */
+    private fun aes128EcbEncrypt(key: ByteArray, plaintext: ByteArray): ByteArray {
+        if (key.size != 16 || plaintext.size != 16) return ByteArray(16)
+
+        return try {
+            val cipher = Cipher.getInstance("AES/ECB/NoPadding")
+            cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"))
+            cipher.doFinal(plaintext)
+        } catch (e: Exception) {
+            ByteArray(16)
+        }
+    }
+
+    // MARK: - ENIN Calculation
+
+    /**
+     * Calculate ENIN (EN Interval Number) for a given timestamp.
+     *
+     * `ENIN = floor(unix_timestamp_seconds / 600)`
+     *
+     * Each ENIN represents a 10-minute interval.
+     */
+    fun calculateEnin(timestampMs: Long = System.currentTimeMillis()): UInt {
+        return ((timestampMs / 1000) / 600).toUInt()
+    }
+
+    // MARK: - EventCodeHash
+
+    /**
+     * Calculate EventCodeHash from EventCode.
+     *
+     * `EventCodeHash = SHA256(EventCode)[0:8]`
+     */
+    fun computeEventCodeHash(eventCode: String): ByteArray {
+        val eventCodeBytes = eventCode.toByteArray(Charsets.UTF_8)
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash = digest.digest(eventCodeBytes)
+        return hash.copyOfRange(0, 8)
+    }
+
+    // MARK: - RPI Resolution
+
+    /**
+     * Attempt to resolve an RPI to a known TEK.
+     *
+     * Searches within a time window around the current ENIN (±6 past + 1 future).
+     *
+     * @param rpi The 16-byte RPI to resolve
+     * @param knownTeks List of known TEKs to search
+     * @param currentEnin Current ENIN (defaults to now)
+     * @return The matching TEK if found, null otherwise
+     */
+    fun resolveRpi(rpi: ByteArray, knownTeks: List<ByteArray>, currentEnin: UInt? = null): ByteArray? {
+        if (rpi.size != 16) return null
+
+        val enin = currentEnin ?: calculateEnin()
+
+        for (tek in knownTeks) {
+            if (tek.size != 16) continue
+
+            val rpik = deriveRpik(tek)
+
+            // Search window: 6 intervals past + current + 1 future
+            for (offset in -6..1) {
+                val testEnin = (enin.toInt() + offset).toUInt()
+                val candidate = generateRpi(rpik, testEnin)
+
+                if (candidate.contentEquals(rpi)) {
+                    return tek
+                }
+            }
+        }
+
+        return null
+    }
+
+    // MARK: - Display ID
+
+    /**
+     * Get displayId from TEK (first 3 bytes as lowercase hex).
+     */
+    fun displayId(tek: ByteArray): String {
+        return tek.take(3).joinToString("") { "%02x".format(it) }
+    }
+
+    // MARK: - HKDF
+
+    /**
+     * HKDF-SHA256 key derivation (simplified: no salt, extract-then-expand).
+     */
+    private fun hkdfSha256(ikm: ByteArray, info: ByteArray, outputLength: Int): ByteArray {
+        // Extract: PRK = HMAC-SHA256(salt=zeros, IKM)
+        val salt = ByteArray(32) // All zeros
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(salt, "HmacSHA256"))
+        val prk = mac.doFinal(ikm)
+
+        // Expand: OKM = HMAC-SHA256(PRK, info || 0x01)
+        mac.init(SecretKeySpec(prk, "HmacSHA256"))
+        mac.update(info)
+        mac.update(0x01.toByte())
+        val okm = mac.doFinal()
+
+        return okm.copyOfRange(0, outputLength)
+    }
+
+    // MARK: - Random Bytes
+
+    /**
+     * Generate cryptographically secure random bytes.
+     */
+    fun generateRandomBytes(count: Int): ByteArray {
+        val bytes = ByteArray(count)
+        SecureRandom().nextBytes(bytes)
+        return bytes
+    }
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIso8601.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIso8601.kt
@@ -1,0 +1,16 @@
+package network.greeting.barnard
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+internal object BarnardIso8601 {
+    fun now(): String = fromMs(System.currentTimeMillis())
+
+    fun fromMs(ms: Long): String {
+        val fmt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+        fmt.timeZone = TimeZone.getTimeZone("UTC")
+        return fmt.format(Date(ms))
+    }
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
@@ -40,6 +40,18 @@ class BarnardModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         return "Barnard"
     }
 
+    // Required by RN's NativeEventEmitter contract. No-ops here — actual
+    // subscription lifecycle is handled by React Native core; we only need
+    // these to silence "new NativeEventEmitter() with no addListener method"
+    // warnings on the JS side.
+    @ReactMethod
+    fun addListener(eventName: String) {
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+    }
+
     @ReactMethod
     fun getCapabilities(promise: Promise) {
         try {

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
@@ -1,0 +1,303 @@
+package network.greeting.barnard
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
+
+class BarnardModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+    private var controller: BarnardController? = null
+
+    init {
+        setupController(reactContext)
+    }
+
+    private fun setupController(context: ReactApplicationContext) {
+        val ctrl = BarnardController(context.applicationContext)
+        
+        ctrl.onEvent = { eventName, payload ->
+            sendEvent(context, eventName, payload)
+        }
+        
+        ctrl.onDebugEvent = { eventName, payload ->
+            sendEvent(context, eventName, payload)
+        }
+        
+        controller = ctrl
+    }
+
+    private fun sendEvent(context: ReactApplicationContext, eventName: String, params: WritableMap) {
+        context
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit(eventName, params)
+    }
+
+    override fun getName(): String {
+        return "Barnard"
+    }
+
+    @ReactMethod
+    fun getCapabilities(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            promise.resolve(ctrl.getCapabilities())
+        } catch (e: Exception) {
+            promise.reject("E_GET_CAPABILITIES", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun getState(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            promise.resolve(ctrl.getState())
+        } catch (e: Exception) {
+            promise.reject("E_GET_STATE", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun getEventMode(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            promise.resolve(ctrl.getEventMode())
+        } catch (e: Exception) {
+            promise.reject("E_GET_EVENT_MODE", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun startScan(config: ReadableMap?, promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            val allowDuplicates = if (config?.hasKey("allowDuplicates") == true) {
+                config.getBoolean("allowDuplicates")
+            } else {
+                true
+            }
+            ctrl.startScan(allowDuplicates)
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_START_SCAN", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun stopScan(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            ctrl.stopScan()
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_STOP_SCAN", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun startAdvertise(config: ReadableMap?, promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            val formatVersion = if (config?.hasKey("formatVersion") == true) {
+                config.getInt("formatVersion")
+            } else {
+                1
+            }
+            ctrl.startAdvertise(formatVersion)
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_START_ADVERTISE", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun stopAdvertise(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            ctrl.stopAdvertise()
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_STOP_ADVERTISE", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun startAuto(config: ReadableMap?, promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            
+            var allowDuplicates = true
+            var formatVersion = 1
+            
+            if (config?.hasKey("scan") == true) {
+                val scan = config.getMap("scan")
+                if (scan?.hasKey("allowDuplicates") == true) {
+                    allowDuplicates = scan.getBoolean("allowDuplicates")
+                }
+            }
+            
+            if (config?.hasKey("advertise") == true) {
+                val advertise = config.getMap("advertise")
+                if (advertise?.hasKey("formatVersion") == true) {
+                    formatVersion = advertise.getInt("formatVersion")
+                }
+            }
+            
+            val wasScanning = ctrl.getState().getBoolean("isScanning")
+            val wasAdvertising = ctrl.getState().getBoolean("isAdvertising")
+            
+            ctrl.startScan(allowDuplicates)
+            ctrl.startAdvertise(formatVersion)
+            
+            val nowScanning = ctrl.getState().getBoolean("isScanning")
+            val nowAdvertising = ctrl.getState().getBoolean("isAdvertising")
+            
+            val result = Arguments.createMap()
+            result.putBoolean("scanningStarted", !wasScanning && nowScanning)
+            result.putBoolean("advertisingStarted", !wasAdvertising && nowAdvertising)
+            result.putArray("issues", Arguments.createArray())
+            
+            promise.resolve(result)
+        } catch (e: Exception) {
+            promise.reject("E_START_AUTO", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun stopAuto(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            ctrl.stopScan()
+            ctrl.stopAdvertise()
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_STOP_AUTO", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun joinEvent(eventCode: String?, promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            if (eventCode.isNullOrBlank()) {
+                promise.reject("E_INVALID_ARGUMENT", "eventCode required")
+                return
+            }
+            ctrl.joinEvent(eventCode)
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_JOIN_EVENT", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun leaveEvent(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            ctrl.leaveEvent()
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_LEAVE_EVENT", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun getExchangedTeks(eventCode: String?, promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            if (eventCode.isNullOrBlank()) {
+                promise.reject("E_INVALID_ARGUMENT", "eventCode required")
+                return
+            }
+            promise.resolve(ctrl.getExchangedTeks(eventCode))
+        } catch (e: Exception) {
+            promise.reject("E_GET_EXCHANGED_TEKS", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun clearTeksForEvent(eventCode: String?, promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            if (eventCode.isNullOrBlank()) {
+                promise.reject("E_INVALID_ARGUMENT", "eventCode required")
+                return
+            }
+            promise.resolve(ctrl.clearTeksForEvent(eventCode))
+        } catch (e: Exception) {
+            promise.reject("E_CLEAR_TEKS_FOR_EVENT", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun clearAllTeks(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            promise.resolve(ctrl.clearAllTeks())
+        } catch (e: Exception) {
+            promise.reject("E_CLEAR_ALL_TEKS", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun dispose(promise: Promise) {
+        try {
+            controller?.dispose()
+            controller = null
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_DISPOSE", e.message, e)
+        }
+    }
+
+    override fun onCatalystInstanceDestroy() {
+        super.onCatalystInstanceDestroy()
+        controller?.dispose()
+        controller = null
+    }
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPackage.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPackage.kt
@@ -1,0 +1,16 @@
+package network.greeting.barnard
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class BarnardPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+        return listOf(BarnardModule(reactContext))
+    }
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+        return emptyList()
+    }
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardTekStorage.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardTekStorage.kt
@@ -1,0 +1,231 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * A stored TEK entry from GATT exchange.
+ */
+data class TekEntry(
+    /** The 16-byte TEK. */
+    val tek: ByteArray,
+    /** The 8-byte EventCodeHash (SHA256(EventCode)[0:8]). */
+    val eventCodeHash: ByteArray,
+    /** When the TEK was first exchanged (epoch millis). */
+    val exchangedAt: Long,
+    /** When the TEK holder was last seen (epoch millis). */
+    var lastSeenAt: Long
+) {
+    /** Display ID: first 3 bytes of TEK as lowercase hex. */
+    val displayId: String
+        get() = BarnardCrypto.displayId(tek)
+
+    /** Convert to JSON for storage. */
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("tek", Base64.encodeToString(tek, Base64.NO_WRAP))
+        put("eventCodeHash", Base64.encodeToString(eventCodeHash, Base64.NO_WRAP))
+        put("exchangedAt", exchangedAt)
+        put("lastSeenAt", lastSeenAt)
+    }
+
+    /** Convert to platform channel map. */
+    fun toMap(): Map<String, Any?> = mapOf(
+        "tek" to Base64.encodeToString(tek, Base64.NO_WRAP),
+        "eventCodeHash" to Base64.encodeToString(eventCodeHash, Base64.NO_WRAP),
+        "exchangedAt" to BarnardIso8601.fromMs(exchangedAt),
+        "lastSeenAt" to BarnardIso8601.fromMs(lastSeenAt),
+        "displayId" to displayId
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TekEntry) return false
+        return tek.contentEquals(other.tek)
+    }
+
+    override fun hashCode(): Int = tek.contentHashCode()
+
+    companion object {
+        /** Create from JSON. */
+        fun fromJson(json: JSONObject): TekEntry? {
+            return try {
+                TekEntry(
+                    tek = Base64.decode(json.getString("tek"), Base64.DEFAULT),
+                    eventCodeHash = Base64.decode(json.getString("eventCodeHash"), Base64.DEFAULT),
+                    exchangedAt = json.getLong("exchangedAt"),
+                    lastSeenAt = json.getLong("lastSeenAt")
+                )
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+}
+
+/**
+ * TEK storage configuration.
+ */
+data class TekStorageConfig(
+    /** TTL in milliseconds (default 24 hours). */
+    val ttlMs: Long = 86400_000L,
+    /** Maximum number of stored entries (default 1000). */
+    val maxEntries: Int = 1000
+)
+
+/**
+ * Persistent storage for exchanged TEKs.
+ *
+ * Storage is organized by EventCodeHash (base64), with bounded size and TTL.
+ */
+class BarnardTekStorage(
+    private val context: Context,
+    private val config: TekStorageConfig = TekStorageConfig()
+) {
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("barnard_tek_storage", Context.MODE_PRIVATE)
+
+    private val keyPrefix = "teks_"
+
+    // MARK: - Public API
+
+    /**
+     * Store a TEK entry for a given event code hash.
+     */
+    fun store(entry: TekEntry) {
+        val key = storageKey(entry.eventCodeHash)
+        val entries = loadEntries(key).toMutableList()
+
+        // Check if we already have this TEK
+        val existingIndex = entries.indexOfFirst { it.tek.contentEquals(entry.tek) }
+        if (existingIndex >= 0) {
+            // Update lastSeenAt
+            entries[existingIndex].lastSeenAt = entry.lastSeenAt
+        } else {
+            entries.add(entry)
+        }
+
+        // Evict expired entries
+        val now = System.currentTimeMillis()
+        val validEntries = entries.filter { now - it.lastSeenAt < config.ttlMs }.toMutableList()
+
+        // LRU eviction if over capacity
+        if (validEntries.size > config.maxEntries) {
+            validEntries.sortBy { it.lastSeenAt }
+            validEntries.subList(0, validEntries.size - config.maxEntries).clear()
+        }
+
+        saveEntries(validEntries, key)
+    }
+
+    /**
+     * Get all TEK entries for a given event code hash.
+     */
+    fun getEntries(eventCodeHash: ByteArray): List<TekEntry> {
+        val key = storageKey(eventCodeHash)
+        val entries = loadEntries(key)
+
+        // Filter expired entries
+        val now = System.currentTimeMillis()
+        val validEntries = entries.filter { now - it.lastSeenAt < config.ttlMs }
+
+        // Save back if we filtered any
+        if (validEntries.size != entries.size) {
+            saveEntries(validEntries, key)
+        }
+
+        return validEntries
+    }
+
+    /**
+     * Get all TEKs (as ByteArray) for a given event code hash.
+     */
+    fun getTeks(eventCodeHash: ByteArray): List<ByteArray> {
+        return getEntries(eventCodeHash).map { it.tek }
+    }
+
+    /**
+     * Clear all TEKs for a given event code hash.
+     * @return The number of entries removed.
+     */
+    fun clear(eventCodeHash: ByteArray): Int {
+        val key = storageKey(eventCodeHash)
+        val entries = loadEntries(key)
+        val count = entries.size
+        prefs.edit().remove(key).apply()
+        return count
+    }
+
+    /**
+     * Clear all stored TEKs across all events.
+     * @return The total number of entries removed.
+     */
+    fun clearAll(): Int {
+        var total = 0
+
+        val allKeys = prefs.all.keys.filter { it.startsWith(keyPrefix) }
+        val editor = prefs.edit()
+
+        for (key in allKeys) {
+            val entries = loadEntries(key)
+            total += entries.size
+            editor.remove(key)
+        }
+
+        editor.apply()
+        return total
+    }
+
+    /**
+     * Update lastSeenAt for a TEK if it exists.
+     */
+    fun updateLastSeen(tek: ByteArray, eventCodeHash: ByteArray, at: Long = System.currentTimeMillis()) {
+        val key = storageKey(eventCodeHash)
+        val entries = loadEntries(key).toMutableList()
+
+        val index = entries.indexOfFirst { it.tek.contentEquals(tek) }
+        if (index >= 0) {
+            entries[index].lastSeenAt = at
+            saveEntries(entries, key)
+        }
+    }
+
+    // MARK: - Private
+
+    private fun storageKey(eventCodeHash: ByteArray): String {
+        return keyPrefix + Base64.encodeToString(eventCodeHash, Base64.NO_WRAP)
+    }
+
+    private fun loadEntries(key: String): List<TekEntry> {
+        val jsonString = prefs.getString(key, null) ?: return emptyList()
+
+        return try {
+            val array = JSONArray(jsonString)
+            (0 until array.length()).mapNotNull { i ->
+                TekEntry.fromJson(array.getJSONObject(i))
+            }
+        } catch (e: Exception) {
+            // Corrupted data, clear it
+            prefs.edit().remove(key).apply()
+            emptyList()
+        }
+    }
+
+    private fun saveEntries(entries: List<TekEntry>, key: String) {
+        if (entries.isEmpty()) {
+            prefs.edit().remove(key).apply()
+            return
+        }
+
+        val array = JSONArray()
+        for (entry in entries) {
+            array.put(entry.toJson())
+        }
+        prefs.edit().putString(key, array.toString()).apply()
+    }
+}

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardCryptoTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardCryptoTest.kt
@@ -1,0 +1,87 @@
+package network.greeting.barnard
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BarnardCryptoTest {
+
+    @Test
+    fun deriveTekForEvent_isDeterministic_andDifferentFromAnonymous() {
+        val deviceSecret = ByteArray(32) { it.toByte() }
+
+        val eventTekA = BarnardCrypto.deriveTekForEvent(deviceSecret, "ethglobal")
+        val eventTekB = BarnardCrypto.deriveTekForEvent(deviceSecret, "ethglobal")
+        val anonymousTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret)
+
+        assertEquals(16, eventTekA.size)
+        assertArrayEquals(eventTekA, eventTekB)
+        assertFalse(eventTekA.contentEquals(anonymousTek))
+    }
+
+    @Test
+    fun resolveRpi_returnsMatchingTek_whenRpiIsKnown() {
+        val tekA = ByteArray(16) { (it + 1).toByte() }
+        val tekB = ByteArray(16) { (it + 33).toByte() }
+        val currentEnin = BarnardCrypto.calculateEnin()
+
+        val rpik = BarnardCrypto.deriveRpik(tekB)
+        val rpi = BarnardCrypto.generateRpi(rpik, currentEnin)
+
+        val resolved = BarnardCrypto.resolveRpi(rpi, listOf(tekA, tekB), currentEnin)
+
+        assertNotNull(resolved)
+        assertArrayEquals(tekB, resolved)
+    }
+
+    @Test
+    fun resolveRpi_returnsNull_whenNoTekMatches() {
+        val tekA = ByteArray(16) { (it + 5).toByte() }
+        val tekB = ByteArray(16) { (it + 85).toByte() }
+        val enin = 12345u
+
+        val rpi = BarnardCrypto.generateRpi(BarnardCrypto.deriveRpik(tekA), enin)
+
+        val resolved = BarnardCrypto.resolveRpi(rpi, listOf(tekB), enin)
+
+        assertNull(resolved)
+    }
+
+    @Test
+    fun computeEventCodeHash_isDeterministic_and8Bytes() {
+        val hashA1 = BarnardCrypto.computeEventCodeHash("event-a")
+        val hashA2 = BarnardCrypto.computeEventCodeHash("event-a")
+        val hashB = BarnardCrypto.computeEventCodeHash("event-b")
+
+        assertEquals(8, hashA1.size)
+        assertArrayEquals(hashA1, hashA2)
+        assertFalse(hashA1.contentEquals(hashB))
+    }
+
+    @Test
+    fun displayId_usesFirstThreeBytesAsLowercaseHex() {
+        val tek = byteArrayOf(
+            0xAB.toByte(),
+            0xCD.toByte(),
+            0xEF.toByte(),
+            0x01,
+            0x02,
+            0x03,
+            0x04,
+            0x05,
+            0x06,
+            0x07,
+            0x08,
+            0x09,
+            0x0A,
+            0x0B,
+            0x0C,
+            0x0D
+        )
+
+        assertEquals("abcdef", BarnardCrypto.displayId(tek))
+    }
+}

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardTekStorageTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardTekStorageTest.kt
@@ -1,0 +1,163 @@
+package network.greeting.barnard
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BarnardTekStorageTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("barnard_tek_storage", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    @Test
+    fun store_andGetEntries_returnsStoredTek() {
+        val storage = BarnardTekStorage(context)
+        val now = System.currentTimeMillis()
+        val eventCodeHash = BarnardCrypto.computeEventCodeHash("event-a")
+        val entry = TekEntry(
+            tek = tek(1),
+            eventCodeHash = eventCodeHash,
+            exchangedAt = now,
+            lastSeenAt = now
+        )
+
+        storage.store(entry)
+
+        val entries = storage.getEntries(eventCodeHash)
+        assertEquals(1, entries.size)
+        assertArrayEquals(entry.tek, entries[0].tek)
+        assertEquals(entry.displayId, entries[0].displayId)
+    }
+
+    @Test
+    fun store_sameTek_updatesLastSeen_withoutDuplicate() {
+        val storage = BarnardTekStorage(context)
+        val eventCodeHash = BarnardCrypto.computeEventCodeHash("event-a")
+        val exchangedAt = System.currentTimeMillis() - 10_000
+        val firstSeenAt = exchangedAt
+        val secondSeenAt = exchangedAt + 5_000
+
+        storage.store(
+            TekEntry(
+                tek = tek(7),
+                eventCodeHash = eventCodeHash,
+                exchangedAt = exchangedAt,
+                lastSeenAt = firstSeenAt
+            )
+        )
+
+        storage.store(
+            TekEntry(
+                tek = tek(7),
+                eventCodeHash = eventCodeHash,
+                exchangedAt = exchangedAt,
+                lastSeenAt = secondSeenAt
+            )
+        )
+
+        val entries = storage.getEntries(eventCodeHash)
+        assertEquals(1, entries.size)
+        assertEquals(secondSeenAt, entries[0].lastSeenAt)
+        assertEquals(exchangedAt, entries[0].exchangedAt)
+    }
+
+    @Test
+    fun clear_removesOnlyTargetEvent() {
+        val storage = BarnardTekStorage(context)
+        val hashA = BarnardCrypto.computeEventCodeHash("event-a")
+        val hashB = BarnardCrypto.computeEventCodeHash("event-b")
+        val now = System.currentTimeMillis()
+
+        storage.store(TekEntry(tek(1), hashA, now, now))
+        storage.store(TekEntry(tek(2), hashB, now, now))
+
+        val removed = storage.clear(hashA)
+
+        assertEquals(1, removed)
+        assertEquals(0, storage.getEntries(hashA).size)
+        assertEquals(1, storage.getEntries(hashB).size)
+    }
+
+    @Test
+    fun clearAll_removesEntriesAcrossAllEvents() {
+        val storage = BarnardTekStorage(context)
+        val hashA = BarnardCrypto.computeEventCodeHash("event-a")
+        val hashB = BarnardCrypto.computeEventCodeHash("event-b")
+        val now = System.currentTimeMillis()
+
+        storage.store(TekEntry(tek(1), hashA, now, now))
+        storage.store(TekEntry(tek(2), hashA, now, now))
+        storage.store(TekEntry(tek(3), hashB, now, now))
+
+        val removed = storage.clearAll()
+
+        assertEquals(3, removed)
+        assertEquals(0, storage.getEntries(hashA).size)
+        assertEquals(0, storage.getEntries(hashB).size)
+    }
+
+    @Test
+    fun store_evictsExpiredEntries_byTtl() {
+        val storage = BarnardTekStorage(
+            context,
+            TekStorageConfig(ttlMs = 1, maxEntries = 100)
+        )
+        val hashA = BarnardCrypto.computeEventCodeHash("event-a")
+        val now = System.currentTimeMillis()
+
+        storage.store(
+            TekEntry(
+                tek = tek(1),
+                eventCodeHash = hashA,
+                exchangedAt = now - 10_000,
+                lastSeenAt = now - 10_000
+            )
+        )
+
+        assertEquals(0, storage.getEntries(hashA).size)
+    }
+
+    @Test
+    fun store_evictsLeastRecentlySeen_whenOverCapacity() {
+        val storage = BarnardTekStorage(
+            context,
+            TekStorageConfig(ttlMs = 86_400_000L, maxEntries = 2)
+        )
+        val hashA = BarnardCrypto.computeEventCodeHash("event-a")
+        val base = System.currentTimeMillis()
+
+        val oldTek = tek(11)
+        val midTek = tek(22)
+        val newTek = tek(33)
+
+        storage.store(TekEntry(oldTek, hashA, base, base))
+        storage.store(TekEntry(midTek, hashA, base + 1, base + 1))
+        storage.store(TekEntry(newTek, hashA, base + 2, base + 2))
+
+        val stored = storage.getEntries(hashA)
+
+        assertEquals(2, stored.size)
+        assertFalse(stored.any { it.tek.contentEquals(oldTek) })
+        assertEquals(1, stored.count { it.tek.contentEquals(midTek) })
+        assertEquals(1, stored.count { it.tek.contentEquals(newTek) })
+    }
+
+    private fun tek(seed: Int): ByteArray {
+        return ByteArray(16) { idx -> (seed + idx).toByte() }
+    }
+}

--- a/packages/react-native/barnard/ios/Barnard-Bridging-Header.h
+++ b/packages/react-native/barnard/ios/Barnard-Bridging-Header.h
@@ -1,0 +1,2 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>

--- a/packages/react-native/barnard/ios/Barnard.m
+++ b/packages/react-native/barnard/ios/Barnard.m
@@ -1,0 +1,62 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+@interface RCT_EXTERN_MODULE(Barnard, RCTEventEmitter)
+
+RCT_EXTERN_METHOD(getCapabilities:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getState:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getEventMode:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(startScan:(NSDictionary *)config
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stopScan:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(startAdvertise:(NSDictionary *)config
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stopAdvertise:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(startAuto:(NSDictionary *)config
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(stopAuto:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(joinEvent:(NSString *)eventCode
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(leaveEvent:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getExchangedTeks:(NSString *)eventCode
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(clearTeksForEvent:(NSString *)eventCode
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(clearAllTeks:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(dispose:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+@end

--- a/packages/react-native/barnard/ios/Barnard.swift
+++ b/packages/react-native/barnard/ios/Barnard.swift
@@ -1,0 +1,273 @@
+import Foundation
+import React
+
+@objc(Barnard)
+class Barnard: RCTEventEmitter {
+  private var controller: BarnardBleController?
+  
+  override init() {
+    super.init()
+    setupController()
+  }
+  
+  private func setupController() {
+    let ctrl = BarnardBleController()
+    
+    ctrl.onEvent = { [weak self] eventName, payload in
+      self?.sendEvent(withName: eventName, body: payload)
+    }
+    
+    ctrl.onDebugEvent = { [weak self] eventName, payload in
+      self?.sendEvent(withName: eventName, body: payload)
+    }
+    
+    controller = ctrl
+  }
+  
+  override func supportedEvents() -> [String]! {
+    return [
+      "BarnardDetection",
+      "BarnardState",
+      "BarnardConstraint",
+      "BarnardError",
+      "BarnardDebug"
+    ]
+  }
+  
+  override static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+  
+  @objc
+  func getCapabilities(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    resolve(controller.getCapabilities())
+  }
+  
+  @objc
+  func getState(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    resolve(controller.getState())
+  }
+
+  @objc
+  func getEventMode(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    resolve(controller.getEventMode())
+  }
+  
+  @objc
+  func startScan(
+    _ config: NSDictionary?,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    let allowDuplicates = config?["allowDuplicates"] as? Bool ?? true
+    controller.startScan(allowDuplicates: allowDuplicates)
+    resolve(nil)
+  }
+  
+  @objc
+  func stopScan(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    controller.stopScan()
+    resolve(nil)
+  }
+  
+  @objc
+  func startAdvertise(
+    _ config: NSDictionary?,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    let formatVersion = config?["formatVersion"] as? Int ?? 1
+    controller.startAdvertise(formatVersion: formatVersion)
+    resolve(nil)
+  }
+  
+  @objc
+  func stopAdvertise(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    controller.stopAdvertise()
+    resolve(nil)
+  }
+  
+  @objc
+  func startAuto(
+    _ config: NSDictionary?,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    
+    var allowDuplicates = true
+    var formatVersion = 1
+    
+    if let scan = config?["scan"] as? NSDictionary {
+      allowDuplicates = scan["allowDuplicates"] as? Bool ?? true
+    }
+    
+    if let advertise = config?["advertise"] as? NSDictionary {
+      formatVersion = advertise["formatVersion"] as? Int ?? 1
+    }
+    
+    let wasScanning = controller.getState()["isScanning"] as? Bool ?? false
+    let wasAdvertising = controller.getState()["isAdvertising"] as? Bool ?? false
+    
+    controller.startScan(allowDuplicates: allowDuplicates)
+    controller.startAdvertise(formatVersion: formatVersion)
+    
+    let nowScanning = controller.getState()["isScanning"] as? Bool ?? false
+    let nowAdvertising = controller.getState()["isAdvertising"] as? Bool ?? false
+    
+    let result: [String: Any] = [
+      "scanningStarted": !wasScanning && nowScanning,
+      "advertisingStarted": !wasAdvertising && nowAdvertising,
+      "issues": []
+    ]
+    
+    resolve(result)
+  }
+  
+  @objc
+  func stopAuto(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    controller.stopScan()
+    controller.stopAdvertise()
+    resolve(nil)
+  }
+
+  @objc
+  func joinEvent(
+    _ eventCode: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    guard !eventCode.isEmpty else {
+      reject("E_INVALID_ARGUMENT", "eventCode required", nil)
+      return
+    }
+    controller.joinEvent(eventCode)
+    resolve(nil)
+  }
+
+  @objc
+  func leaveEvent(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    controller.leaveEvent()
+    resolve(nil)
+  }
+
+  @objc
+  func getExchangedTeks(
+    _ eventCode: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    guard !eventCode.isEmpty else {
+      reject("E_INVALID_ARGUMENT", "eventCode required", nil)
+      return
+    }
+    resolve(controller.getExchangedTeks(eventCode: eventCode))
+  }
+
+  @objc
+  func clearTeksForEvent(
+    _ eventCode: String,
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    guard !eventCode.isEmpty else {
+      reject("E_INVALID_ARGUMENT", "eventCode required", nil)
+      return
+    }
+    resolve(controller.clearTeksForEvent(eventCode: eventCode))
+  }
+
+  @objc
+  func clearAllTeks(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    resolve(controller.clearAllTeks())
+  }
+  
+  @objc
+  func dispose(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    controller?.dispose()
+    controller = nil
+    resolve(nil)
+  }
+}

--- a/packages/react-native/barnard/ios/Barnard.swift
+++ b/packages/react-native/barnard/ios/Barnard.swift
@@ -4,26 +4,29 @@ import React
 @objc(Barnard)
 class Barnard: RCTEventEmitter {
   private var controller: BarnardBleController?
-  
+  private var hasListeners = false
+
   override init() {
     super.init()
     setupController()
   }
-  
+
   private func setupController() {
     let ctrl = BarnardBleController()
-    
+
     ctrl.onEvent = { [weak self] eventName, payload in
-      self?.sendEvent(withName: eventName, body: payload)
+      guard let self = self, self.hasListeners else { return }
+      self.sendEvent(withName: eventName, body: payload)
     }
-    
+
     ctrl.onDebugEvent = { [weak self] eventName, payload in
-      self?.sendEvent(withName: eventName, body: payload)
+      guard let self = self, self.hasListeners else { return }
+      self.sendEvent(withName: eventName, body: payload)
     }
-    
+
     controller = ctrl
   }
-  
+
   override func supportedEvents() -> [String]! {
     return [
       "BarnardDetection",
@@ -33,7 +36,15 @@ class Barnard: RCTEventEmitter {
       "BarnardDebug"
     ]
   }
-  
+
+  override func startObserving() {
+    hasListeners = true
+  }
+
+  override func stopObserving() {
+    hasListeners = false
+  }
+
   override static func requiresMainQueueSetup() -> Bool {
     return false
   }

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -1,0 +1,801 @@
+import CoreBluetooth
+import Foundation
+
+final class BarnardBleController: NSObject {
+  private let discoveryServiceUUID = CBUUID(string: "0000B001-0000-1000-8000-00805F9B34FB")
+  private let rpidCharacteristicUUID = CBUUID(string: "0000B002-0000-1000-8000-00805F9B34FB")
+  private let tekCharacteristicUUID = CBUUID(string: "0000B003-0000-1000-8000-00805F9B34FB")
+  private let eventCodeHashCharacteristicUUID = CBUUID(string: "0000B004-0000-1000-8000-00805F9B34FB")
+  private let localName = "BNRD"
+
+  private var debugLocalName: String {
+    #if DEBUG
+    let suffix = debugDeviceSuffix()
+    return "BND-\(suffix)"
+    #else
+    return localName
+    #endif
+  }
+
+  private func debugDeviceSuffix() -> String {
+    let deviceSecret = rpid.getDeviceSecret()
+    let tail = deviceSecret.suffix(2)
+    let hex = tail.map { String(format: "%02x", $0) }.joined().uppercased()
+    return hex.isEmpty ? "DEAD" : hex
+  }
+
+  private let iso8601: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+  }()
+
+  private let rpid = BarnardRpidGenerator()
+  private let tekStorage = BarnardTekStorage()
+
+  private var centralManager: CBCentralManager!
+  private var peripheralManager: CBPeripheralManager!
+
+  private var rpidCharacteristic: CBMutableCharacteristic?
+  private var tekCharacteristic: CBMutableCharacteristic?
+  private var eventCodeHashCharacteristic: CBMutableCharacteristic?
+
+  private var isScanning = false
+  private var isAdvertising = false
+  private var allowDuplicates = true
+  private var formatVersion: UInt8 = 1
+
+  private var lastDiscoveryNameById: [UUID: String] = [:]
+
+  private var discoveredRssi: [UUID: Int] = [:]
+  private var discoveredAt: [UUID: Date] = [:]
+
+  private var connectQueue: [UUID] = []
+  private var peripheralsById: [UUID: CBPeripheral] = [:]
+  private var lastConnectAttemptAt: [UUID: Date] = [:]
+  private var activePeripheral: CBPeripheral?
+
+  private let maxConcurrentConnections = 1
+  private let cooldownPerPeerSeconds: TimeInterval = 10
+  private let maxConnectQueue = 20
+
+  private var peripheralCharacteristics: [UUID: [CBUUID: CBCharacteristic]] = [:]
+  private var peripheralReadValues: [UUID: PeripheralGattValues] = [:]
+
+  private struct PeripheralGattValues {
+    var eventCodeHash: Data?
+    var rpid: Data?
+    var tek: Data?
+  }
+
+  var onEvent: ((String, [String: Any]) -> Void)?
+  var onDebugEvent: ((String, [String: Any]) -> Void)?
+
+  override init() {
+    super.init()
+    centralManager = CBCentralManager(delegate: self, queue: nil)
+    peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
+  }
+
+  func dispose() {
+    stopScan()
+    stopAdvertise()
+    onEvent = nil
+    onDebugEvent = nil
+  }
+
+  func getCapabilities() -> [String: Any] {
+    [
+      "supportedTransports": ["ble"],
+      "supportsConnectionlessRpid": false,
+      "supportsGattFallback": true,
+      "supportsBackground": false,
+      "supportsHighRateRssi": false,
+    ]
+  }
+
+  func getState() -> [String: Any] {
+    [
+      "isScanning": isScanning,
+      "isAdvertising": isAdvertising,
+      "eventMode": rpid.isEventMode ? "event" : "anonymous",
+      "eventCode": rpid.eventCode as Any,
+    ]
+  }
+
+  func getEventMode() -> [String: Any] {
+    [
+      "mode": rpid.isEventMode ? "event" : "anonymous",
+      "eventCode": rpid.eventCode as Any,
+    ]
+  }
+
+  func startScan(allowDuplicates: Bool) {
+    self.allowDuplicates = allowDuplicates
+    guard centralManager.state == .poweredOn else {
+      emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(centralManager.state.rawValue)")
+      return
+    }
+    if isScanning { return }
+    let options: [String: Any] = [CBCentralManagerScanOptionAllowDuplicatesKey: allowDuplicates]
+    centralManager.scanForPeripherals(withServices: [discoveryServiceUUID], options: options)
+    isScanning = true
+    emitState(reasonCode: "scan_start")
+    emitDebug(level: "info", name: "scan_start", data: ["allowDuplicates": allowDuplicates])
+  }
+
+  func stopScan() {
+    if !isScanning { return }
+    centralManager.stopScan()
+    if let active = activePeripheral {
+      centralManager.cancelPeripheralConnection(active)
+    }
+    isScanning = false
+    connectQueue.removeAll()
+    activePeripheral = nil
+
+    discoveredRssi.removeAll()
+    discoveredAt.removeAll()
+    peripheralsById.removeAll()
+    lastConnectAttemptAt.removeAll()
+    peripheralCharacteristics.removeAll()
+    peripheralReadValues.removeAll()
+    lastDiscoveryNameById.removeAll()
+
+    emitState(reasonCode: "scan_stop")
+    emitDebug(level: "info", name: "scan_stop", data: nil)
+  }
+
+  func startAdvertise(formatVersion: Int) {
+    self.formatVersion = UInt8(clamping: formatVersion)
+    guard peripheralManager.state == .poweredOn else {
+      emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(peripheralManager.state.rawValue)")
+      return
+    }
+    if isAdvertising { return }
+    ensureGattService()
+    var ad: [String: Any] = [
+      CBAdvertisementDataServiceUUIDsKey: [discoveryServiceUUID],
+    ]
+    #if DEBUG
+    ad[CBAdvertisementDataLocalNameKey] = debugLocalName
+    #endif
+    peripheralManager.startAdvertising(ad)
+    isAdvertising = true
+    emitState(reasonCode: "advertise_start")
+    emitDebug(level: "info", name: "advertise_start", data: [
+      "formatVersion": Int(formatVersion),
+      "serviceUuid": discoveryServiceUUID.uuidString,
+      "localName": debugLocalName,
+      "eventMode": rpid.isEventMode,
+    ])
+  }
+
+  func stopAdvertise() {
+    if !isAdvertising { return }
+    peripheralManager.stopAdvertising()
+    isAdvertising = false
+    emitState(reasonCode: "advertise_stop")
+    emitDebug(level: "info", name: "advertise_stop", data: nil)
+  }
+
+  func joinEvent(_ eventCode: String) {
+    rpid.joinEvent(eventCode)
+    rebuildGattServiceIfNeeded()
+    emitState(reasonCode: "join_event")
+    emitDebug(level: "info", name: "join_event", data: [
+      "eventCode": eventCode,
+      "displayId": rpid.getCurrentDisplayId(),
+    ])
+  }
+
+  func leaveEvent() {
+    rpid.leaveEvent()
+    rebuildGattServiceIfNeeded()
+    emitState(reasonCode: "leave_event")
+    emitDebug(level: "info", name: "leave_event", data: nil)
+  }
+
+  func getExchangedTeks(eventCode: String) -> [[String: Any]] {
+    let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+    let entries = tekStorage.getEntries(for: eventCodeHash)
+    return entries.map { $0.toDict() }
+  }
+
+  func clearTeksForEvent(eventCode: String) -> Int {
+    let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+    let count = tekStorage.clear(for: eventCodeHash)
+    emitDebug(level: "info", name: "clear_teks_for_event", data: [
+      "eventCode": eventCode,
+      "count": count,
+    ])
+    return count
+  }
+
+  func clearAllTeks() -> Int {
+    let count = tekStorage.clearAll()
+    emitDebug(level: "info", name: "clear_all_teks", data: ["count": count])
+    return count
+  }
+
+  private func ensureGattService() {
+    if rpidCharacteristic != nil { return }
+    buildAndAddGattService()
+  }
+
+  private func rebuildGattServiceIfNeeded() {
+    guard peripheralManager.state == .poweredOn else { return }
+
+    peripheralManager.removeAllServices()
+    rpidCharacteristic = nil
+    tekCharacteristic = nil
+    eventCodeHashCharacteristic = nil
+
+    buildAndAddGattService()
+
+    emitDebug(level: "info", name: "gatt_service_rebuilt", data: [
+      "eventMode": rpid.isEventMode,
+    ])
+  }
+
+  private func buildAndAddGattService() {
+    let rpidCh = CBMutableCharacteristic(
+      type: rpidCharacteristicUUID,
+      properties: [.read],
+      value: nil,
+      permissions: [.readable]
+    )
+
+    let tekCh = CBMutableCharacteristic(
+      type: tekCharacteristicUUID,
+      properties: [.read, .write],
+      value: nil,
+      permissions: [.readable, .writeable]
+    )
+
+    let eventCodeHashCh = CBMutableCharacteristic(
+      type: eventCodeHashCharacteristicUUID,
+      properties: [.read],
+      value: nil,
+      permissions: [.readable]
+    )
+
+    let svc = CBMutableService(type: discoveryServiceUUID, primary: true)
+    svc.characteristics = [rpidCh, tekCh, eventCodeHashCh]
+    peripheralManager.add(svc)
+
+    rpidCharacteristic = rpidCh
+    tekCharacteristic = tekCh
+    eventCodeHashCharacteristic = eventCodeHashCh
+
+    emitDebug(level: "info", name: "gatt_service_added", data: [
+      "characteristics": ["RPID", "TEK", "EventCodeHash"],
+    ])
+  }
+
+  private func enqueueConnect(_ peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    peripheralsById[id] = peripheral
+
+    if connectQueue.contains(id) || (activePeripheral?.identifier == id) { return }
+
+    if connectQueue.count >= maxConnectQueue {
+      emitDebug(level: "warn", name: "connect_queue_full", data: ["max": maxConnectQueue])
+      return
+    }
+
+    connectQueue.append(id)
+    pumpConnectQueue()
+  }
+
+  private func pumpConnectQueue() {
+    if maxConcurrentConnections <= 0 { return }
+    if activePeripheral != nil { return }
+    guard let nextId = connectQueue.first else { return }
+
+    let now = Date()
+    if let last = lastConnectAttemptAt[nextId], now.timeIntervalSince(last) < cooldownPerPeerSeconds {
+      connectQueue.removeFirst()
+      connectQueue.append(nextId)
+      return
+    }
+
+    guard let peripheral = peripheralsById[nextId] else {
+      connectQueue.removeFirst()
+      return
+    }
+
+    connectQueue.removeFirst()
+    activePeripheral = peripheral
+    lastConnectAttemptAt[nextId] = now
+
+    peripheralReadValues[nextId] = PeripheralGattValues()
+
+    peripheral.delegate = self
+    centralManager.connect(peripheral, options: nil)
+    emitDebug(level: "trace", name: "connect_attempt", data: ["id": nextId.uuidString])
+  }
+
+  private func startGattExchange(for peripheral: CBPeripheral, service: CBService) {
+    let id = peripheral.identifier
+    var charMap: [CBUUID: CBCharacteristic] = [:]
+
+    guard let characteristics = service.characteristics else {
+      finishConnection(peripheral)
+      return
+    }
+
+    for ch in characteristics {
+      charMap[ch.uuid] = ch
+    }
+    peripheralCharacteristics[id] = charMap
+
+    if let eventCodeHashCh = charMap[eventCodeHashCharacteristicUUID] {
+      peripheral.readValue(for: eventCodeHashCh)
+    } else {
+      readRpidCharacteristic(for: peripheral)
+    }
+  }
+
+  private func readRpidCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let rpidCh = charMap[rpidCharacteristicUUID]
+    else {
+      finishConnection(peripheral)
+      return
+    }
+    peripheral.readValue(for: rpidCh)
+  }
+
+  private func readTekCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let tekCh = charMap[tekCharacteristicUUID]
+    else {
+      completeGattExchange(for: peripheral)
+      return
+    }
+    peripheral.readValue(for: tekCh)
+  }
+
+  private func writeTekCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let tekCh = charMap[tekCharacteristicUUID]
+    else {
+      completeGattExchange(for: peripheral)
+      return
+    }
+
+    let myTek = rpid.getCurrentTek()
+    peripheral.writeValue(myTek, for: tekCh, type: .withResponse)
+  }
+
+  private func completeGattExchange(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let values = peripheralReadValues[id] else {
+      finishConnection(peripheral)
+      return
+    }
+
+    if let rpidData = values.rpid {
+      let rssi = discoveredRssi[id] ?? 0
+      let ts = discoveredAt[id] ?? Date()
+      emitDetection(
+        timestamp: ts,
+        rssi: rssi,
+        payload: rpidData,
+        resolvedTek: values.tek,
+        debugLocalName: lastDiscoveryNameById[id]
+      )
+    }
+
+    finishConnection(peripheral)
+  }
+
+  private func finishConnection(_ peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
+    lastDiscoveryNameById.removeValue(forKey: id)
+    centralManager.cancelPeripheralConnection(peripheral)
+  }
+
+  private func shouldExchangeTek(remoteEventCodeHash: Data?) -> Bool {
+    guard rpid.isEventMode else { return false }
+    guard let remoteHash = remoteEventCodeHash, !remoteHash.isEmpty else { return false }
+
+    let myHash = rpid.getEventCodeHash()
+    return myHash == remoteHash
+  }
+
+  private func emitState(reasonCode: String?) {
+    var payload: [String: Any] = [
+      "type": "state",
+      "timestamp": iso8601.string(from: Date()),
+      "state": [
+        "isScanning": isScanning,
+        "isAdvertising": isAdvertising,
+        "eventMode": rpid.isEventMode ? "event" : "anonymous",
+        "eventCode": rpid.eventCode as Any,
+      ],
+    ]
+    if let rc = reasonCode {
+      payload["reasonCode"] = rc
+    }
+    onEvent?("BarnardState", payload)
+  }
+
+  private func emitConstraint(code: String, message: String?) {
+    var payload: [String: Any] = [
+      "type": "constraint",
+      "timestamp": iso8601.string(from: Date()),
+      "code": code,
+      "requiredAction": NSNull(),
+    ]
+    if let msg = message {
+      payload["message"] = msg
+    }
+    onEvent?("BarnardConstraint", payload)
+  }
+
+  private func emitError(code: String, message: String, recoverable: Bool? = nil) {
+    var payload: [String: Any] = [
+      "type": "error",
+      "timestamp": iso8601.string(from: Date()),
+      "code": code,
+      "message": message,
+    ]
+    if let rec = recoverable {
+      payload["recoverable"] = rec
+    }
+    onEvent?("BarnardError", payload)
+  }
+
+  private func emitDetection(
+    timestamp: Date,
+    rssi: Int,
+    payload: Data,
+    resolvedTek: Data? = nil,
+    debugLocalName: String? = nil
+  ) {
+    guard payload.count == 17 else {
+      emitDebug(level: "warn", name: "payload_invalid_length", data: ["length": payload.count])
+      return
+    }
+    let version = Int(payload[0])
+    if version != 1 {
+      emitDebug(level: "warn", name: "payload_unsupported_version", data: ["formatVersion": version])
+      return
+    }
+
+    let rpidBytes = payload.subdata(in: 1 ..< 17)
+    let displayId = rpidBytes.prefix(4).map { String(format: "%02x", $0) }.joined()
+
+    var resolvedTekToEmit: Data? = resolvedTek
+    var resolvedDisplayId: String?
+
+    if resolvedTekToEmit == nil, rpid.isEventMode {
+      let eventCodeHash = rpid.getEventCodeHash()
+      let knownTeks = tekStorage.getTeks(for: eventCodeHash)
+
+      if let matched = BarnardCrypto.resolveRpi(rpidBytes, knownTeks: knownTeks) {
+        resolvedTekToEmit = matched
+        tekStorage.updateLastSeen(tek: matched, eventCodeHash: eventCodeHash)
+      }
+    }
+
+    if let tek = resolvedTekToEmit {
+      resolvedDisplayId = BarnardCrypto.displayId(from: tek)
+    }
+
+    var eventPayload: [String: Any] = [
+      "type": "detection",
+      "timestamp": iso8601.string(from: timestamp),
+      "transport": "ble",
+      "formatVersion": version,
+      "rpid": rpidBytes.base64EncodedString(),
+      "displayId": displayId,
+      "rssi": rssi,
+      "rssiSummary": NSNull(),
+      "payloadRaw": payload.base64EncodedString(),
+    ]
+
+    if let tek = resolvedTekToEmit {
+      eventPayload["resolvedTek"] = tek.base64EncodedString()
+    }
+    if let dispId = resolvedDisplayId {
+      eventPayload["resolvedDisplayId"] = dispId
+    }
+    #if DEBUG
+    if let name = debugLocalName {
+      eventPayload["debugLocalName"] = name
+    }
+    #endif
+
+    onEvent?("BarnardDetection", eventPayload)
+  }
+
+  private func emitDebug(level: String, name: String, data: [String: Any]?) {
+    var payload: [String: Any] = [
+      "type": "debug",
+      "timestamp": iso8601.string(from: Date()),
+      "level": level,
+      "name": name,
+    ]
+    if let value = data {
+      payload["data"] = value
+    }
+    onDebugEvent?("BarnardDebug", payload)
+  }
+}
+
+extension BarnardBleController: CBCentralManagerDelegate {
+  func centralManagerDidUpdateState(_ central: CBCentralManager) {
+    emitDebug(level: "info", name: "central_state", data: ["state": central.state.rawValue])
+    if central.state != .poweredOn, isScanning {
+      stopScan()
+    }
+  }
+
+  func centralManager(
+    _ central: CBCentralManager,
+    didDiscover peripheral: CBPeripheral,
+    advertisementData: [String: Any],
+    rssi RSSI: NSNumber
+  ) {
+    let now = Date()
+    discoveredRssi[peripheral.identifier] = RSSI.intValue
+    discoveredAt[peripheral.identifier] = now
+
+    emitDebug(level: "trace", name: "ble_discovery_result", data: [
+      "id": peripheral.identifier.uuidString,
+      "rssi": RSSI.intValue,
+      "name": (advertisementData[CBAdvertisementDataLocalNameKey] as? String) as Any,
+    ])
+
+    #if DEBUG
+    if let name = advertisementData[CBAdvertisementDataLocalNameKey] as? String, !name.isEmpty {
+      lastDiscoveryNameById[peripheral.identifier] = name
+    }
+    #endif
+
+    enqueueConnect(peripheral)
+  }
+
+  func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+    emitDebug(level: "trace", name: "connected", data: ["id": peripheral.identifier.uuidString])
+    peripheral.discoverServices([discoveryServiceUUID])
+  }
+
+  func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+    emitError(code: "connect_failed", message: error?.localizedDescription ?? "unknown", recoverable: true)
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
+    activePeripheral = nil
+    pumpConnectQueue()
+  }
+
+  func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
+    activePeripheral = nil
+    pumpConnectQueue()
+  }
+}
+
+extension BarnardBleController: CBPeripheralDelegate {
+  func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+    if let error = error {
+      emitError(code: "service_discovery_failed", message: error.localizedDescription, recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+    guard let services = peripheral.services,
+      let svc = services.first(where: { $0.uuid == discoveryServiceUUID })
+    else {
+      emitError(code: "service_not_found", message: "Barnard service not found", recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+
+    peripheral.discoverCharacteristics(
+      [rpidCharacteristicUUID, tekCharacteristicUUID, eventCodeHashCharacteristicUUID],
+      for: svc
+    )
+  }
+
+  func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+    if let error = error {
+      emitError(code: "characteristic_discovery_failed", message: error.localizedDescription, recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+    startGattExchange(for: peripheral, service: service)
+  }
+
+  func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+    let id = peripheral.identifier
+
+    if let error = error {
+      emitError(code: "read_failed", message: error.localizedDescription, recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+
+    let value = characteristic.value ?? Data()
+
+    switch characteristic.uuid {
+    case eventCodeHashCharacteristicUUID:
+      peripheralReadValues[id]?.eventCodeHash = value
+      emitDebug(level: "trace", name: "gatt_read_event_code_hash", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+        "isEmpty": value.isEmpty,
+      ])
+      readRpidCharacteristic(for: peripheral)
+
+    case rpidCharacteristicUUID:
+      peripheralReadValues[id]?.rpid = value
+      emitDebug(level: "trace", name: "gatt_read_rpid", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+      ])
+      let remoteHash = peripheralReadValues[id]?.eventCodeHash
+      if shouldExchangeTek(remoteEventCodeHash: remoteHash) {
+        readTekCharacteristic(for: peripheral)
+      } else {
+        completeGattExchange(for: peripheral)
+      }
+
+    case tekCharacteristicUUID:
+      peripheralReadValues[id]?.tek = value
+      emitDebug(level: "trace", name: "gatt_read_tek", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+      ])
+
+      if value.count == 16,
+        let remoteHash = peripheralReadValues[id]?.eventCodeHash,
+        remoteHash.count == 8
+      {
+        let entry = TekEntry(
+          tek: value,
+          eventCodeHash: remoteHash,
+          exchangedAt: Date(),
+          lastSeenAt: Date()
+        )
+        tekStorage.store(entry: entry)
+        emitDebug(level: "info", name: "tek_received", data: [
+          "displayId": BarnardCrypto.displayId(from: value),
+        ])
+      }
+
+      writeTekCharacteristic(for: peripheral)
+
+    default:
+      break
+    }
+  }
+
+  func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+    if let error = error {
+      emitError(code: "write_failed", message: error.localizedDescription, recoverable: true)
+    } else {
+      emitDebug(level: "trace", name: "gatt_write_tek", data: [
+        "id": peripheral.identifier.uuidString,
+        "displayId": rpid.getCurrentDisplayId(),
+      ])
+    }
+    completeGattExchange(for: peripheral)
+  }
+}
+
+extension BarnardBleController: CBPeripheralManagerDelegate {
+  func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+    emitDebug(level: "info", name: "peripheral_state", data: ["state": peripheral.state.rawValue])
+    if peripheral.state != .poweredOn, isAdvertising {
+      stopAdvertise()
+    }
+  }
+
+  func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+    if let error = error {
+      emitError(code: "gatt_service_add_failed", message: error.localizedDescription, recoverable: false)
+    }
+  }
+
+  func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+    if let error = error {
+      emitError(code: "advertise_failed", message: error.localizedDescription, recoverable: true)
+      isAdvertising = false
+      emitState(reasonCode: "advertise_failed")
+    }
+  }
+
+  func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+    switch request.characteristic.uuid {
+    case rpidCharacteristicUUID:
+      let payload = rpid.currentPayload(formatVersion: formatVersion, now: Date())
+      request.value = payload
+      peripheral.respond(to: request, withResult: .success)
+
+      var displayId = ""
+      if payload.count >= 5 {
+        let bytes = payload.subdata(in: 1 ..< 5)
+        displayId = bytes.map { String(format: "%02x", $0) }.joined()
+      }
+      emitDebug(level: "trace", name: "gatt_read_rpid", data: [
+        "bytes": payload.count,
+        "formatVersion": Int(formatVersion),
+        "displayId": displayId,
+      ])
+
+    case tekCharacteristicUUID:
+      if rpid.isEventMode {
+        let tekData = rpid.getCurrentTek()
+        request.value = tekData
+        peripheral.respond(to: request, withResult: .success)
+        emitDebug(level: "trace", name: "gatt_respond_tek_read", data: [
+          "displayId": rpid.getCurrentDisplayId(),
+        ])
+      } else {
+        peripheral.respond(to: request, withResult: .readNotPermitted)
+        emitDebug(level: "trace", name: "gatt_reject_tek_read", data: [
+          "reason": "anonymous_mode",
+        ])
+      }
+
+    case eventCodeHashCharacteristicUUID:
+      let hash = rpid.getEventCodeHash()
+      request.value = hash
+      peripheral.respond(to: request, withResult: .success)
+      emitDebug(level: "trace", name: "gatt_respond_event_code_hash", data: [
+        "bytes": hash.count,
+        "isEmpty": hash.isEmpty,
+      ])
+
+    default:
+      peripheral.respond(to: request, withResult: .attributeNotFound)
+    }
+  }
+
+  func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
+    for request in requests {
+      guard request.characteristic.uuid == tekCharacteristicUUID else {
+        peripheral.respond(to: request, withResult: .writeNotPermitted)
+        continue
+      }
+
+      guard let value = request.value, value.count == 16 else {
+        peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
+        continue
+      }
+
+      guard rpid.isEventMode else {
+        peripheral.respond(to: request, withResult: .writeNotPermitted)
+        emitDebug(level: "trace", name: "gatt_reject_tek_write", data: [
+          "reason": "anonymous_mode",
+        ])
+        continue
+      }
+
+      let eventCodeHash = rpid.getEventCodeHash()
+      let entry = TekEntry(
+        tek: value,
+        eventCodeHash: eventCodeHash,
+        exchangedAt: Date(),
+        lastSeenAt: Date()
+      )
+      tekStorage.store(entry: entry)
+
+      peripheral.respond(to: request, withResult: .success)
+      emitDebug(level: "info", name: "tek_received_via_write", data: [
+        "displayId": BarnardCrypto.displayId(from: value),
+      ])
+    }
+  }
+}

--- a/packages/react-native/barnard/ios/BarnardCrypto.swift
+++ b/packages/react-native/barnard/ios/BarnardCrypto.swift
@@ -1,0 +1,140 @@
+import CommonCrypto
+import CryptoKit
+import Foundation
+
+enum BarnardCrypto {
+  static func deriveTekForEvent(deviceSecret: Data, eventCode: String) -> Data {
+    guard let eventCodeData = eventCode.data(using: .utf8) else {
+      return generateRandomBytes(16)
+    }
+
+    var combined = deviceSecret
+    combined.append(eventCodeData)
+
+    let key = SymmetricKey(data: combined)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "barnard-tek".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  static func deriveTekForAnonymous(deviceSecret: Data) -> Data {
+    let key = SymmetricKey(data: deviceSecret)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "barnard-tek-anonymous".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  static func deriveRpik(from tek: Data) -> Data {
+    guard tek.count == 16 else {
+      return Data(count: 16)
+    }
+
+    let key = SymmetricKey(data: tek)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "EN-RPIK".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  static func generateRpi(rpik: Data, enin: UInt32) -> Data {
+    guard rpik.count == 16 else {
+      return Data(count: 16)
+    }
+
+    var paddedData = Data(count: 16)
+
+    let prefix = "EN-RPI".data(using: .utf8)!
+    paddedData.replaceSubrange(0 ..< 6, with: prefix)
+
+    var eninBE = enin.bigEndian
+    let eninBytes = Data(bytes: &eninBE, count: 4)
+    paddedData.replaceSubrange(12 ..< 16, with: eninBytes)
+
+    return aes128EcbEncrypt(key: rpik, plaintext: paddedData)
+  }
+
+  private static func aes128EcbEncrypt(key: Data, plaintext: Data) -> Data {
+    guard key.count == 16, plaintext.count == 16 else {
+      return Data(count: 16)
+    }
+
+    var outputBuffer = [UInt8](repeating: 0, count: 16)
+    var dataOutMoved = 0
+
+    let status = key.withUnsafeBytes { keyPtr in
+      plaintext.withUnsafeBytes { inputPtr in
+        CCCrypt(
+          CCOperation(kCCEncrypt),
+          CCAlgorithm(kCCAlgorithmAES128),
+          CCOptions(kCCOptionECBMode),
+          keyPtr.baseAddress,
+          key.count,
+          nil,
+          inputPtr.baseAddress,
+          plaintext.count,
+          &outputBuffer,
+          outputBuffer.count,
+          &dataOutMoved
+        )
+      }
+    }
+
+    return status == kCCSuccess ? Data(outputBuffer) : Data(count: 16)
+  }
+
+  static func calculateEnin(for date: Date = Date()) -> UInt32 {
+    UInt32(Int(date.timeIntervalSince1970) / 600)
+  }
+
+  static func computeEventCodeHash(_ eventCode: String) -> Data {
+    guard let eventCodeData = eventCode.data(using: .utf8) else {
+      return Data(count: 8)
+    }
+
+    let hash = SHA256.hash(data: eventCodeData)
+    return Data(hash).prefix(8)
+  }
+
+  static func resolveRpi(_ rpi: Data, knownTeks: [Data], currentEnin: UInt32? = nil) -> Data? {
+    guard rpi.count == 16 else { return nil }
+
+    let enin = currentEnin ?? calculateEnin()
+
+    for tek in knownTeks {
+      guard tek.count == 16 else { continue }
+
+      let rpik = deriveRpik(from: tek)
+
+      for offset in -6 ... 1 {
+        let testEnin = UInt32(Int(enin) + offset)
+        let candidate = generateRpi(rpik: rpik, enin: testEnin)
+
+        if candidate == rpi {
+          return tek
+        }
+      }
+    }
+
+    return nil
+  }
+
+  static func displayId(from tek: Data) -> String {
+    tek.prefix(3).map { String(format: "%02x", $0) }.joined()
+  }
+
+  static func generateRandomBytes(_ count: Int) -> Data {
+    var bytes = [UInt8](repeating: 0, count: count)
+    _ = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+    return Data(bytes)
+  }
+}

--- a/packages/react-native/barnard/ios/BarnardCrypto.swift
+++ b/packages/react-native/barnard/ios/BarnardCrypto.swift
@@ -116,7 +116,9 @@ enum BarnardCrypto {
       let rpik = deriveRpik(from: tek)
 
       for offset in -6 ... 1 {
-        let testEnin = UInt32(Int(enin) + offset)
+        let signed = Int64(enin) + Int64(offset)
+        guard signed >= 0, signed <= Int64(UInt32.max) else { continue }
+        let testEnin = UInt32(signed)
         let candidate = generateRpi(rpik: rpik, enin: testEnin)
 
         if candidate == rpi {

--- a/packages/react-native/barnard/ios/BarnardRpidGenerator.swift
+++ b/packages/react-native/barnard/ios/BarnardRpidGenerator.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+final class BarnardRpidGenerator {
+  private let deviceSecretKey = "barnard.rpidSeed"
+  private let eventCodeKey = "barnard.eventCode"
+
+  private(set) var eventCode: String? {
+    didSet {
+      if eventCode != oldValue {
+        regenerateTek()
+      }
+    }
+  }
+
+  private var currentTek: Data
+
+  init() {
+    let defaults = UserDefaults.standard
+    eventCode = defaults.string(forKey: eventCodeKey)
+    currentTek = Data()
+    regenerateTek()
+  }
+
+  func joinEvent(_ code: String) {
+    let defaults = UserDefaults.standard
+    defaults.set(code, forKey: eventCodeKey)
+    eventCode = code
+  }
+
+  func leaveEvent() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: eventCodeKey)
+    eventCode = nil
+  }
+
+  var isEventMode: Bool {
+    eventCode != nil
+  }
+
+  func getCurrentTek() -> Data {
+    currentTek
+  }
+
+  private func regenerateTek() {
+    let deviceSecret = getOrCreateDeviceSecret()
+    if let code = eventCode {
+      currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: code)
+    } else {
+      currentTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret: deviceSecret)
+    }
+  }
+
+  func getEventCodeHash() -> Data {
+    guard let code = eventCode else {
+      return Data()
+    }
+    return BarnardCrypto.computeEventCodeHash(code)
+  }
+
+  func currentPayload(formatVersion: UInt8 = 1, now: Date = Date()) -> Data {
+    let enin = BarnardCrypto.calculateEnin(for: now)
+    let rpik = BarnardCrypto.deriveRpik(from: currentTek)
+    let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: enin)
+
+    var payload = Data([formatVersion])
+    payload.append(rpi)
+    return payload
+  }
+
+  private func getOrCreateDeviceSecret() -> Data {
+    let defaults = UserDefaults.standard
+
+    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
+      return existing
+    }
+
+    let newSecret = BarnardCrypto.generateRandomBytes(32)
+    defaults.set(newSecret, forKey: deviceSecretKey)
+    return newSecret
+  }
+
+  func getDeviceSecret() -> Data {
+    getOrCreateDeviceSecret()
+  }
+
+  func getCurrentDisplayId() -> String {
+    BarnardCrypto.displayId(from: currentTek)
+  }
+}

--- a/packages/react-native/barnard/ios/BarnardTekStorage.swift
+++ b/packages/react-native/barnard/ios/BarnardTekStorage.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+struct TekEntry: Codable, Equatable {
+  let tek: Data
+  let eventCodeHash: Data
+  let exchangedAt: Date
+  var lastSeenAt: Date
+
+  var displayId: String {
+    tek.prefix(3).map { String(format: "%02x", $0) }.joined()
+  }
+
+  func toDict() -> [String: Any] {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    return [
+      "tek": tek.base64EncodedString(),
+      "eventCodeHash": eventCodeHash.base64EncodedString(),
+      "exchangedAt": formatter.string(from: exchangedAt),
+      "lastSeenAt": formatter.string(from: lastSeenAt),
+      "displayId": displayId,
+    ]
+  }
+}
+
+struct TekStorageConfig {
+  let ttlSeconds: Int
+  let maxEntries: Int
+
+  init(ttlSeconds: Int = 86400, maxEntries: Int = 1000) {
+    self.ttlSeconds = ttlSeconds
+    self.maxEntries = maxEntries
+  }
+}
+
+final class BarnardTekStorage {
+  private let storageKeyPrefix = "barnard.tekStorage."
+  private let defaults = UserDefaults.standard
+  private let config: TekStorageConfig
+
+  init(config: TekStorageConfig = TekStorageConfig()) {
+    self.config = config
+  }
+
+  func store(entry: TekEntry) {
+    let key = storageKey(for: entry.eventCodeHash)
+    var entries = loadEntries(key: key)
+
+    if let index = entries.firstIndex(where: { $0.tek == entry.tek }) {
+      entries[index].lastSeenAt = entry.lastSeenAt
+    } else {
+      entries.append(entry)
+    }
+
+    let now = Date()
+    entries = entries.filter { item in
+      now.timeIntervalSince(item.lastSeenAt) < Double(config.ttlSeconds)
+    }
+
+    if entries.count > config.maxEntries {
+      entries.sort { $0.lastSeenAt < $1.lastSeenAt }
+      entries = Array(entries.suffix(config.maxEntries))
+    }
+
+    saveEntries(entries, key: key)
+  }
+
+  func getEntries(for eventCodeHash: Data) -> [TekEntry] {
+    let key = storageKey(for: eventCodeHash)
+    let entries = loadEntries(key: key)
+
+    let now = Date()
+    let validEntries = entries.filter { item in
+      now.timeIntervalSince(item.lastSeenAt) < Double(config.ttlSeconds)
+    }
+
+    if validEntries.count != entries.count {
+      saveEntries(validEntries, key: key)
+    }
+
+    return validEntries
+  }
+
+  func getTeks(for eventCodeHash: Data) -> [Data] {
+    getEntries(for: eventCodeHash).map(\.tek)
+  }
+
+  func clear(for eventCodeHash: Data) -> Int {
+    let key = storageKey(for: eventCodeHash)
+    let entries = loadEntries(key: key)
+    let count = entries.count
+    defaults.removeObject(forKey: key)
+    return count
+  }
+
+  func clearAll() -> Int {
+    var total = 0
+
+    for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(storageKeyPrefix) {
+      if let data = defaults.data(forKey: key),
+        let entries = try? JSONDecoder().decode([TekEntry].self, from: data)
+      {
+        total += entries.count
+      }
+      defaults.removeObject(forKey: key)
+    }
+
+    return total
+  }
+
+  func updateLastSeen(tek: Data, eventCodeHash: Data, at date: Date = Date()) {
+    let key = storageKey(for: eventCodeHash)
+    var entries = loadEntries(key: key)
+
+    if let index = entries.firstIndex(where: { $0.tek == tek }) {
+      entries[index].lastSeenAt = date
+      saveEntries(entries, key: key)
+    }
+  }
+
+  private func storageKey(for eventCodeHash: Data) -> String {
+    storageKeyPrefix + eventCodeHash.base64EncodedString()
+  }
+
+  private func loadEntries(key: String) -> [TekEntry] {
+    guard let data = defaults.data(forKey: key) else {
+      return []
+    }
+
+    do {
+      return try JSONDecoder().decode([TekEntry].self, from: data)
+    } catch {
+      defaults.removeObject(forKey: key)
+      return []
+    }
+  }
+
+  private func saveEntries(_ entries: [TekEntry], key: String) {
+    guard !entries.isEmpty else {
+      defaults.removeObject(forKey: key)
+      return
+    }
+
+    do {
+      let data = try JSONEncoder().encode(entries)
+      defaults.set(data, forKey: key)
+    } catch {
+      print("BarnardTekStorage: Failed to encode entries: \(error)")
+    }
+  }
+}

--- a/packages/react-native/barnard/jest.config.cjs
+++ b/packages/react-native/barnard/jest.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  clearMocks: true,
+  roots: ['<rootDir>/__tests__'],
+  modulePathIgnorePatterns: ['<rootDir>/lib/'],
+};

--- a/packages/react-native/barnard/package.json
+++ b/packages/react-native/barnard/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "barnard",
+  "version": "0.1.0",
+  "description": "React Native plugin for Barnard SDK - BLE Scan/Advertise + GATT-based RPID detection",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "types": "lib/typescript/index.d.ts",
+  "react-native": "src/index.ts",
+  "source": "src/index.ts",
+  "files": [
+    "src",
+    "lib",
+    "ios",
+    "android",
+    "react-native-barnard.podspec",
+    "README.md"
+  ],
+  "scripts": {
+    "typescript": "tsc --noEmit",
+    "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "prepare": "bob build"
+  },
+  "keywords": [
+    "react-native",
+    "ios",
+    "android",
+    "bluetooth",
+    "ble",
+    "barnard",
+    "rpid",
+    "proximity"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thegreeting/barnard.git",
+    "directory": "packages/react-native/barnard"
+  },
+  "author": "The Greeting Network",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/thegreeting/barnard/issues"
+  },
+  "homepage": "https://github.com/thegreeting/barnard#readme",
+  "devDependencies": {
+    "@react-native-community/eslint-config": "^3.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-native": "^0.72.0",
+    "eslint": "^8.0.0",
+    "react": "^18.2.0",
+    "react-native": "^0.72.0",
+    "react-native-builder-bob": "^0.20.0",
+    "typescript": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": ">=0.71.0"
+  },
+  "react-native-builder-bob": {
+    "source": "src",
+    "output": "lib",
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ]
+  }
+}

--- a/packages/react-native/barnard/package.json
+++ b/packages/react-native/barnard/package.json
@@ -18,6 +18,8 @@
   "scripts": {
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "prepare": "bob build"
   },
   "keywords": [
@@ -43,12 +45,15 @@
   "homepage": "https://github.com/thegreeting/barnard#readme",
   "devDependencies": {
     "@react-native-community/eslint-config": "^3.2.0",
+    "@types/jest": "^29.5.14",
     "@types/react": "^18.2.0",
     "@types/react-native": "^0.72.0",
     "eslint": "^8.0.0",
+    "jest": "^29.7.0",
     "react": "^18.2.0",
     "react-native": "^0.72.0",
     "react-native-builder-bob": "^0.20.0",
+    "ts-jest": "^29.2.5",
     "typescript": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/react-native/barnard/react-native-barnard.podspec
+++ b/packages/react-native/barnard/react-native-barnard.podspec
@@ -1,0 +1,20 @@
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+
+Pod::Spec.new do |s|
+  s.name         = "barnard"
+  s.version      = package["version"]
+  s.summary      = package["description"]
+  s.homepage     = package["homepage"]
+  s.license      = package["license"]
+  s.authors      = package["author"]
+  s.platforms    = { :ios => "14.0" }
+  s.source       = { :git => package["repository"]["url"], :tag => "#{s.version}" }
+
+  s.source_files = "ios/**/*.{h,m,mm,swift}"
+
+  s.dependency "React-Core"
+
+  s.swift_version = "5.0"
+end

--- a/packages/react-native/barnard/src/BarnardManager.ts
+++ b/packages/react-native/barnard/src/BarnardManager.ts
@@ -36,7 +36,7 @@ import type {
  *
  * // Later: cleanup
  * unsubscribe();
- * barnard.dispose();
+ * await barnard.dispose();
  * ```
  */
 export class BarnardManager {

--- a/packages/react-native/barnard/src/BarnardManager.ts
+++ b/packages/react-native/barnard/src/BarnardManager.ts
@@ -149,16 +149,17 @@ export class BarnardManager {
 
   /**
    * Dispose of the manager and release resources.
+   *
+   * Resolves once the native module has finished releasing its resources.
+   * Always await this when tearing down, to avoid leaking scan/advertise sessions.
    */
-  dispose(): void {
+  async dispose(): Promise<void> {
     // Unsubscribe from all events
     this.subscriptions.forEach((sub) => sub.remove());
     this.subscriptions = [];
 
-    // Call native dispose
-    BarnardModule.dispose().catch((error) => {
-      console.warn('Failed to dispose Barnard:', error);
-    });
+    // Call native dispose and propagate completion to the caller
+    await BarnardModule.dispose();
   }
 
   /**

--- a/packages/react-native/barnard/src/BarnardManager.ts
+++ b/packages/react-native/barnard/src/BarnardManager.ts
@@ -1,0 +1,254 @@
+import { EmitterSubscription } from 'react-native';
+import { BarnardModule, BarnardEventEmitter } from './NativeBarnard';
+import type {
+  BarnardCapabilities,
+  BarnardState,
+  EventModeState,
+  ScanConfig,
+  AdvertiseConfig,
+  AutoConfig,
+  AutoStartResult,
+  TekEntry,
+  DetectionEvent,
+  StateEvent,
+  ConstraintEvent,
+  ErrorEvent,
+  DebugEvent,
+  BarnardEvent,
+} from './types';
+
+/**
+ * High-level API for Barnard SDK.
+ *
+ * Provides BLE Scan/Advertise functionality with GATT-based RPID detection.
+ *
+ * @example
+ * ```typescript
+ * const barnard = new BarnardManager();
+ *
+ * // Listen for detections
+ * const unsubscribe = barnard.onDetection((event) => {
+ *   console.log('Detected:', event.displayId, event.rssi);
+ * });
+ *
+ * // Start scanning and advertising
+ * await barnard.startAuto();
+ *
+ * // Later: cleanup
+ * unsubscribe();
+ * barnard.dispose();
+ * ```
+ */
+export class BarnardManager {
+  private subscriptions: EmitterSubscription[] = [];
+
+  /**
+   * Get platform capabilities.
+   */
+  async getCapabilities(): Promise<BarnardCapabilities> {
+    return BarnardModule.getCapabilities();
+  }
+
+  /**
+   * Get current state (scanning/advertising status).
+   */
+  async getState(): Promise<BarnardState> {
+    return BarnardModule.getState();
+  }
+
+  /**
+   * Get current event mode state.
+   */
+  async getEventMode(): Promise<EventModeState> {
+    return BarnardModule.getEventMode();
+  }
+
+  /**
+   * Start BLE scanning for nearby devices.
+   *
+   * @param config - Optional scan configuration
+   */
+  async startScan(config?: ScanConfig): Promise<void> {
+    return BarnardModule.startScan(config);
+  }
+
+  /**
+   * Stop BLE scanning.
+   */
+  async stopScan(): Promise<void> {
+    return BarnardModule.stopScan();
+  }
+
+  /**
+   * Start BLE advertising as a peripheral.
+   *
+   * @param config - Optional advertise configuration
+   */
+  async startAdvertise(config?: AdvertiseConfig): Promise<void> {
+    return BarnardModule.startAdvertise(config);
+  }
+
+  /**
+   * Stop BLE advertising.
+   */
+  async stopAdvertise(): Promise<void> {
+    return BarnardModule.stopAdvertise();
+  }
+
+  /**
+   * Start both scanning and advertising simultaneously.
+   *
+   * @param config - Optional auto configuration
+   * @returns Result indicating which operations started successfully
+   */
+  async startAuto(config?: AutoConfig): Promise<AutoStartResult> {
+    return BarnardModule.startAuto(config);
+  }
+
+  /**
+   * Stop both scanning and advertising.
+   */
+  async stopAuto(): Promise<void> {
+    return BarnardModule.stopAuto();
+  }
+
+  /**
+   * Join an event and enable TEK exchange/resolution.
+   */
+  async joinEvent(eventCode: string): Promise<void> {
+    return BarnardModule.joinEvent(eventCode);
+  }
+
+  /**
+   * Leave event mode and return to anonymous mode.
+   */
+  async leaveEvent(): Promise<void> {
+    return BarnardModule.leaveEvent();
+  }
+
+  /**
+   * Get exchanged TEKs for the specified event code.
+   */
+  async getExchangedTeks(eventCode: string): Promise<TekEntry[]> {
+    return BarnardModule.getExchangedTeks(eventCode);
+  }
+
+  /**
+   * Clear TEKs for the specified event code.
+   */
+  async clearTeksForEvent(eventCode: string): Promise<number> {
+    return BarnardModule.clearTeksForEvent(eventCode);
+  }
+
+  /**
+   * Clear all exchanged TEKs.
+   */
+  async clearAllTeks(): Promise<number> {
+    return BarnardModule.clearAllTeks();
+  }
+
+  /**
+   * Dispose of the manager and release resources.
+   */
+  dispose(): void {
+    // Unsubscribe from all events
+    this.subscriptions.forEach((sub) => sub.remove());
+    this.subscriptions = [];
+
+    // Call native dispose
+    BarnardModule.dispose().catch((error) => {
+      console.warn('Failed to dispose Barnard:', error);
+    });
+  }
+
+  /**
+   * Subscribe to detection events.
+   *
+   * @param callback - Function to call when a detection occurs
+   * @returns Function to unsubscribe
+   */
+  onDetection(callback: (event: DetectionEvent) => void): () => void {
+    return this.addEventListener('BarnardDetection', callback);
+  }
+
+  /**
+   * Subscribe to state change events.
+   *
+   * @param callback - Function to call when state changes
+   * @returns Function to unsubscribe
+   */
+  onStateChange(callback: (event: StateEvent) => void): () => void {
+    return this.addEventListener('BarnardState', callback);
+  }
+
+  /**
+   * Subscribe to constraint violation events.
+   *
+   * @param callback - Function to call when a constraint is violated
+   * @returns Function to unsubscribe
+   */
+  onConstraint(callback: (event: ConstraintEvent) => void): () => void {
+    return this.addEventListener('BarnardConstraint', callback);
+  }
+
+  /**
+   * Subscribe to error events.
+   *
+   * @param callback - Function to call when an error occurs
+   * @returns Function to unsubscribe
+   */
+  onError(callback: (event: ErrorEvent) => void): () => void {
+    return this.addEventListener('BarnardError', callback);
+  }
+
+  /**
+   * Subscribe to debug events.
+   *
+   * @param callback - Function to call when a debug event occurs
+   * @returns Function to unsubscribe
+   */
+  onDebug(callback: (event: DebugEvent) => void): () => void {
+    return this.addEventListener('BarnardDebug', callback);
+  }
+
+  /**
+   * Subscribe to all events.
+   *
+   * @param callback - Function to call when any event occurs
+   * @returns Function to unsubscribe
+   */
+  onEvent(callback: (event: BarnardEvent) => void): () => void {
+    const detectionUnsub = this.onDetection(callback);
+    const stateUnsub = this.onStateChange(callback);
+    const constraintUnsub = this.onConstraint(callback);
+    const errorUnsub = this.onError(callback);
+    const debugUnsub = this.onDebug(callback);
+
+    return () => {
+      detectionUnsub();
+      stateUnsub();
+      constraintUnsub();
+      errorUnsub();
+      debugUnsub();
+    };
+  }
+
+  /**
+   * Internal helper to subscribe to native events.
+   */
+  private addEventListener<T>(
+    eventName: string,
+    callback: (event: T) => void
+  ): () => void {
+    const subscription = BarnardEventEmitter.addListener(eventName, callback);
+    this.subscriptions.push(subscription);
+
+    return () => {
+      const index = this.subscriptions.indexOf(subscription);
+      if (index !== -1) {
+        this.subscriptions.splice(index, 1);
+      }
+      subscription.remove();
+    };
+  }
+}

--- a/packages/react-native/barnard/src/NativeBarnard.ts
+++ b/packages/react-native/barnard/src/NativeBarnard.ts
@@ -1,0 +1,69 @@
+import { NativeModules, NativeEventEmitter } from 'react-native';
+import type {
+  BarnardCapabilities,
+  BarnardState,
+  EventModeState,
+  ScanConfig,
+  AdvertiseConfig,
+  AutoConfig,
+  AutoStartResult,
+  TekEntry,
+} from './types';
+
+const LINKING_ERROR =
+  "The package 'barnard' doesn't seem to be linked. Make sure: \n\n" +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n' +
+  '- If you are using Expo, install it in a custom dev client or bare workflow\n';
+
+/**
+ * Native module interface.
+ */
+interface BarnardNativeModule {
+  getCapabilities(): Promise<BarnardCapabilities>;
+  getState(): Promise<BarnardState>;
+  getEventMode(): Promise<EventModeState>;
+  startScan(config?: ScanConfig): Promise<void>;
+  stopScan(): Promise<void>;
+  startAdvertise(config?: AdvertiseConfig): Promise<void>;
+  stopAdvertise(): Promise<void>;
+  startAuto(config?: AutoConfig): Promise<AutoStartResult>;
+  stopAuto(): Promise<void>;
+  joinEvent(eventCode: string): Promise<void>;
+  leaveEvent(): Promise<void>;
+  getExchangedTeks(eventCode: string): Promise<TekEntry[]>;
+  clearTeksForEvent(eventCode: string): Promise<number>;
+  clearAllTeks(): Promise<number>;
+  dispose(): Promise<void>;
+}
+
+/**
+ * Native module instance.
+ */
+const BarnardModule = NativeModules.Barnard
+  ? (NativeModules.Barnard as BarnardNativeModule)
+  : new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    ) as BarnardNativeModule;
+
+/**
+ * Native event emitter for Barnard events.
+ */
+const BarnardEventEmitter: NativeEventEmitter = NativeModules.Barnard
+  ? new NativeEventEmitter(NativeModules.Barnard)
+  : ({
+      addListener() {
+        throw new Error(LINKING_ERROR);
+      },
+      removeAllListeners() {},
+      listenerCount() {
+        return 0;
+      },
+    } as unknown as NativeEventEmitter);
+
+export { BarnardModule, BarnardEventEmitter };

--- a/packages/react-native/barnard/src/index.ts
+++ b/packages/react-native/barnard/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * React Native Barnard SDK
+ *
+ * BLE Scan/Advertise + GATT-based RPID detection for React Native.
+ */
+
+export { BarnardManager } from './BarnardManager';
+
+export type {
+  TransportKind,
+  EventMode,
+  EventModeState,
+  BarnardCapabilities,
+  BarnardState,
+  ScanConfig,
+  AdvertiseConfig,
+  AutoConfig,
+  AutoStartResult,
+  BarnardIssueSeverity,
+  BarnardIssue,
+  TekEntry,
+  BaseEvent,
+  DetectionEvent,
+  StateEvent,
+  ConstraintEvent,
+  ErrorEvent,
+  DebugLevel,
+  DebugEvent,
+  BarnardEvent,
+} from './types';

--- a/packages/react-native/barnard/src/types.ts
+++ b/packages/react-native/barnard/src/types.ts
@@ -1,0 +1,344 @@
+/**
+ * Transport kind for proximity detection.
+ */
+export type TransportKind = 'ble' | 'uwb' | 'thread' | 'unknown';
+
+/**
+ * Platform capabilities for Barnard SDK.
+ */
+export interface BarnardCapabilities {
+  /**
+   * List of supported transport types.
+   */
+  supportedTransports: TransportKind[];
+
+  /**
+   * Whether this transport can carry RPID without connecting (connectionless).
+   */
+  supportsConnectionlessRpid: boolean;
+
+  /**
+   * Whether this transport supports an optional GATT-like connection fallback.
+   */
+  supportsGattFallback: boolean;
+
+  /**
+   * Whether background operation is supported by the implementation.
+   */
+  supportsBackground: boolean;
+
+  /**
+   * Whether this implementation can produce high-rate RSSI observations.
+   */
+  supportsHighRateRssi: boolean;
+}
+
+/**
+ * Current state of scanning and advertising operations.
+ */
+export interface BarnardState {
+  /**
+   * Whether scanning is currently active.
+   */
+  isScanning: boolean;
+
+  /**
+   * Whether advertising is currently active.
+   */
+  isAdvertising: boolean;
+
+  /**
+   * Current operating mode.
+   */
+  eventMode?: EventMode;
+
+  /**
+   * Active event code when in event mode.
+   */
+  eventCode?: string;
+}
+
+/**
+ * Operating mode for resolvable ID behavior.
+ */
+export type EventMode = 'anonymous' | 'event';
+
+/**
+ * Current event mode details.
+ */
+export interface EventModeState {
+  mode: EventMode;
+  eventCode?: string;
+}
+
+/**
+ * Configuration for scan operations.
+ */
+export interface ScanConfig {
+  /**
+   * Allow duplicate detections (recommended for better RSSI tracking).
+   * Default: true
+   */
+  allowDuplicates?: boolean;
+}
+
+/**
+ * Configuration for advertise operations.
+ */
+export interface AdvertiseConfig {
+  /**
+   * RPID payload format version.
+   * Default: 1
+   */
+  formatVersion?: number;
+}
+
+/**
+ * Configuration for auto mode (scan + advertise).
+ */
+export interface AutoConfig {
+  /**
+   * Scan configuration.
+   */
+  scan?: ScanConfig;
+
+  /**
+   * Advertise configuration.
+   */
+  advertise?: AdvertiseConfig;
+}
+
+/**
+ * Result from starting auto mode.
+ */
+export interface AutoStartResult {
+  /**
+   * Whether scanning was successfully started.
+   */
+  scanningStarted: boolean;
+
+  /**
+   * Whether advertising was successfully started.
+   */
+  advertisingStarted: boolean;
+
+  /**
+   * List of non-fatal issues encountered during startup.
+   */
+  issues: BarnardIssue[];
+}
+
+/**
+ * Issue severity level.
+ */
+export type BarnardIssueSeverity = 'info' | 'warn' | 'error';
+
+/**
+ * Non-fatal issue reported during operations.
+ */
+export interface BarnardIssue {
+  /**
+   * Severity level.
+   */
+  severity: BarnardIssueSeverity;
+
+  /**
+   * Machine-readable code.
+   */
+  code: string;
+
+  /**
+   * Optional human-readable message.
+   */
+  message?: string;
+}
+
+/**
+ * Exchanged TEK entry (event mode only).
+ */
+export interface TekEntry {
+  /**
+   * Base64-encoded 16-byte TEK.
+   */
+  tek: string;
+
+  /**
+   * Base64-encoded 8-byte event code hash.
+   */
+  eventCodeHash: string;
+
+  /**
+   * ISO 8601 timestamp when first exchanged.
+   */
+  exchangedAt: string;
+
+  /**
+   * ISO 8601 timestamp when last seen.
+   */
+  lastSeenAt: string;
+
+  /**
+   * Human-readable ID derived from TEK.
+   */
+  displayId: string;
+}
+
+/**
+ * Base event type with timestamp.
+ */
+export interface BaseEvent {
+  /**
+   * ISO 8601 timestamp with fractional seconds.
+   */
+  timestamp: string;
+}
+
+/**
+ * RPID detection event.
+ */
+export interface DetectionEvent extends BaseEvent {
+  type: 'detection';
+
+  /**
+   * Transport that detected the RPID.
+   */
+  transport: TransportKind;
+
+  /**
+   * RPID payload format version.
+   */
+  formatVersion: number;
+
+  /**
+   * Base64-encoded RPID (16 bytes).
+   */
+  rpid: string;
+
+  /**
+   * Hex-encoded display ID (first 4 bytes of RPID).
+   */
+  displayId: string;
+
+  /**
+   * RSSI value in dBm.
+   */
+  rssi: number;
+
+  /**
+   * Optional base64-encoded raw payload.
+   */
+  payloadRaw?: string;
+
+  /**
+   * Optional resolved TEK (base64) when resolution succeeded.
+   */
+  resolvedTek?: string;
+
+  /**
+   * Optional resolved display ID derived from resolved TEK.
+   */
+  resolvedDisplayId?: string;
+
+  /**
+   * Optional debug-only peer local name.
+   */
+  debugLocalName?: string;
+}
+
+/**
+ * State change event.
+ */
+export interface StateEvent extends BaseEvent {
+  type: 'state';
+
+  /**
+   * New state.
+   */
+  state: BarnardState;
+
+  /**
+   * Optional reason code for the state change.
+   */
+  reasonCode?: string;
+}
+
+/**
+ * Constraint violation event (e.g., permissions, Bluetooth disabled).
+ */
+export interface ConstraintEvent extends BaseEvent {
+  type: 'constraint';
+
+  /**
+   * Machine-readable constraint code.
+   */
+  code: string;
+
+  /**
+   * Optional human-readable message.
+   */
+  message?: string;
+
+  /**
+   * Optional suggested action to resolve the constraint.
+   */
+  requiredAction?: string;
+}
+
+/**
+ * Error event.
+ */
+export interface ErrorEvent extends BaseEvent {
+  type: 'error';
+
+  /**
+   * Machine-readable error code.
+   */
+  code: string;
+
+  /**
+   * Human-readable error message.
+   */
+  message: string;
+
+  /**
+   * Whether the error is recoverable.
+   */
+  recoverable?: boolean;
+}
+
+/**
+ * Debug level.
+ */
+export type DebugLevel = 'trace' | 'info' | 'warn' | 'error';
+
+/**
+ * Debug event for troubleshooting.
+ */
+export interface DebugEvent extends BaseEvent {
+  type: 'debug';
+
+  /**
+   * Debug level.
+   */
+  level: DebugLevel;
+
+  /**
+   * Event name.
+   */
+  name: string;
+
+  /**
+   * Optional structured data.
+   */
+  data?: Record<string, any>;
+}
+
+/**
+ * Union of all event types.
+ */
+export type BarnardEvent =
+  | DetectionEvent
+  | StateEvent
+  | ConstraintEvent
+  | ErrorEvent
+  | DebugEvent;

--- a/packages/react-native/barnard/tsconfig.json
+++ b/packages/react-native/barnard/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
## Summary
- add a new React Native package (`barnard`) with iOS and Android native modules plus TypeScript API
- add a React Native demo app under `examples/react-native/barnard_demo`
- implement resolvable ID event mode flow on iOS (join/leave event, TEK exchange, `resolvedTek` / `resolvedDisplayId` emission)
- expose event-mode APIs in the RN bridge and JS manager (`getEventMode`, `joinEvent`, `leaveEvent`, TEK storage operations)

## Notes
- Android includes matching API surface for event mode, but TEK exchange/resolution internals are currently stubbed and return empty/zero for TEK storage operations.
- package import name is `barnard`.
- iOS minimum target was raised to 14.0 to align with CryptoKit HKDF usage.

## Validation
- Swift typecheck passed for iOS core logic files:
  - `BarnardCrypto.swift`
  - `BarnardTekStorage.swift`
  - `BarnardRpidGenerator.swift`
  - `BarnardBleController.swift`
- Full RN build/test was not run in this environment.
