### PR TITLE
feat(enin): add configurable ENIN derivation [superseded by #51]

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -75,6 +75,9 @@ internal class BarnardController(
     private var allowDuplicates: Boolean = true
     private var formatVersion: Int = 1
     private var debugOriginalName: String? = null
+    private var eninMode: BarnardCrypto.EninMode = BarnardCrypto.EninMode.FIXED_LENGTH
+    private var eninSeconds: Long = 600L
+    private var beaconChain: BarnardCrypto.BeaconChainConfig = BarnardCrypto.BeaconChainConfig()
 
     // MARK: - Event Mode
 
@@ -186,6 +189,9 @@ internal class BarnardController(
                     "supportsGattFallback" to true,
                     "supportsBackground" to false,
                     "supportsHighRateRssi" to false,
+                    "eninMode" to eninModeName(),
+                    "eninSeconds" to eninSeconds,
+                    "beaconChain" to beaconChainMap(),
                 )
             )
 
@@ -194,9 +200,18 @@ internal class BarnardController(
                     "isScanning" to isScanning,
                     "isAdvertising" to isAdvertising,
                     "eventMode" to if (eventCode != null) "event" else "anonymous",
-                    "eventCode" to eventCode
+                    "eventCode" to eventCode,
+                    "eninMode" to eninModeName(),
+                    "eninSeconds" to eninSeconds,
+                    "beaconChain" to beaconChainMap(),
                 )
             )
