### PR TITLE
Scope Barnard v2 display IDs to event windows

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -870,6 +870,9 @@ internal class BarnardController(
                     "cachedEnin" to knownPeer.enin,
                     "currentEnin" to currentEnin,
                 ))
+                // Force a fresh resolution. enqueueConnect dedups against in-flight /
+                // queued connects, so following advertisements on the same address
+                // remain safe.
                 enqueueConnect(device)
             }
         } else if (isResolutionBackedOff(address, nowMs)) {

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -46,7 +46,7 @@ private const val TAG = "BarnardBLE"
  *
  * GATT service (fixed UUID):
  * - B002 RPID (Read, 17 bytes)
- * - B003 displayId (Read, 4 bytes) — SHA256(TEK)[0:4]
+ * - B003 displayId (Read, 4 bytes when joined to an event) — SHA256(TEK)[0:4]
  * - B004 EventCodeHash (Read, 0 or 8 bytes)
  *
  * TEK is never transmitted over BLE in v2.
@@ -137,6 +137,7 @@ internal class BarnardController(
 
     private data class KnownPeer(
         val rpid: ByteArray,
+        val enin: Long,
         val detectedDisplayId: String?,
         val debugLocalName: String?
     )
@@ -581,7 +582,7 @@ internal class BarnardController(
         )
         service.addCharacteristic(rpidCh)
 
-        // B003 displayId (Read only) — v2: was TEK (r/w), now SHA256(TEK)[0:4]
+        // B003 displayId (Read only) — v2: was TEK (r/w), now event-scoped SHA256(TEK)[0:4]
         val displayIdCh = BluetoothGattCharacteristic(
             displayIdCharUuid,
             BluetoothGattCharacteristic.PROPERTY_READ,
@@ -857,8 +858,20 @@ internal class BarnardController(
             "name" to result.scanRecord?.deviceName
         ))
 
-        if (knownPeers.containsKey(address)) {
-            emitRssiUpdate(address, result.rssi, nowMs)
+        val knownPeer = knownPeers[address]
+        if (knownPeer != null) {
+            val currentEnin = BarnardCrypto.calculateEnin(nowMs).toLong()
+            if (BarnardV2Policy.KnownPeerWindow(knownPeer.enin).matches(currentEnin)) {
+                emitRssiUpdate(address, result.rssi, nowMs)
+            } else {
+                knownPeers.remove(address)
+                emitDebug("trace", "known_peer_rpid_expired", mapOf(
+                    "address" to address,
+                    "cachedEnin" to knownPeer.enin,
+                    "currentEnin" to currentEnin,
+                ))
+                enqueueConnect(device)
+            }
         } else if (isResolutionBackedOff(address, nowMs)) {
             emitResolutionBackoff(address, nowMs)
         } else {
@@ -1239,8 +1252,10 @@ internal class BarnardController(
                 resolutionBackoffUntilMs.remove(address)
 
                 if (rpidData.size == 17) {
+                    val peerEnin = BarnardCrypto.calculateEnin(ts).toLong()
                     knownPeers[address] = KnownPeer(
                         rpidData,
+                        peerEnin,
                         detectedDisplayIdHex,
                         lastDiscoveryNameById[address]
                     )
@@ -1282,7 +1297,15 @@ internal class BarnardController(
                 }
 
                 displayIdCharUuid -> {
-                    // v2: always serve 4-byte SHA256(TEK)[0:4].
+                    if (!BarnardV2Policy.shouldServeGattDisplayId(eventCode)) {
+                        server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+                        emitDebug("trace", "gatt_reject_display_id_read", mapOf(
+                            "reason" to "not_joined_to_event"
+                        ))
+                        return
+                    }
+
+                    // v2: event-scoped 4-byte SHA256(TEK)[0:4].
                     val displayId = BarnardCrypto.displayId4(currentTek)
                     val slice =
                         if (offset <= 0) displayId

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
@@ -1,0 +1,11 @@
+package network.greeting.barnard
+
+internal object BarnardV2Policy {
+    fun shouldServeGattDisplayId(eventCode: String?): Boolean {
+        return !eventCode.isNullOrEmpty()
+    }
+
+    data class KnownPeerWindow(val enin: Long) {
+        fun matches(currentEnin: Long): Boolean = enin == currentEnin
+    }
+}

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
@@ -1,0 +1,22 @@
+package network.greeting.barnard
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class BarnardV2PolicyTest {
+    @Test
+    fun shouldServeGattDisplayId_onlyWhenJoinedToEvent() {
+        assertFalse(BarnardV2Policy.shouldServeGattDisplayId(null))
+        assertFalse(BarnardV2Policy.shouldServeGattDisplayId(""))
+        assertTrue(BarnardV2Policy.shouldServeGattDisplayId("CONF-2026"))
+    }
+
+    @Test
+    fun knownPeerRpidIsReusableOnlyWithinSameEnin() {
+        val peer = BarnardV2Policy.KnownPeerWindow(enin = 1234)
+
+        assertTrue(peer.matches(1234))
+        assertFalse(peer.matches(1235))
+    }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -10,7 +10,7 @@ import UIKit
 ///
 /// GATT service (fixed UUID):
 /// - B002 RPID (Read, 17 bytes)
-/// - B003 displayId (Read, 4 bytes) — `SHA256(TEK)[0:4]`. v2 no longer serves TEK.
+/// - B003 displayId (Read, 4 bytes when joined to an event) — `SHA256(TEK)[0:4]`. v2 no longer serves TEK.
 /// - B004 EventCodeHash (Read, 0 or 8 bytes)
 ///
 /// TEK is never transmitted over BLE in v2.
@@ -117,11 +117,17 @@ final class BarnardBleController: NSObject {
 
   private struct KnownPeer {
     let rpid: Data
+    let enin: UInt32
     var detectedDisplayId: String?
     var debugLocalName: String?
   }
 
   private var knownPeers: [UUID: KnownPeer] = [:]
+
+  private func shouldServeGattDisplayId() -> Bool {
+    guard let eventCode = rpid.eventCode else { return false }
+    return !eventCode.isEmpty
+  }
 
   // MARK: - Event Sinks
 
@@ -423,7 +429,7 @@ final class BarnardBleController: NSObject {
       permissions: [.readable]
     )
 
-    // B003 displayId (Read only, 4 bytes) — v2: was TEK, now SHA256(TEK)[0:4]
+    // B003 displayId (Read only, 4 bytes) — v2: was TEK, now event-scoped SHA256(TEK)[0:4]
     let displayIdCh = CBMutableCharacteristic(
       type: displayIdCharacteristicUUID,
       properties: [.read],
@@ -680,8 +686,10 @@ final class BarnardBleController: NSObject {
       )
 
       if rpidData.count == 17 {
+        let peerEnin = BarnardCrypto.calculateEnin(for: ts)
         knownPeers[id] = KnownPeer(
           rpid: rpidData,
+          enin: peerEnin,
           detectedDisplayId: detectedDisplayId,
           debugLocalName: lastDiscoveryNameById[id]
         )
@@ -919,8 +927,19 @@ extension BarnardBleController: CBCentralManagerDelegate {
     }
     #endif
 
-    if knownPeers[peripheral.identifier] != nil {
-      emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
+    if let knownPeer = knownPeers[peripheral.identifier] {
+      let currentEnin = BarnardCrypto.calculateEnin(for: now)
+      if knownPeer.enin == currentEnin {
+        emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
+      } else {
+        knownPeers.removeValue(forKey: peripheral.identifier)
+        emitDebug(level: "trace", name: "known_peer_rpid_expired", data: [
+          "id": peripheral.identifier.uuidString,
+          "cachedEnin": Int(knownPeer.enin),
+          "currentEnin": Int(currentEnin),
+        ])
+        enqueueConnect(peripheral)
+      }
     } else if isResolutionBackedOff(peripheral.identifier, now: now) {
       emitResolutionBackoff(peripheral.identifier, now: now)
     } else {
@@ -1168,7 +1187,15 @@ extension BarnardBleController: CBPeripheralManagerDelegate {
       )
 
     case displayIdCharacteristicUUID:
-      // v2: B003 always serves 4-byte SHA256(TEK)[0:4]. Read-only.
+      guard shouldServeGattDisplayId() else {
+        peripheral.respond(to: request, withResult: .readNotPermitted)
+        emitDebug(level: "trace", name: "gatt_reject_display_id_read", data: [
+          "reason": "not_joined_to_event",
+        ])
+        return
+      }
+
+      // v2: event-scoped B003 serves 4-byte SHA256(TEK)[0:4]. Read-only.
       let displayId = BarnardCrypto.displayId4(from: rpid.getCurrentTek())
       respondRead(
         peripheral,

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -125,8 +125,7 @@ final class BarnardBleController: NSObject {
   private var knownPeers: [UUID: KnownPeer] = [:]
 
   private func shouldServeGattDisplayId() -> Bool {
-    guard let eventCode = rpid.eventCode else { return false }
-    return !eventCode.isEmpty
+    BarnardV2Policy.shouldServeGattDisplayId(eventCode: rpid.eventCode)
   }
 
   // MARK: - Event Sinks
@@ -929,7 +928,7 @@ extension BarnardBleController: CBCentralManagerDelegate {
 
     if let knownPeer = knownPeers[peripheral.identifier] {
       let currentEnin = BarnardCrypto.calculateEnin(for: now)
-      if knownPeer.enin == currentEnin {
+      if BarnardV2Policy.KnownPeerWindow(enin: knownPeer.enin).matches(currentEnin) {
         emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
       } else {
         knownPeers.removeValue(forKey: peripheral.identifier)
@@ -938,6 +937,9 @@ extension BarnardBleController: CBCentralManagerDelegate {
           "cachedEnin": Int(knownPeer.enin),
           "currentEnin": Int(currentEnin),
         ])
+        // Force a fresh resolution. enqueueConnect dedups against in-flight /
+        // queued connects, so following advertisements on the same identifier
+        // remain safe.
         enqueueConnect(peripheral)
       }
     } else if isResolutionBackedOff(peripheral.identifier, now: now) {

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardV2Policy.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardV2Policy.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Pure-logic policy decisions for Barnard v2.
+///
+/// Mirrors `BarnardV2Policy` on the Android side so the same review-fix
+/// rules are expressed in the same shape on both platforms.
+enum BarnardV2Policy {
+  /// B003 displayId may only be served while the peripheral is joined to an event.
+  /// Anonymous reads are rejected so the device-secret-derived TEK does not
+  /// surface as a stable on-wire displayId.
+  static func shouldServeGattDisplayId(eventCode: String?) -> Bool {
+    guard let code = eventCode, !code.isEmpty else { return false }
+    return true
+  }
+
+  /// Cached known-peer RPID is reusable only within the ENIN window in which
+  /// it was resolved. After ENIN rotation the SDK must re-read B002/B003.
+  struct KnownPeerWindow {
+    let enin: UInt32
+    func matches(_ currentEnin: UInt32) -> Bool { enin == currentEnin }
+  }
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -811,6 +811,9 @@ internal class BarnardController(
                     "cachedEnin" to knownPeer.enin,
                     "currentEnin" to currentEnin,
                 ))
+                // Force a fresh resolution. enqueueConnect dedups against in-flight /
+                // queued connects, so following advertisements on the same address
+                // remain safe.
                 enqueueConnect(device)
             }
         } else if (isResolutionBackedOff(address, nowMs)) {

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -46,7 +46,7 @@ private const val TAG = "BarnardBLE"
  * callbacks (onEvent / onDebugEvent) instead of a method channel.
  *
  * - B002 RPID (Read, 17 bytes)
- * - B003 displayId (Read, 4 bytes) — SHA256(TEK)[0:4]
+ * - B003 displayId (Read, 4 bytes when joined to an event) — SHA256(TEK)[0:4]
  * - B004 EventCodeHash (Read, 0 or 8 bytes)
  *
  * TEK is never transmitted over BLE in v2.
@@ -125,6 +125,7 @@ internal class BarnardController(
 
     private data class KnownPeer(
         val rpid: ByteArray,
+        val enin: Long,
         val detectedDisplayId: String?
     )
 
@@ -798,8 +799,20 @@ internal class BarnardController(
             "name" to result.scanRecord?.deviceName
         ))
 
-        if (knownPeers.containsKey(address)) {
-            emitRssiUpdate(address, result.rssi, nowMs)
+        val knownPeer = knownPeers[address]
+        if (knownPeer != null) {
+            val currentEnin = BarnardCrypto.calculateEnin(nowMs).toLong()
+            if (BarnardV2Policy.KnownPeerWindow(knownPeer.enin).matches(currentEnin)) {
+                emitRssiUpdate(address, result.rssi, nowMs)
+            } else {
+                knownPeers.remove(address)
+                emitDebug("trace", "known_peer_rpid_expired", mapOf(
+                    "address" to address,
+                    "cachedEnin" to knownPeer.enin,
+                    "currentEnin" to currentEnin,
+                ))
+                enqueueConnect(device)
+            }
         } else if (isResolutionBackedOff(address, nowMs)) {
             emitResolutionBackoff(address, nowMs)
         } else {
@@ -1172,7 +1185,8 @@ internal class BarnardController(
                 resolutionBackoffUntilMs.remove(address)
 
                 if (rpidData.size == 17) {
-                    knownPeers[address] = KnownPeer(rpidData, detectedDisplayIdHex)
+                    val peerEnin = BarnardCrypto.calculateEnin(ts).toLong()
+                    knownPeers[address] = KnownPeer(rpidData, peerEnin, detectedDisplayIdHex)
                 }
             }
 
@@ -1211,6 +1225,14 @@ internal class BarnardController(
                 }
 
                 displayIdCharUuid -> {
+                    if (!BarnardV2Policy.shouldServeGattDisplayId(eventCode)) {
+                        server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+                        emitDebug("trace", "gatt_reject_display_id_read", mapOf(
+                            "reason" to "not_joined_to_event"
+                        ))
+                        return
+                    }
+
                     val displayId = BarnardCrypto.displayId4(currentTek)
                     val slice =
                         if (offset <= 0) displayId

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
@@ -1,0 +1,11 @@
+package network.greeting.barnard
+
+internal object BarnardV2Policy {
+    fun shouldServeGattDisplayId(eventCode: String?): Boolean {
+        return !eventCode.isNullOrEmpty()
+    }
+
+    data class KnownPeerWindow(val enin: Long) {
+        fun matches(currentEnin: Long): Boolean = enin == currentEnin
+    }
+}

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
@@ -1,0 +1,22 @@
+package network.greeting.barnard
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class BarnardV2PolicyTest {
+    @Test
+    fun shouldServeGattDisplayId_onlyWhenJoinedToEvent() {
+        assertFalse(BarnardV2Policy.shouldServeGattDisplayId(null))
+        assertFalse(BarnardV2Policy.shouldServeGattDisplayId(""))
+        assertTrue(BarnardV2Policy.shouldServeGattDisplayId("CONF-2026"))
+    }
+
+    @Test
+    fun knownPeerRpidIsReusableOnlyWithinSameEnin() {
+        val peer = BarnardV2Policy.KnownPeerWindow(enin = 1234)
+
+        assertTrue(peer.matches(1234))
+        assertFalse(peer.matches(1235))
+    }
+}

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -8,7 +8,7 @@ import UIKit
 /// Barnard v2 BLE controller (React Native bridge variant).
 ///
 /// - B002 RPID (Read, 17 bytes)
-/// - B003 displayId (Read, 4 bytes) — SHA256(TEK)[0:4]
+/// - B003 displayId (Read, 4 bytes when joined to an event) — SHA256(TEK)[0:4]
 /// - B004 EventCodeHash (Read, 0 or 8 bytes)
 ///
 /// TEK is never transmitted over BLE in v2.
@@ -92,10 +92,16 @@ final class BarnardBleController: NSObject {
 
   private struct KnownPeer {
     let rpid: Data
+    let enin: UInt32
     var detectedDisplayId: String?
   }
 
   private var knownPeers: [UUID: KnownPeer] = [:]
+
+  private func shouldServeGattDisplayId() -> Bool {
+    guard let eventCode = rpid.eventCode else { return false }
+    return !eventCode.isEmpty
+  }
 
   /// Event callback. `eventName` is one of: BarnardDetection, BarnardState,
   /// BarnardConstraint, BarnardError, BarnardRssiUpdate.
@@ -589,7 +595,12 @@ final class BarnardBleController: NSObject {
       )
 
       if rpidData.count == 17 {
-        knownPeers[id] = KnownPeer(rpid: rpidData, detectedDisplayId: detectedDisplayId)
+        let peerEnin = BarnardCrypto.calculateEnin(for: ts)
+        knownPeers[id] = KnownPeer(
+          rpid: rpidData,
+          enin: peerEnin,
+          detectedDisplayId: detectedDisplayId
+        )
         resolutionBackoffUntil.removeValue(forKey: id)
       }
     }
@@ -820,8 +831,19 @@ extension BarnardBleController: CBCentralManagerDelegate {
     }
     #endif
 
-    if knownPeers[peripheral.identifier] != nil {
-      emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
+    if let knownPeer = knownPeers[peripheral.identifier] {
+      let currentEnin = BarnardCrypto.calculateEnin(for: now)
+      if knownPeer.enin == currentEnin {
+        emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
+      } else {
+        knownPeers.removeValue(forKey: peripheral.identifier)
+        emitDebug(level: "trace", name: "known_peer_rpid_expired", data: [
+          "id": peripheral.identifier.uuidString,
+          "cachedEnin": Int(knownPeer.enin),
+          "currentEnin": Int(currentEnin),
+        ])
+        enqueueConnect(peripheral)
+      }
     } else if isResolutionBackedOff(peripheral.identifier, now: now) {
       emitResolutionBackoff(peripheral.identifier, now: now)
     } else {
@@ -1072,6 +1094,14 @@ extension BarnardBleController: CBPeripheralManagerDelegate {
       )
 
     case displayIdCharacteristicUUID:
+      guard shouldServeGattDisplayId() else {
+        peripheral.respond(to: request, withResult: .readNotPermitted)
+        emitDebug(level: "trace", name: "gatt_reject_display_id_read", data: [
+          "reason": "not_joined_to_event",
+        ])
+        return
+      }
+
       let displayId = BarnardCrypto.displayId4(from: rpid.getCurrentTek())
       respondRead(
         peripheral,

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -99,8 +99,7 @@ final class BarnardBleController: NSObject {
   private var knownPeers: [UUID: KnownPeer] = [:]
 
   private func shouldServeGattDisplayId() -> Bool {
-    guard let eventCode = rpid.eventCode else { return false }
-    return !eventCode.isEmpty
+    BarnardV2Policy.shouldServeGattDisplayId(eventCode: rpid.eventCode)
   }
 
   /// Event callback. `eventName` is one of: BarnardDetection, BarnardState,
@@ -833,7 +832,7 @@ extension BarnardBleController: CBCentralManagerDelegate {
 
     if let knownPeer = knownPeers[peripheral.identifier] {
       let currentEnin = BarnardCrypto.calculateEnin(for: now)
-      if knownPeer.enin == currentEnin {
+      if BarnardV2Policy.KnownPeerWindow(enin: knownPeer.enin).matches(currentEnin) {
         emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
       } else {
         knownPeers.removeValue(forKey: peripheral.identifier)
@@ -842,6 +841,9 @@ extension BarnardBleController: CBCentralManagerDelegate {
           "cachedEnin": Int(knownPeer.enin),
           "currentEnin": Int(currentEnin),
         ])
+        // Force a fresh resolution. enqueueConnect dedups against in-flight /
+        // queued connects, so following advertisements on the same identifier
+        // remain safe.
         enqueueConnect(peripheral)
       }
     } else if isResolutionBackedOff(peripheral.identifier, now: now) {

--- a/packages/react-native/barnard/ios/BarnardV2Policy.swift
+++ b/packages/react-native/barnard/ios/BarnardV2Policy.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Pure-logic policy decisions for Barnard v2.
+///
+/// Mirrors `BarnardV2Policy` on the Android side so the same review-fix
+/// rules are expressed in the same shape on both platforms.
+enum BarnardV2Policy {
+  /// B003 displayId may only be served while the peripheral is joined to an event.
+  /// Anonymous reads are rejected so the device-secret-derived TEK does not
+  /// surface as a stable on-wire displayId.
+  static func shouldServeGattDisplayId(eventCode: String?) -> Bool {
+    guard let code = eventCode, !code.isEmpty else { return false }
+    return true
+  }
+
+  /// Cached known-peer RPID is reusable only within the ENIN window in which
+  /// it was resolved. After ENIN rotation the SDK must re-read B002/B003.
+  struct KnownPeerWindow {
+    let enin: UInt32
+    func matches(_ currentEnin: UInt32) -> Bool { enin == currentEnin }
+  }
+}

--- a/specs/004-resolvable-id/spec.md
+++ b/specs/004-resolvable-id/spec.md
@@ -59,7 +59,7 @@ Service UUID: `0000B001-0000-1000-8000-00805F9B34FB`.
 | UUID | Role | Properties | Value | Length |
 |------|------|------------|-------|--------|
 | `0000B002-…` | RPID | Read | `[formatVersion + RPI(enin_now)]` | 17 B |
-| `0000B003-…` | displayId | Read | `SHA256(TEK)[0:4]` | 4 B |
+| `0000B003-…` | displayId | Read | `SHA256(TEK)[0:4]` only when joined to an event; read fails otherwise | 4 B or error |
 | `0000B004-…` | EventCodeHash | Read | `SHA256(EventCode)[0:8]` when joined, empty otherwise | 0 or 8 B |
 
 **v2 has no Write characteristics.** Any inbound write request is rejected with `.writeNotPermitted` (iOS) / `GATT_WRITE_NOT_PERMITTED` (Android).
@@ -80,7 +80,7 @@ Central                                   Peripheral
    │ ◀──── 17 bytes ─────────────────── │
    │                                       │
    │ ── read B003 (displayId) ──────────▶ │
-   │ ◀──── 4 bytes ──────────────────── │   (or error → see §5.2)
+   │ ◀──── 4 bytes ──────────────────── │   (or error/null → see §5.2)
    │                                       │
    │ ── disconnect ─────────────────────▶ │
    │                                       │
@@ -92,6 +92,8 @@ Central                                   Peripheral
 ### 5.2 B003 read-failure policy
 
 If B004 matches and B002 succeeds but the subsequent B003 read fails (timeout, error, missing characteristic, invalid length), the central side **still emits a `DetectionEvent`** with `detectedDisplayId = null`. Consumers always see the detection.
+
+When a peripheral has not joined an event, B003 read requests fail (`.readNotPermitted` on iOS / `GATT_READ_NOT_PERMITTED` on Android). This prevents the anonymous TEK, which is derived from the device secret, from becoming a stable on-wire displayId. A central observing such a peer still emits the detection with `detectedDisplayId = null` after B002 succeeds.
 
 A debug event with name `gatt_b003_read_failed` (error path) or `gatt_b003_missing` / `gatt_b003_invalid_length` accompanies the detection for diagnostics.
 
@@ -258,11 +260,12 @@ This is **not** part of the Barnard schema. Consumers customise the projection a
 - "eventMode" key on state events.
 
 ### Added
-- B003 serves 4-byte `SHA256(TEK)[0:4]`, Read-only.
+- B003 serves event-scoped 4-byte `SHA256(TEK)[0:4]`, Read-only; anonymous B003 reads fail.
 - `DetectionEvent.enin`, `reporterRpid`, `detectedDisplayId` (nullable).
 - `BarnardClient.myDisplayId`, `currentEnin`, `getCurrentRpi()`, `exportCurrentTek()`.
 - Lowercase-hex at the bridge boundary (was base64 in v1).
 - Atomic reporter RPID + ENIN snapshot.
+- Known-peer RSSI caches are ENIN-scoped; when the ENIN changes, the SDK re-reads B002/B003 before emitting more `rssi_update` events for that peer.
 
 ### Compatibility
 - **v1 ⇄ v2 BLE interoperability is not supported.** A v1 peer attempts a TEK Write on B003, which a v2 peripheral rejects; a v2 peer expects 4 bytes on B003, which a v1 peripheral cannot provide.


### PR DESCRIPTION
## Summary

Stacked on #44 / `feature/42-barnard-v2`.

This PR keeps the review-fix scope separate from the main Barnard v2 protocol PR:

- Reject B003 displayId reads while the peripheral is not joined to an event, so anonymous TEK-derived IDs are not exposed on wire.
- Keep B003 read failure non-fatal for centrals after B004 and B002 succeed, resulting in `detectedDisplayId = null`.
- Store the ENIN for each cached known-peer RPID and force a fresh B002/B003 GATT read when the scan timestamp moves to a new ENIN.
- Update spec 004 to document anonymous B003 rejection and ENIN-scoped known-peer caches.
- Add small Android policy tests for the two review decisions.

## Why

The main v2 PR removed TEK exchange, but review found two follow-up correctness issues:

- anonymous B003 reads could expose a stable displayId derived from device-secret TEK;
- long-running scans could emit `rssi_update.rpid` from a stale cached peer RPID after ENIN rotation.

## Validation

- `flutter analyze` in `packages/dart/barnard`
- `flutter test` in `packages/dart/barnard`
- `npm run typescript` in `packages/react-native/barnard`
- `npm test -- --runInBand` in `packages/react-native/barnard`
- `./gradlew :app:compileDebugKotlin` in `examples/flutter/barnard_poc/android`
- `./gradlew :barnard:compileDebugKotlin` in `examples/react-native/barnard_demo/android`
- `./gradlew :barnard:testDebugUnitTest --tests network.greeting.barnard.BarnardV2PolicyTest` in `examples/flutter/barnard_poc/android`
- `xcrun swiftc -parse` for Flutter and React Native iOS Barnard Swift sources

## Notes

- Full Flutter Android `:barnard:testDebugUnitTest` still fails in the pre-existing `BarnardPluginTest` Mockito setup; the new `BarnardV2PolicyTest` passes when selected directly.
- React Native Android unit test execution hit an Android JDK image transform environment error, but `:barnard:compileDebugKotlin` succeeds.

Refs #44