+
+            "configure" -> {
+                val args = call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()
+                configure(args)
+                result.success(null)
+            }
 
             "getEventMode" -> result.success(
                 mapOf(
@@ -352,6 +367,50 @@ internal class BarnardController(
 
     private val isEventMode: Boolean
         get() = eventCode != null
+
+    private fun configure(args: Map<*, *>) {
+        eninMode = when (args["eninMode"] as? String) {
+            "beaconSlot" -> BarnardCrypto.EninMode.BEACON_SLOT
+            else -> BarnardCrypto.EninMode.FIXED_LENGTH
+        }
+        eninSeconds = ((args["eninSeconds"] as? Number)?.toLong() ?: 600L).coerceIn(12L, 3600L)
+
+        val chain = args["beaconChain"] as? Map<*, *>
+        beaconChain = BarnardCrypto.BeaconChainConfig(
+            chainId = chain?.get("chainId") as? String ?: "mainnet",
+            genesisUnixSeconds = (chain?.get("genesisUnixSeconds") as? Number)?.toLong() ?: 1606824023L,
+            slotSeconds = (chain?.get("slotSeconds") as? Number)?.toLong() ?: 12L,
+        )
+
+        knownPeers.clear()
+        emitDebug("info", "configure", mapOf(
+            "eninMode" to eninModeName(),
+            "eninSeconds" to eninSeconds,
+            "beaconChain" to beaconChainMap(),
+        ))
+    }
+
+    private fun currentEnin(timestampMs: Long = System.currentTimeMillis()): UInt {
+        return BarnardCrypto.calculateEnin(
+            timestampMs = timestampMs,
+            mode = eninMode,
+            eninSeconds = eninSeconds,
+            beaconChain = beaconChain,
+        )
+    }
+
+    private fun eninModeName(): String {
+        return when (eninMode) {
+            BarnardCrypto.EninMode.BEACON_SLOT -> "beaconSlot"
+            BarnardCrypto.EninMode.FIXED_LENGTH -> "fixedLength"
+        }
+    }
+
+    private fun beaconChainMap(): Map<String, Any> = mapOf(
+        "chainId" to beaconChain.chainId,
+        "genesisUnixSeconds" to beaconChain.effectiveGenesisUnixSeconds,
+        "slotSeconds" to beaconChain.effectiveSlotSeconds,
+    )
 
     private fun getEventCodeHash(): ByteArray {
         val code = eventCode ?: return ByteArray(0)
@@ -613,7 +672,7 @@ internal class BarnardController(
     // MARK: - RPID Payload Generation
 
     private fun computePayload(nowMs: Long): ByteArray {
-        val enin = BarnardCrypto.calculateEnin(nowMs)
+        val enin = currentEnin(nowMs)
         val rpik = BarnardCrypto.deriveRpik(currentTek)
         val rpi = BarnardCrypto.generateRpi(rpik, enin)
 
@@ -633,7 +692,10 @@ internal class BarnardController(
                 "isScanning" to isScanning,
                 "isAdvertising" to isAdvertising,
                 "eventMode" to if (isEventMode) "event" else "anonymous",
-                "eventCode" to eventCode
+                "eventCode" to eventCode,
+                "eninMode" to eninModeName(),
+                "eninSeconds" to eninSeconds,
+                "beaconChain" to beaconChainMap(),
             ),
             "reasonCode" to reasonCode,
         )
@@ -690,7 +752,13 @@ internal class BarnardController(
             val eventCodeHash = getEventCodeHash()
             val knownTeks = tekStorage.getTeks(eventCodeHash)
 
-            resolvedTekToEmit = BarnardCrypto.resolveRpi(rpid, knownTeks)
+            resolvedTekToEmit = BarnardCrypto.resolveRpi(
+                rpi = rpid,
+                knownTeks = knownTeks,
+                mode = eninMode,
+                eninSeconds = eninSeconds,
+                beaconChain = beaconChain,
+            )
             if (resolvedTekToEmit != null) {
                 // Update lastSeenAt
                 tekStorage.updateLastSeen(resolvedTekToEmit, eventCodeHash)

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
@@ -30,6 +30,18 @@ import javax.crypto.spec.SecretKeySpec
  * ```
  */
 object BarnardCrypto {
+    enum class EninMode { FIXED_LENGTH, BEACON_SLOT }
+
+    data class BeaconChainConfig(
+        val chainId: String = "mainnet",
+        val genesisUnixSeconds: Long = 1606824023L,
+        val slotSeconds: Long = 12L,
+    ) {
+        val effectiveGenesisUnixSeconds: Long
+            get() = genesisUnixSeconds.coerceAtLeast(0L)
+        val effectiveSlotSeconds: Long
+            get() = slotSeconds.coerceAtLeast(1L)
+    }
 
     // MARK: - TEK Derivation
 
@@ -118,8 +130,23 @@ object BarnardCrypto {
      *
      * Each ENIN represents a 10-minute interval.
      */
-    fun calculateEnin(timestampMs: Long = System.currentTimeMillis()): UInt {
-        return ((timestampMs / 1000) / 600).toUInt()
+    fun calculateEnin(
+        timestampMs: Long = System.currentTimeMillis(),
+        mode: EninMode = EninMode.FIXED_LENGTH,
+        eninSeconds: Long = 600L,
+        beaconChain: BeaconChainConfig = BeaconChainConfig(),
+    ): UInt {
+        val unixSeconds = timestampMs / 1000
+        return when (mode) {
+            EninMode.FIXED_LENGTH -> {
+                val effectiveSeconds = eninSeconds.coerceIn(12L, 3600L)
+                (unixSeconds / effectiveSeconds).toUInt()
+            }
+            EninMode.BEACON_SLOT -> {
+                val elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
+                if (elapsed <= 0L) 0U else (elapsed / beaconChain.effectiveSlotSeconds).toUInt()
+            }
+        }
     }
 
     // MARK: - EventCodeHash
@@ -148,10 +175,21 @@ object BarnardCrypto {
      * @param currentEnin Current ENIN (defaults to now)
      * @return The matching TEK if found, null otherwise
      */
-    fun resolveRpi(rpi: ByteArray, knownTeks: List<ByteArray>, currentEnin: UInt? = null): ByteArray? {
+    fun resolveRpi(
+        rpi: ByteArray,
+        knownTeks: List<ByteArray>,
+        currentEnin: UInt? = null,
+        mode: EninMode = EninMode.FIXED_LENGTH,
+        eninSeconds: Long = 600L,
+        beaconChain: BeaconChainConfig = BeaconChainConfig(),
+    ): ByteArray? {
         if (rpi.size != 16) return null
 
-        val enin = currentEnin ?: calculateEnin()
+        val enin = currentEnin ?: calculateEnin(
+            mode = mode,
+            eninSeconds = eninSeconds,
+            beaconChain = beaconChain,
+        )
 
         for (tek in knownTeks) {
             if (tek.size != 16) continue
@@ -160,7 +198,9 @@ object BarnardCrypto {
 
             // Search window: 6 intervals past + current + 1 future
             for (offset in -6..1) {
-                val testEnin = (enin.toInt() + offset).toUInt()
+                val testEninInt = enin.toInt() + offset
+                if (testEninInt < 0) continue
+                val testEnin = testEninInt.toUInt()
                 val candidate = generateRpi(rpik, testEnin)
 
                 if (candidate.contentEquals(rpi)) {

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -59,6 +59,9 @@ final class BarnardBleController: NSObject {
   private var isAdvertising = false
   private var allowDuplicates = true
   private var formatVersion: UInt8 = 1
+  private var eninMode: BarnardCrypto.EninMode = .fixedLength
+  private var eninSeconds: Int = 600
+  private var beaconChain: BarnardCrypto.BeaconChainConfig = .ethereumMainnet
 
   private var lastDiscoveryNameById: [UUID: String] = [:]
 
@@ -141,6 +144,9 @@ final class BarnardBleController: NSObject {
         "supportsGattFallback": true,
         "supportsBackground": false,
         "supportsHighRateRssi": false,
+        "eninMode": eninModeName(),
+        "eninSeconds": eninSeconds,
+        "beaconChain": beaconChainDict(),
       ])
 
     case "getState":
@@ -149,7 +155,15 @@ final class BarnardBleController: NSObject {
         "isAdvertising": isAdvertising,
         "eventMode": rpid.isEventMode ? "event" : "anonymous",
         "eventCode": rpid.eventCode as Any,
+        "eninMode": eninModeName(),
+        "eninSeconds": eninSeconds,
+        "beaconChain": beaconChainDict(),
       ])
+
+    case "configure":
+      let args = (call.arguments as? [String: Any]) ?? [:]
+      configure(args)
+      result(nil)
 
     case "getEventMode":
       result([
@@ -574,6 +588,41 @@ final class BarnardBleController: NSObject {
     return myHash == remoteHash
   }
 
+  private func configure(_ args: [String: Any]) {
+    eninMode = (args["eninMode"] as? String) == "beaconSlot" ? .beaconSlot : .fixedLength
+    let requestedSeconds = (args["eninSeconds"] as? Int) ?? 600
+    eninSeconds = min(max(requestedSeconds, 12), 3600)
+
+    let chain = args["beaconChain"] as? [String: Any]
+    beaconChain = BarnardCrypto.BeaconChainConfig(
+      chainId: (chain?["chainId"] as? String) ?? "mainnet",
+      genesisUnixSeconds: (chain?["genesisUnixSeconds"] as? Int) ?? 1_606_824_023,
+      slotSeconds: (chain?["slotSeconds"] as? Int) ?? 12
+    )
+
+    knownPeers.removeAll()
+    emitDebug(level: "info", name: "configure", data: [
+      "eninMode": eninModeName(),
+      "eninSeconds": eninSeconds,
+      "beaconChain": beaconChainDict(),
+    ])
+  }
+
+  private func eninModeName() -> String {
+    switch eninMode {
+    case .beaconSlot: return "beaconSlot"
+    case .fixedLength: return "fixedLength"
+    }
+  }
+
+  private func beaconChainDict() -> [String: Any] {
+    [
+      "chainId": beaconChain.chainId,
+      "genesisUnixSeconds": beaconChain.effectiveGenesisUnixSeconds,
+      "slotSeconds": beaconChain.effectiveSlotSeconds,
+    ]
+  }
+
   // MARK: - Event Emission
 
   private func emitState(reasonCode: String?) {
@@ -585,6 +634,9 @@ final class BarnardBleController: NSObject {
         "isAdvertising": isAdvertising,
         "eventMode": rpid.isEventMode ? "event" : "anonymous",
         "eventCode": rpid.eventCode as Any,
+        "eninMode": eninModeName(),
+        "eninSeconds": eninSeconds,
+        "beaconChain": beaconChainDict(),
       ],
       "reasonCode": reasonCode as Any,
     ])
@@ -638,7 +690,13 @@ final class BarnardBleController: NSObject {
       let eventCodeHash = rpid.getEventCodeHash()
       let knownTeks = tekStorage.getTeks(for: eventCodeHash)
 
-      if let matched = BarnardCrypto.resolveRpi(rpidBytes, knownTeks: knownTeks) {
+      if let matched = BarnardCrypto.resolveRpi(
+        rpidBytes,
+        knownTeks: knownTeks,
+        mode: eninMode,
+        eninSeconds: eninSeconds,
+        beaconChain: beaconChain
+      ) {
         resolvedTekToEmit = matched
         // Update lastSeenAt
         tekStorage.updateLastSeen(tek: matched, eventCodeHash: eventCodeHash)
@@ -901,7 +959,13 @@ extension BarnardBleController: CBPeripheralManagerDelegate {
   func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
     switch request.characteristic.uuid {
     case rpidCharacteristicUUID:
-      let payload = rpid.currentPayload(formatVersion: formatVersion, now: Date())
+      let payload = rpid.currentPayload(
+        formatVersion: formatVersion,
+        now: Date(),
+        eninMode: eninMode,
+        eninSeconds: eninSeconds,
+        beaconChain: beaconChain
+      )
       request.value = payload
       peripheral.respond(to: request, withResult: .success)
 

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCrypto.swift
@@ -22,6 +22,26 @@ import Foundation
 ///                      RPI = AES128-ECB(RPIK, PaddedData)
 /// ```
 enum BarnardCrypto {
+  enum EninMode {
+    case fixedLength
+    case beaconSlot
+  }
+
+  struct BeaconChainConfig {
+    let chainId: String
+    let genesisUnixSeconds: Int
+    let slotSeconds: Int
+
+    static let ethereumMainnet = BeaconChainConfig(
+      chainId: "mainnet",
+      genesisUnixSeconds: 1_606_824_023,
+      slotSeconds: 12
+    )
+
+    var effectiveGenesisUnixSeconds: Int { max(0, genesisUnixSeconds) }
+    var effectiveSlotSeconds: Int { max(1, slotSeconds) }
+  }
+
   // MARK: - TEK Derivation
 
   /// Derive TEK for Event Mode from DeviceSecret and EventCode.
@@ -143,8 +163,22 @@ enum BarnardCrypto {
   /// `ENIN = floor(unix_timestamp_seconds / 600)`
   ///
   /// Each ENIN represents a 10-minute interval.
-  static func calculateEnin(for date: Date = Date()) -> UInt32 {
-    UInt32(Int(date.timeIntervalSince1970) / 600)
+  static func calculateEnin(
+    for date: Date = Date(),
+    mode: EninMode = .fixedLength,
+    eninSeconds: Int = 600,
+    beaconChain: BeaconChainConfig = .ethereumMainnet
+  ) -> UInt32 {
+    let unixSeconds = Int(date.timeIntervalSince1970)
+    switch mode {
+    case .fixedLength:
+      let effectiveSeconds = min(max(eninSeconds, 12), 3600)
+      return UInt32(unixSeconds / effectiveSeconds)
+    case .beaconSlot:
+      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
+      if elapsed <= 0 { return 0 }
+      return UInt32(elapsed / beaconChain.effectiveSlotSeconds)
+    }
   }
 
   // MARK: - EventCodeHash
@@ -172,10 +206,21 @@ enum BarnardCrypto {
   ///   - knownTeks: List of known TEKs to search
   ///   - currentEnin: Current ENIN (defaults to now)
   /// - Returns: The matching TEK if found, nil otherwise
-  static func resolveRpi(_ rpi: Data, knownTeks: [Data], currentEnin: UInt32? = nil) -> Data? {
+  static func resolveRpi(
+    _ rpi: Data,
+    knownTeks: [Data],
+    currentEnin: UInt32? = nil,
+    mode: EninMode = .fixedLength,
+    eninSeconds: Int = 600,
+    beaconChain: BeaconChainConfig = .ethereumMainnet
+  ) -> Data? {
     guard rpi.count == 16 else { return nil }
 
-    let enin = currentEnin ?? calculateEnin()
+    let enin = currentEnin ?? calculateEnin(
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    )
 
     for tek in knownTeks {
       guard tek.count == 16 else { continue }
@@ -184,7 +229,9 @@ enum BarnardCrypto {
 
       // Search window: 6 intervals past + current + 1 future
       for offset in -6 ... 1 {
-        let testEnin = UInt32(Int(enin) + offset)
+        let testEninInt = Int(enin) + offset
+        if testEninInt < 0 { continue }
+        let testEnin = UInt32(testEninInt)
         let candidate = generateRpi(rpik: rpik, enin: testEnin)
 
         if candidate == rpi {

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardRpidGenerator.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardRpidGenerator.swift
@@ -103,8 +103,19 @@ final class BarnardRpidGenerator {
   ///   - formatVersion: Protocol version byte (default: 1)
   ///   - now: Current timestamp (default: now)
   /// - Returns: 17 bytes: [formatVersion(1) + RPI(16)]
-  func currentPayload(formatVersion: UInt8 = 1, now: Date = Date()) -> Data {
-    let enin = BarnardCrypto.calculateEnin(for: now)
+  func currentPayload(
+    formatVersion: UInt8 = 1,
+    now: Date = Date(),
+    eninMode: BarnardCrypto.EninMode = .fixedLength,
+    eninSeconds: Int = 600,
+    beaconChain: BarnardCrypto.BeaconChainConfig = .ethereumMainnet
+  ) -> Data {
+    let enin = BarnardCrypto.calculateEnin(
+      for: now,
+      mode: eninMode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    )
     let rpik = BarnardCrypto.deriveRpik(from: currentTek)
     let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: enin)
 

--- a/packages/dart/barnard/lib/src/domain/capabilities.dart
+++ b/packages/dart/barnard/lib/src/domain/capabilities.dart
@@ -1,3 +1,4 @@
+import "config.dart";
 import "transport.dart";
 
 class BarnardCapabilities {
@@ -7,6 +8,9 @@ class BarnardCapabilities {
     required this.supportsGattFallback,
     required this.supportsBackground,
     required this.supportsHighRateRssi,
+    this.eninMode = EninMode.fixedLength,
+    this.eninSeconds = 600,
+    this.beaconChain = BeaconChainConfig.ethereumMainnet,
   });
 
   final Set<TransportKind> supportedTransports;
@@ -22,4 +26,13 @@ class BarnardCapabilities {
 
   /// Whether this implementation can produce high-rate RSSI observations.
   final bool supportsHighRateRssi;
+
+  /// ENIN mode currently used by this implementation.
+  final EninMode eninMode;
+
+  /// Effective fixed-length ENIN window when [eninMode] is [EninMode.fixedLength].
+  final int eninSeconds;
+
+  /// Beacon Chain timing parameters when [eninMode] is [EninMode.beaconSlot].
+  final BeaconChainConfig beaconChain;
 }

--- a/packages/dart/barnard/lib/src/domain/config.dart
+++ b/packages/dart/barnard/lib/src/domain/config.dart
@@ -5,6 +5,9 @@ class BarnardConfig {
   const BarnardConfig({
     this.transport = TransportKind.ble,
     this.eventCode,
+    this.eninMode = EninMode.fixedLength,
+    this.eninSeconds = 600,
+    this.beaconChain = BeaconChainConfig.ethereumMainnet,
     this.tekStorage = const TekStorageConfig(),
     this.rpid = const RpidConfig(),
     this.rssi = const RssiConfig(),
@@ -25,12 +28,59 @@ class BarnardConfig {
   /// - Peers can be identified and tracked within the event scope
   final String? eventCode;
 
+  /// ENIN derivation mode. Defaults to GAEN-compatible fixed-length windows.
+  final EninMode eninMode;
+
+  /// Fixed-length ENIN window in seconds. Effective value is clamped to 12..3600.
+  final int eninSeconds;
+
+  /// Beacon Chain timing parameters used when [eninMode] is [EninMode.beaconSlot].
+  final BeaconChainConfig beaconChain;
+
   /// Configuration for TEK storage.
   final TekStorageConfig tekStorage;
 
   final RpidConfig rpid;
   final RssiConfig rssi;
   final ConnectConfig connect;
+
+  int get effectiveEninSeconds => eninSeconds.clamp(12, 3600);
+}
+
+enum EninMode { fixedLength, beaconSlot }
+
+class BeaconChainConfig {
+  const BeaconChainConfig({
+    required this.chainId,
+    required this.genesisUnixSeconds,
+    required this.slotSeconds,
+  });
+
+  static const ethereumMainnet = BeaconChainConfig(
+    chainId: "mainnet",
+    genesisUnixSeconds: 1606824023,
+    slotSeconds: 12,
+  );
+
+  final String chainId;
+  final int genesisUnixSeconds;
+  final int slotSeconds;
+
+  int get effectiveGenesisUnixSeconds =>
+      genesisUnixSeconds < 0 ? 0 : genesisUnixSeconds;
+
+  int get effectiveSlotSeconds => slotSeconds < 1 ? 1 : slotSeconds;
+
+  @override
+  bool operator ==(Object other) {
+    return other is BeaconChainConfig &&
+        other.chainId == chainId &&
+        other.genesisUnixSeconds == genesisUnixSeconds &&
+        other.slotSeconds == slotSeconds;
+  }
+
+  @override
+  int get hashCode => Object.hash(chainId, genesisUnixSeconds, slotSeconds);
 }
 
 class ScanConfig {

--- a/packages/dart/barnard/lib/src/domain/crypto.dart
+++ b/packages/dart/barnard/lib/src/domain/crypto.dart
@@ -28,6 +28,8 @@ import 'dart:typed_data';
 
 import 'package:pointycastle/export.dart';
 
+import 'config.dart';
+
 /// HKDF-SHA256 key derivation function (RFC 5869).
 ///
 /// - [ikm]: Input keying material
@@ -167,11 +169,26 @@ Uint8List generateRpi(Uint8List rpik, int enin) {
 
 /// Calculate ENIN (EN Interval Number) for a given timestamp.
 ///
-/// `ENIN = floor(unix_timestamp_seconds / 600)`
+/// Defaults to GAEN-compatible `floor(unix_timestamp_seconds / 600)`.
 ///
-/// Each ENIN represents a 10-minute interval.
-int calculateEnin(DateTime timestamp) {
-  return timestamp.millisecondsSinceEpoch ~/ 1000 ~/ 600;
+/// With [EninMode.beaconSlot], the returned ENIN is the Beacon Chain slot
+/// number for [beaconChain].
+int calculateEnin(
+  DateTime timestamp, {
+  EninMode mode = EninMode.fixedLength,
+  int eninSeconds = 600,
+  BeaconChainConfig beaconChain = BeaconChainConfig.ethereumMainnet,
+}) {
+  final int unixSeconds = timestamp.millisecondsSinceEpoch ~/ 1000;
+  switch (mode) {
+    case EninMode.fixedLength:
+      final int effectiveSeconds = eninSeconds.clamp(12, 3600);
+      return unixSeconds ~/ effectiveSeconds;
+    case EninMode.beaconSlot:
+      final int elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds;
+      if (elapsed <= 0) return 0;
+      return elapsed ~/ beaconChain.effectiveSlotSeconds;
+  }
 }
 
 /// Calculate EventCodeHash from EventCode.
@@ -203,6 +220,7 @@ Uint8List? resolveRpi({
     // Search window: 6 intervals past + current + 1 future
     for (var offset = -6; offset <= 1; offset++) {
       final enin = currentEnin + offset;
+      if (enin < 0) continue;
       final candidate = generateRpi(rpik, enin);
 
       if (_bytesEqual(candidate, rpi)) {
@@ -278,8 +296,17 @@ abstract class BarnardCrypto {
   }
 
   /// Calculate current ENIN.
-  static int currentEnin() {
-    return calculateEnin(DateTime.now());
+  static int currentEnin({
+    EninMode mode = EninMode.fixedLength,
+    int eninSeconds = 600,
+    BeaconChainConfig beaconChain = BeaconChainConfig.ethereumMainnet,
+  }) {
+    return calculateEnin(
+      DateTime.now(),
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain,
+    );
   }
 
   /// Attempt to resolve an RPI to a known TEK.

--- a/packages/dart/barnard/lib/src/domain/state.dart
+++ b/packages/dart/barnard/lib/src/domain/state.dart
@@ -1,14 +1,23 @@
+import "config.dart";
+
 class BarnardState {
   const BarnardState({
     required this.isScanning,
     required this.isAdvertising,
+    this.eninMode = EninMode.fixedLength,
+    this.eninSeconds = 600,
+    this.beaconChain = BeaconChainConfig.ethereumMainnet,
   });
 
   static const idle = BarnardState(isScanning: false, isAdvertising: false);
 
   final bool isScanning;
   final bool isAdvertising;
+  final EninMode eninMode;
+  final int eninSeconds;
+  final BeaconChainConfig beaconChain;
 
   @override
-  String toString() => "BarnardState(isScanning=$isScanning, isAdvertising=$isAdvertising)";
+  String toString() =>
+      "BarnardState(isScanning=$isScanning, isAdvertising=$isAdvertising, eninMode=$eninMode, eninSeconds=$eninSeconds, beaconChain=${beaconChain.chainId})";
 }

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
@@ -18,11 +18,11 @@ class BarnardBleClient implements BarnardClient {
     required EventMode initialMode,
     String? initialEventCode,
     String? initialMyResolvedDisplayId,
-  })  : _capabilities = capabilities,
-        _state = initialState,
-        _currentMode = initialMode,
-        _currentEventCode = initialEventCode,
-        _myResolvedDisplayId = initialMyResolvedDisplayId;
+  }) : _capabilities = capabilities,
+       _state = initialState,
+       _currentMode = initialMode,
+       _currentEventCode = initialEventCode,
+       _myResolvedDisplayId = initialMyResolvedDisplayId;
 
   static const MethodChannel _methods = MethodChannel("barnard/methods");
   static const EventChannel _eventsChannel = EventChannel("barnard/events");
@@ -51,19 +51,28 @@ class BarnardBleClient implements BarnardClient {
   String? _myResolvedDisplayId;
   bool _disposed = false;
 
-  static Future<BarnardBleClient> create() async {
+  static Future<BarnardBleClient> create({
+    BarnardConfig config = const BarnardConfig(),
+  }) async {
+    await _methods.invokeMethod<void>(
+      "configure",
+      _encodeBarnardConfig(config),
+    );
+
     final Map<Object?, Object?> capsMap =
         (await _methods.invokeMethod<Map<Object?, Object?>>(
-              "getCapabilities",
-            )) ??
-            <Object?, Object?>{};
+          "getCapabilities",
+        )) ??
+        <Object?, Object?>{};
     final Map<Object?, Object?> stateMap =
         (await _methods.invokeMethod<Map<Object?, Object?>>("getState")) ??
-            <Object?, Object?>{};
+        <Object?, Object?>{};
     Map<Object?, Object?> modeMap;
     try {
-      modeMap = (await _methods
-              .invokeMethod<Map<Object?, Object?>>("getEventMode")) ??
+      modeMap =
+          (await _methods.invokeMethod<Map<Object?, Object?>>(
+            "getEventMode",
+          )) ??
           <Object?, Object?>{};
     } on MissingPluginException {
       modeMap = <Object?, Object?>{};
@@ -72,8 +81,9 @@ class BarnardBleClient implements BarnardClient {
     }
 
     final String? modeStr = modeMap["mode"] as String?;
-    final EventMode initialMode =
-        modeStr == "event" ? EventMode.event : EventMode.anonymous;
+    final EventMode initialMode = modeStr == "event"
+        ? EventMode.event
+        : EventMode.anonymous;
     final String? eventCode = modeMap["eventCode"] as String?;
 
     // Fetch own resolved display ID
@@ -176,11 +186,11 @@ class BarnardBleClient implements BarnardClient {
   @override
   Future<BarnardStartResult> startAuto([AutoConfig? config]) async {
     _ensureNotDisposed();
-    final Map<Object?, Object?>? out =
-        await _methods.invokeMethod<Map<Object?, Object?>>(
-      "startAuto",
-      _encodeAutoConfig(config),
-    );
+    final Map<Object?, Object?>? out = await _methods
+        .invokeMethod<Map<Object?, Object?>>(
+          "startAuto",
+          _encodeAutoConfig(config),
+        );
     if (out == null) {
       return const BarnardStartResult(
         scanningStarted: false,
@@ -278,8 +288,9 @@ class BarnardBleClient implements BarnardClient {
     int? limit,
     List<int>? rpidBytes,
   }) {
-    final Uint8List? filterRpid =
-        rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
+    final Uint8List? filterRpid = rpidBytes == null
+        ? null
+        : Uint8List.fromList(rpidBytes);
     Iterable<RssiSample> samples = _rssiBuffer.toList();
     if (since != null) {
       samples = samples.where((RssiSample s) => !s.timestamp.isBefore(since));
@@ -313,10 +324,10 @@ class BarnardBleClient implements BarnardClient {
 }
 
 Map<String, Object?> _encodeScanConfig(ScanConfig? config) => <String, Object?>{
-      "transport": (config?.transport ?? TransportKind.ble).name,
-      "allowDuplicates":
-          config?.allowDuplicates ?? const ScanConfig().allowDuplicates,
-    };
+  "transport": (config?.transport ?? TransportKind.ble).name,
+  "allowDuplicates":
+      config?.allowDuplicates ?? const ScanConfig().allowDuplicates,
+};
 
 Map<String, Object?> _encodeAdvertiseConfig(AdvertiseConfig? config) =>
     <String, Object?>{
@@ -326,8 +337,21 @@ Map<String, Object?> _encodeAdvertiseConfig(AdvertiseConfig? config) =>
     };
 
 Map<String, Object?> _encodeAutoConfig(AutoConfig? config) => <String, Object?>{
-      "scan": _encodeScanConfig(config?.scan),
-      "advertise": _encodeAdvertiseConfig(config?.advertise),
+  "scan": _encodeScanConfig(config?.scan),
+  "advertise": _encodeAdvertiseConfig(config?.advertise),
+};
+
+Map<String, Object?> _encodeBarnardConfig(BarnardConfig config) =>
+    <String, Object?>{
+      "transport": config.transport.name,
+      "eventCode": config.eventCode,
+      "eninMode": config.eninMode.name,
+      "eninSeconds": config.effectiveEninSeconds,
+      "beaconChain": <String, Object?>{
+        "chainId": config.beaconChain.chainId,
+        "genesisUnixSeconds": config.beaconChain.effectiveGenesisUnixSeconds,
+        "slotSeconds": config.beaconChain.effectiveSlotSeconds,
+      },
     };
 
 BarnardStartResult _parseStartResult(Map<Object?, Object?> map) {
@@ -377,13 +401,45 @@ BarnardCapabilities _parseCapabilities(Map<Object?, Object?> map) {
     supportsGattFallback: map["supportsGattFallback"] == true,
     supportsBackground: map["supportsBackground"] == true,
     supportsHighRateRssi: map["supportsHighRateRssi"] == true,
+    eninMode: _parseEninMode(map["eninMode"]),
+    eninSeconds: ((map["eninSeconds"] as int?) ?? 600).clamp(12, 3600),
+    beaconChain: _parseBeaconChain(map["beaconChain"]),
   );
 }
 
 BarnardState _parseState(Map<Object?, Object?> map) {
   final bool isScanning = map["isScanning"] == true;
   final bool isAdvertising = map["isAdvertising"] == true;
-  return BarnardState(isScanning: isScanning, isAdvertising: isAdvertising);
+  return BarnardState(
+    isScanning: isScanning,
+    isAdvertising: isAdvertising,
+    eninMode: _parseEninMode(map["eninMode"]),
+    eninSeconds: ((map["eninSeconds"] as int?) ?? 600).clamp(12, 3600),
+    beaconChain: _parseBeaconChain(map["beaconChain"]),
+  );
+}
+
+EninMode _parseEninMode(Object? value) {
+  if (value == "beaconSlot") return EninMode.beaconSlot;
+  return EninMode.fixedLength;
+}
+
+BeaconChainConfig _parseBeaconChain(Object? value) {
+  if (value is! Map) return BeaconChainConfig.ethereumMainnet;
+  final String chainId =
+      (value["chainId"] as String?) ??
+      BeaconChainConfig.ethereumMainnet.chainId;
+  final int genesisUnixSeconds =
+      (value["genesisUnixSeconds"] as int?) ??
+      BeaconChainConfig.ethereumMainnet.genesisUnixSeconds;
+  final int slotSeconds =
+      (value["slotSeconds"] as int?) ??
+      BeaconChainConfig.ethereumMainnet.slotSeconds;
+  return BeaconChainConfig(
+    chainId: chainId,
+    genesisUnixSeconds: genesisUnixSeconds,
+    slotSeconds: slotSeconds,
+  );
 }
 
 BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
@@ -399,6 +455,9 @@ BarnardEvent _parseBarnardEvent(Map<Object?, Object?> map) {
         state: BarnardState(
           isScanning: state["isScanning"] == true,
           isAdvertising: state["isAdvertising"] == true,
+          eninMode: _parseEninMode(state["eninMode"]),
+          eninSeconds: ((state["eninSeconds"] as int?) ?? 600).clamp(12, 3600),
+          beaconChain: _parseBeaconChain(state["beaconChain"]),
         ),
         reasonCode: map["reasonCode"] as String?,
       );
@@ -492,8 +551,9 @@ BarnardDebugEvent _parseDebugEvent(Map<Object?, Object?> map) {
     _ => DebugLevel.info,
   };
   final String name = (map["name"] as String?) ?? "debug";
-  final Map<Object?, Object?>? rawData =
-      map["data"] is Map ? map["data"] as Map<Object?, Object?> : null;
+  final Map<Object?, Object?>? rawData = map["data"] is Map
+      ? map["data"] as Map<Object?, Object?>
+      : null;
   final Map<String, Object?>? data = rawData?.map(
     (k, v) => MapEntry(k.toString(), v),
   );

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
@@ -31,12 +31,14 @@ class MockBarnard implements BarnardClient {
   MockBarnard({
     int simulatedPeerCount = 50,
     int tickMs = 200,
+    BarnardConfig config = const BarnardConfig(),
     MockBarnardOverrides? overrides,
     Uint8List? deviceSecret,
-  })  : _tickMs = tickMs.clamp(50, 2000),
-        _random = Random(),
-        _overrides = overrides,
-        _deviceSecret = deviceSecret ?? _generateRandomBytes(32) {
+  }) : _tickMs = tickMs.clamp(50, 2000),
+       _random = Random(),
+       _config = config,
+       _overrides = overrides,
+       _deviceSecret = deviceSecret ?? _generateRandomBytes(32) {
     _peers = List<MockPeer>.generate(simulatedPeerCount.clamp(1, 2000), (
       int i,
     ) {
@@ -44,7 +46,7 @@ class MockBarnard implements BarnardClient {
       return MockPeer(id: i, seed: seed, transport: TransportKind.ble);
     });
 
-    _state = BarnardState.idle;
+    _state = _buildState(isScanning: false, isAdvertising: false);
     _events = StreamController<BarnardEvent>.broadcast();
     _debugEvents = StreamController<BarnardDebugEvent>.broadcast();
     _debugBuffer = RingBuffer<BarnardDebugEvent>(2000);
@@ -59,6 +61,7 @@ class MockBarnard implements BarnardClient {
 
   final int _tickMs;
   final Random _random;
+  final BarnardConfig _config;
   final MockBarnardOverrides? _overrides;
   final Uint8List _deviceSecret;
 
@@ -89,13 +92,16 @@ class MockBarnard implements BarnardClient {
   int get _maxAggEntries => max(2000, min(10000, _peers.length * 3));
 
   @override
-  BarnardCapabilities get capabilities => const BarnardCapabilities(
-        supportedTransports: {TransportKind.ble},
-        supportsConnectionlessRpid: true,
-        supportsGattFallback: false,
-        supportsBackground: false,
-        supportsHighRateRssi: true,
-      );
+  BarnardCapabilities get capabilities => BarnardCapabilities(
+    supportedTransports: const {TransportKind.ble},
+    supportsConnectionlessRpid: true,
+    supportsGattFallback: false,
+    supportsBackground: false,
+    supportsHighRateRssi: true,
+    eninMode: _effectiveEninMode,
+    eninSeconds: _effectiveEninSeconds,
+    beaconChain: _config.beaconChain,
+  );
 
   @override
   BarnardState get state => _state;
@@ -120,7 +126,7 @@ class MockBarnard implements BarnardClient {
     _ensureNotDisposed();
     if (_state.isScanning) return;
     _setState(
-      BarnardState(isScanning: true, isAdvertising: _state.isAdvertising),
+      _buildState(isScanning: true, isAdvertising: _state.isAdvertising),
       reasonCode: "scan_start",
     );
     _ensureTicker();
@@ -131,7 +137,7 @@ class MockBarnard implements BarnardClient {
     _ensureNotDisposed();
     if (!_state.isScanning) return;
     _setState(
-      BarnardState(isScanning: false, isAdvertising: _state.isAdvertising),
+      _buildState(isScanning: false, isAdvertising: _state.isAdvertising),
       reasonCode: "scan_stop",
     );
     _clearAggregation();
@@ -143,7 +149,7 @@ class MockBarnard implements BarnardClient {
     _ensureNotDisposed();
     if (_state.isAdvertising) return;
     _setState(
-      BarnardState(isScanning: _state.isScanning, isAdvertising: true),
+      _buildState(isScanning: _state.isScanning, isAdvertising: true),
       reasonCode: "advertise_start",
     );
     _ensureTicker();
@@ -154,7 +160,7 @@ class MockBarnard implements BarnardClient {
     _ensureNotDisposed();
     if (!_state.isAdvertising) return;
     _setState(
-      BarnardState(isScanning: _state.isScanning, isAdvertising: false),
+      _buildState(isScanning: _state.isScanning, isAdvertising: false),
       reasonCode: "advertise_stop",
     );
     _maybeStopTicker();
@@ -315,8 +321,9 @@ class MockBarnard implements BarnardClient {
     List<int>? rpidBytes,
   }) {
     final List<RssiSample> all = _rssiBuffer.toList();
-    final Uint8List? filterRpid =
-        rpidBytes == null ? null : Uint8List.fromList(rpidBytes);
+    final Uint8List? filterRpid = rpidBytes == null
+        ? null
+        : Uint8List.fromList(rpidBytes);
 
     Iterable<RssiSample> filtered = all;
     if (since != null) {
@@ -360,15 +367,14 @@ class MockBarnard implements BarnardClient {
     if (!_state.isScanning) return;
 
     final DateTime now = DateTime.now();
-    final int rotationSeconds = _clampRotationSeconds();
-    final int windowIndex =
-        (now.millisecondsSinceEpoch ~/ 1000) ~/ rotationSeconds;
+    final int windowIndex = _calculateEnin(now);
     if (_lastWindowIndex != windowIndex) {
       _lastWindowIndex = windowIndex;
       _clearAggregation();
       _emitDebug(DebugLevel.info, "mock_rotation_window", <String, Object?>{
         "windowIndex": windowIndex,
-        "rotationSeconds": rotationSeconds,
+        "eninMode": _effectiveEninMode.name,
+        "eninSeconds": _effectiveEninSeconds,
       });
     }
 
@@ -468,8 +474,8 @@ class MockBarnard implements BarnardClient {
 
     // Evict the least-recently-seen entries to keep the mock bounded.
     // This is O(n) but only triggers when the map exceeds the cap.
-    final List<MapEntry<String, _RssiAgg>> entries =
-        _aggByRpidKey.entries.toList(growable: false);
+    final List<MapEntry<String, _RssiAgg>> entries = _aggByRpidKey.entries
+        .toList(growable: false);
     entries.sort((a, b) {
       final DateTime aSeen =
           a.value.lastSeenAt ?? DateTime.fromMillisecondsSinceEpoch(0);
@@ -494,12 +500,34 @@ class MockBarnard implements BarnardClient {
     if (_disposed) throw StateError("MockBarnard is disposed");
   }
 
-  int _clampRotationSeconds() {
-    final int rotationSeconds =
-        _overrides?.rotationSeconds ?? const RpidConfig().rotationSeconds;
-    return rotationSeconds.clamp(
-      const RpidConfig().minRotationSeconds,
-      const RpidConfig().maxRotationSeconds,
+  EninMode get _effectiveEninMode => _overrides?.rotationSeconds == null
+      ? _config.eninMode
+      : EninMode.fixedLength;
+
+  int get _effectiveEninSeconds {
+    final int seconds = _overrides?.rotationSeconds ?? _config.eninSeconds;
+    return seconds.clamp(12, 3600);
+  }
+
+  int _calculateEnin(DateTime timestamp) {
+    return calculateEnin(
+      timestamp,
+      mode: _effectiveEninMode,
+      eninSeconds: _effectiveEninSeconds,
+      beaconChain: _config.beaconChain,
+    );
+  }
+
+  BarnardState _buildState({
+    required bool isScanning,
+    required bool isAdvertising,
+  }) {
+    return BarnardState(
+      isScanning: isScanning,
+      isAdvertising: isAdvertising,
+      eninMode: _effectiveEninMode,
+      eninSeconds: _effectiveEninSeconds,
+      beaconChain: _config.beaconChain,
     );
   }
 

--- a/packages/dart/barnard/test/config_test.dart
+++ b/packages/dart/barnard/test/config_test.dart
@@ -1,0 +1,50 @@
+import "package:barnard/barnard.dart";
+import "package:barnard/mock_barnard.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ENIN config", () {
+    test("BarnardConfig defaults to GAEN-compatible fixed-length ENIN", () {
+      const config = BarnardConfig();
+
+      expect(config.eninMode, equals(EninMode.fixedLength));
+      expect(config.effectiveEninSeconds, equals(600));
+      expect(config.beaconChain, equals(BeaconChainConfig.ethereumMainnet));
+    });
+
+    test("BarnardConfig clamps fixed-length ENIN seconds", () {
+      const tooShort = BarnardConfig(eninSeconds: 1);
+      const tooLong = BarnardConfig(eninSeconds: 7200);
+
+      expect(tooShort.effectiveEninSeconds, equals(12));
+      expect(tooLong.effectiveEninSeconds, equals(3600));
+    });
+
+    test("BeaconChainConfig validates effective timing parameters", () {
+      const config = BeaconChainConfig(
+        chainId: "local",
+        genesisUnixSeconds: -1,
+        slotSeconds: 0,
+      );
+
+      expect(config.effectiveGenesisUnixSeconds, equals(0));
+      expect(config.effectiveSlotSeconds, equals(1));
+    });
+
+    test("MockBarnard surfaces ENIN mode in capabilities and state", () {
+      final barnard = MockBarnard(
+        config: const BarnardConfig(
+          eninMode: EninMode.beaconSlot,
+          beaconChain: BeaconChainConfig.ethereumMainnet,
+        ),
+      );
+
+      expect(barnard.capabilities.eninMode, equals(EninMode.beaconSlot));
+      expect(barnard.state.eninMode, equals(EninMode.beaconSlot));
+      expect(
+        barnard.state.beaconChain,
+        equals(BeaconChainConfig.ethereumMainnet),
+      );
+    });
+  });
+}

--- a/packages/dart/barnard/test/crypto_test.dart
+++ b/packages/dart/barnard/test/crypto_test.dart
@@ -83,17 +83,21 @@ void main() {
       expect(tek1, isNot(equals(tek2)));
     });
 
-    test("deriveTek produces different output for different device secrets",
-        () {
-      final deviceSecret1 = Uint8List.fromList(List.generate(32, (i) => i));
-      final deviceSecret2 = Uint8List.fromList(List.generate(32, (i) => i + 1));
-      const eventCode = "TECH2026";
+    test(
+      "deriveTek produces different output for different device secrets",
+      () {
+        final deviceSecret1 = Uint8List.fromList(List.generate(32, (i) => i));
+        final deviceSecret2 = Uint8List.fromList(
+          List.generate(32, (i) => i + 1),
+        );
+        const eventCode = "TECH2026";
 
-      final tek1 = deriveTek(deviceSecret1, eventCode);
-      final tek2 = deriveTek(deviceSecret2, eventCode);
+        final tek1 = deriveTek(deviceSecret1, eventCode);
+        final tek2 = deriveTek(deviceSecret2, eventCode);
 
-      expect(tek1, isNot(equals(tek2)));
-    });
+        expect(tek1, isNot(equals(tek2)));
+      },
+    );
   });
 
   group("RPIK derivation", () {
@@ -173,8 +177,10 @@ void main() {
   group("ENIN calculation", () {
     test("calculateEnin returns correct value", () {
       // UNIX timestamp 1736947200 = 2026-01-15 12:00:00 UTC
-      final timestamp =
-          DateTime.fromMillisecondsSinceEpoch(1736947200 * 1000, isUtc: true);
+      final timestamp = DateTime.fromMillisecondsSinceEpoch(
+        1736947200 * 1000,
+        isUtc: true,
+      );
 
       final enin = calculateEnin(timestamp);
 
@@ -183,11 +189,14 @@ void main() {
     });
 
     test("calculateEnin changes every 10 minutes", () {
-      final timestamp1 =
-          DateTime.fromMillisecondsSinceEpoch(1736947200 * 1000, isUtc: true);
+      final timestamp1 = DateTime.fromMillisecondsSinceEpoch(
+        1736947200 * 1000,
+        isUtc: true,
+      );
       final timestamp2 = DateTime.fromMillisecondsSinceEpoch(
-          (1736947200 + 600) * 1000,
-          isUtc: true);
+        (1736947200 + 600) * 1000,
+        isUtc: true,
+      );
 
       final enin1 = calculateEnin(timestamp1);
       final enin2 = calculateEnin(timestamp2);
@@ -196,16 +205,87 @@ void main() {
     });
 
     test("calculateEnin is stable within 10-minute window", () {
-      final timestamp1 =
-          DateTime.fromMillisecondsSinceEpoch(1736947200 * 1000, isUtc: true);
+      final timestamp1 = DateTime.fromMillisecondsSinceEpoch(
+        1736947200 * 1000,
+        isUtc: true,
+      );
       final timestamp2 = DateTime.fromMillisecondsSinceEpoch(
-          (1736947200 + 599) * 1000,
-          isUtc: true);
+        (1736947200 + 599) * 1000,
+        isUtc: true,
+      );
 
       final enin1 = calculateEnin(timestamp1);
       final enin2 = calculateEnin(timestamp2);
 
       expect(enin1, equals(enin2));
+    });
+
+    test("calculateEnin supports fixed-length windows", () {
+      final timestamp = DateTime.fromMillisecondsSinceEpoch(
+        1736947224 * 1000,
+        isUtc: true,
+      );
+
+      final enin = calculateEnin(
+        timestamp,
+        mode: EninMode.fixedLength,
+        eninSeconds: 12,
+      );
+
+      expect(enin, equals(144745602));
+    });
+
+    test("calculateEnin clamps fixed-length windows to safe bounds", () {
+      final timestamp = DateTime.fromMillisecondsSinceEpoch(
+        3600 * 1000,
+        isUtc: true,
+      );
+
+      expect(calculateEnin(timestamp, eninSeconds: 1), equals(300));
+      expect(calculateEnin(timestamp, eninSeconds: 7200), equals(1));
+    });
+
+    test("calculateEnin supports Beacon Chain slot identity", () {
+      final timestamp = DateTime.fromMillisecondsSinceEpoch(
+        (BeaconChainConfig.ethereumMainnet.genesisUnixSeconds + 24) * 1000,
+        isUtc: true,
+      );
+
+      final enin = calculateEnin(
+        timestamp,
+        mode: EninMode.beaconSlot,
+        beaconChain: BeaconChainConfig.ethereumMainnet,
+      );
+
+      expect(enin, equals(2));
+    });
+
+    test(
+      "calculateEnin clamps pre-genesis Beacon Chain timestamps to zero",
+      () {
+        final timestamp = DateTime.fromMillisecondsSinceEpoch(
+          (BeaconChainConfig.ethereumMainnet.genesisUnixSeconds - 1) * 1000,
+          isUtc: true,
+        );
+
+        final enin = calculateEnin(
+          timestamp,
+          mode: EninMode.beaconSlot,
+          beaconChain: BeaconChainConfig.ethereumMainnet,
+        );
+
+        expect(enin, equals(0));
+      },
+    );
+
+    test("resolveRpi skips negative ENIN candidates near zero", () {
+      final rpi = Uint8List.fromList(List.generate(16, (i) => i));
+      final tek = Uint8List.fromList(List.generate(16, (i) => i + 1));
+
+      expect(
+        () => resolveRpi(rpi: rpi, knownTeks: <Uint8List>[tek], currentEnin: 0),
+        returnsNormally,
+      );
     });
   });
 
@@ -227,16 +307,18 @@ void main() {
       expect(hash1, equals(hash2));
     });
 
-    test("calculateEventCodeHash produces different output for different codes",
-        () {
-      const eventCode1 = "EVENT_A";
-      const eventCode2 = "EVENT_B";
+    test(
+      "calculateEventCodeHash produces different output for different codes",
+      () {
+        const eventCode1 = "EVENT_A";
+        const eventCode2 = "EVENT_B";
 
-      final hash1 = calculateEventCodeHash(eventCode1);
-      final hash2 = calculateEventCodeHash(eventCode2);
+        final hash1 = calculateEventCodeHash(eventCode1);
+        final hash2 = calculateEventCodeHash(eventCode2);
 
-      expect(hash1, isNot(equals(hash2)));
-    });
+        expect(hash1, isNot(equals(hash2)));
+      },
+    );
   });
 
   group("RPI resolution", () {

--- a/schema/barnard/v1/README.md
+++ b/schema/barnard/v1/README.md
@@ -9,4 +9,6 @@ This is the shared source of truth for:
 Notes
 - Terminology is not translated: **Scan / Advertise / Central / Peripheral / GATT / Transport**
 - `DetectionEvent` is based on receiver-observed facts: `rpid + rssi + timestamp`
-
+- ENIN derivation is explicit in config/capabilities/state:
+  - `fixedLength`: `floor(unix_seconds / eninSeconds)`, with `eninSeconds` in `12..3600`
+  - `beaconSlot`: ENIN is the Beacon Chain slot number for the configured chain

--- a/schema/barnard/v1/capabilities.schema.json
+++ b/schema/barnard/v1/capabilities.schema.json
@@ -13,14 +13,23 @@
     "supportsConnectionlessRpid": { "type": "boolean" },
     "supportsGattFallback": { "type": "boolean" },
     "supportsBackground": { "type": "boolean" },
-    "supportsHighRateRssi": { "type": "boolean" }
+    "supportsHighRateRssi": { "type": "boolean" },
+    "eninMode": { "$ref": "common.schema.json#/$defs/EninMode" },
+    "eninSeconds": {
+      "type": "integer",
+      "minimum": 12,
+      "maximum": 3600
+    },
+    "beaconChain": { "$ref": "common.schema.json#/$defs/BeaconChainConfig" }
   },
   "required": [
     "supportedTransports",
     "supportsConnectionlessRpid",
     "supportsGattFallback",
     "supportsBackground",
-    "supportsHighRateRssi"
+    "supportsHighRateRssi",
+    "eninMode",
+    "eninSeconds",
+    "beaconChain"
   ]
 }
-

--- a/schema/barnard/v1/common.schema.json
+++ b/schema/barnard/v1/common.schema.json
@@ -8,6 +8,20 @@
       "type": "string",
       "enum": ["ble", "uwb", "thread", "unknown"]
     },
+    "EninMode": {
+      "type": "string",
+      "enum": ["fixedLength", "beaconSlot"]
+    },
+    "BeaconChainConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "chainId": { "type": "string", "minLength": 1 },
+        "genesisUnixSeconds": { "type": "integer", "minimum": 0 },
+        "slotSeconds": { "type": "integer", "minimum": 1 }
+      },
+      "required": ["chainId", "genesisUnixSeconds", "slotSeconds"]
+    },
     "DebugLevel": {
       "type": "string",
       "enum": ["trace", "info", "warn", "error"]
@@ -33,4 +47,3 @@
     }
   }
 }
-

--- a/schema/barnard/v1/config.schema.json
+++ b/schema/barnard/v1/config.schema.json
@@ -6,11 +6,20 @@
   "additionalProperties": false,
   "properties": {
     "transport": { "$ref": "common.schema.json#/$defs/TransportKind" },
+    "eventCode": { "type": ["string", "null"] },
+    "eninMode": { "$ref": "common.schema.json#/$defs/EninMode" },
+    "eninSeconds": {
+      "type": "integer",
+      "minimum": 12,
+      "maximum": 3600,
+      "description": "Fixed-length ENIN window in seconds when eninMode is fixedLength. Default is 600."
+    },
+    "beaconChain": { "$ref": "common.schema.json#/$defs/BeaconChainConfig" },
     "rpid": { "$ref": "#/$defs/RpidConfig" },
     "rssi": { "$ref": "#/$defs/RssiConfig" },
     "connect": { "$ref": "#/$defs/ConnectConfig" }
   },
-  "required": ["transport", "rpid", "rssi", "connect"],
+  "required": ["transport", "eninMode", "eninSeconds", "beaconChain", "rpid", "rssi", "connect"],
   "$defs": {
     "RpidConfig": {
       "type": "object",
@@ -52,4 +61,3 @@
     }
   }
 }
-

--- a/schema/barnard/v1/events.schema.json
+++ b/schema/barnard/v1/events.schema.json
@@ -64,9 +64,16 @@
           "additionalProperties": false,
           "properties": {
             "isScanning": { "type": "boolean" },
-            "isAdvertising": { "type": "boolean" }
+            "isAdvertising": { "type": "boolean" },
+            "eninMode": { "$ref": "common.schema.json#/$defs/EninMode" },
+            "eninSeconds": {
+              "type": "integer",
+              "minimum": 12,
+              "maximum": 3600
+            },
+            "beaconChain": { "$ref": "common.schema.json#/$defs/BeaconChainConfig" }
           },
-          "required": ["isScanning", "isAdvertising"]
+          "required": ["isScanning", "isAdvertising", "eninMode", "eninSeconds", "beaconChain"]
         },
         "reasonCode": { "type": ["string", "null"] }
       },

--- a/specs/004-resolvable-id/spec.md
+++ b/specs/004-resolvable-id/spec.md
@@ -42,8 +42,8 @@ Key constraint: **No global device uniqueness** - identity must be scoped to a s
 | **Event Code** | User-input string (e.g., "TECH2026") shared among event participants |
 | **TEK** | Temporary Exposure Key (16 bytes), derived from DeviceSecret + Event Code |
 | **RPIK** | RPI Key (16 bytes), derived from TEK |
-| **RPI** | Rolling Proximity Identifier (16 bytes), rotates every 10-15 minutes |
-| **ENIN** | EN Interval Number = floor(unix_timestamp / 600) |
+| **RPI** | Rolling Proximity Identifier (16 bytes), rotates at ENIN boundaries |
+| **ENIN** | EN Interval Number. Default is `floor(unix_timestamp / 600)`; Beacon Slot mode makes ENIN equal to an Ethereum Beacon Chain slot number. |
 | **displayId** | Event-scoped device ID: first 3 bytes of TEK as hex (6 chars) |
 
 ## Two Modes
@@ -89,13 +89,33 @@ DeviceSecret (32 bytes, device-generated, never transmitted)
     where PaddedData = "EN-RPI" (6 bytes) ‖ 0x000000000000 (6 bytes) ‖ ENIN (4 bytes, big-endian)
 ```
 
-### ENIN Calculation
+### ENIN Derivation Modes
+
+Barnard supports two ENIN derivation modes. Peers in the same event MUST use the same `(eninMode, eninSeconds, beaconChain)` parameters; otherwise they derive different RPIs and detections can fail to resolve.
+
+#### Mode A: fixedLength
 
 ```
-ENIN = floor(unix_timestamp_seconds / 600)
+ENIN = floor(unix_timestamp_seconds / eninSeconds)
 ```
 
-Each ENIN represents a 10-minute interval. RPI rotates at ENIN boundaries.
+- Default: `eninMode = fixedLength`, `eninSeconds = 600`.
+- `eninSeconds` is clamped to `12..3600`.
+- This preserves GAEN-compatible behavior when unset.
+- This mode has no external time-anchor semantics; ENIN is only a Barnard-internal counter.
+
+#### Mode B: beaconSlot
+
+```
+ENIN = floor((unix_timestamp_seconds - beaconChain.genesisUnixSeconds) / beaconChain.slotSeconds)
+```
+
+- Default Beacon Chain preset: Ethereum mainnet, `genesisUnixSeconds = 1606824023`, `slotSeconds = 12`.
+- Pre-genesis timestamps clamp to ENIN `0`.
+- In this mode, the ENIN integer is semantically the Beacon Chain slot number.
+- Attestation consumers MUST NOT interpret ENIN values from one chain under another chain's timing parameters.
+
+Beacon Slot mode is recommended for attendance-proof flows that commit observations onchain because the ENIN can be verified against the beacon slot's canonical time axis. The on-wire RPID and event shapes do not add device-unique persistent identifiers; the existing RPI payload remains `[formatVersion + RPI]`.
 
 ### EventCodeHash Calculation
 
@@ -293,12 +313,34 @@ class BarnardConfig {
   const BarnardConfig({
     this.transport = TransportKind.ble,
     this.eventCode,  // null for Anonymous Mode
+    this.eninMode = EninMode.fixedLength,
+    this.eninSeconds = 600,
+    this.beaconChain = BeaconChainConfig.ethereumMainnet,
     this.tekStorage = const TekStorageConfig(),
     // ... existing fields
   });
   
   final String? eventCode;
+  final EninMode eninMode;
+  final int eninSeconds; // effective value clamped to 12..3600
+  final BeaconChainConfig beaconChain;
   final TekStorageConfig tekStorage;
+}
+
+enum EninMode { fixedLength, beaconSlot }
+
+class BeaconChainConfig {
+  const BeaconChainConfig({
+    required this.chainId,
+    required this.genesisUnixSeconds,
+    required this.slotSeconds,
+  });
+
+  static const ethereumMainnet = BeaconChainConfig(
+    chainId: "mainnet",
+    genesisUnixSeconds: 1606824023,
+    slotSeconds: 12,
+  );
 }
 
 class TekStorageConfig {


### PR DESCRIPTION
Superseded by #51.

#50 was created from the pre-v2 merge base and conflicted with the current `main` after #44/#48. I rebuilt the #43 change on top of latest `main` in #51 instead.