### PR TITLE
Control BLE permission prompts and manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,23 @@ It focuses on **Scan/Advertise** and delivering a stable event model (main + deb
 - `schema/` — language-agnostic **JSON Schemas** (source of truth for event/config/capabilities shapes)
 - `packages/`
   - `packages/dart/barnard/` — Flutter plugin package (public API + mock + real BLE Transport)
+  - `packages/react-native/barnard/` — React Native package (TypeScript API + native BLE Transport)
 - `examples/`
   - `examples/dart/barnard_demo/` — demo using the mock implementation
   - `examples/flutter/barnard_poc/` — Flutter PoC app (real BLE via GATT-first RPID read)
+  - `examples/react-native/barnard_demo/` — React Native demo app
 - `.github/workflows/` — CI (Flutter analyze/test, Android plugin unit tests, and demos)
 
-## Dart (Flutter) quick start
+## Package READMEs
+
+Start with the package README for the platform you are integrating:
+
+- [Flutter/Dart package](packages/dart/barnard/README.md)
+- [React Native package](packages/react-native/barnard/README.md)
+
+Those documents cover installation, iOS `Info.plist` setup, Android manifest merge behavior, runtime permission APIs, and minimal Scan / Advertise usage.
+
+## Flutter quick start
 
 From `packages/dart/barnard`:
 
@@ -48,7 +59,21 @@ flutter pub get
 flutter run
 ```
 
+## React Native quick start
+
+From `packages/react-native/barnard`:
+
+```bash
+npm install
+npm test
+```
+
+Run the React Native demo from `examples/react-native/barnard_demo` after installing its app dependencies and native platform dependencies.
+
 ## Principles
 
 - Detection is based on **receiver-observed facts**: `rpid + rssi + timestamp`
-- Cross-language consistency is driven by **JSON Schema** under `schema/barnard/v1`
+- Cross-language consistency is driven by **JSON Schema** under `schema/barnard/v2`
+- On-wire BLE payloads must not contain device-unique persistent identifiers
+- Host apps control OS permission dialog timing through Barnard permission APIs
+- Android uses `neverForLocation` for Barnard's default BLE Scan permission; host apps that use BLE Scan results themselves for physical location can override that merged declaration

--- a/README.md
+++ b/README.md
@@ -76,4 +76,5 @@ Run the React Native demo from `examples/react-native/barnard_demo` after instal
 - Cross-language consistency is driven by **JSON Schema** under `schema/barnard/v2`
 - On-wire BLE payloads must not contain device-unique persistent identifiers
 - Host apps control OS permission dialog timing through Barnard permission APIs
+- Host apps can detect blocked runtime permissions and send users to app settings instead of retrying dialogs the OS will not show
 - Android uses `neverForLocation` for Barnard's default BLE Scan permission; host apps that use BLE Scan results themselves for physical location can override that merged declaration

--- a/examples/flutter/barnard_poc/README.md
+++ b/examples/flutter/barnard_poc/README.md
@@ -12,4 +12,4 @@ flutter run
 ## Notes
 
 - iOS requires `NSBluetoothAlwaysUsageDescription` (and typically `NSBluetoothPeripheralUsageDescription`) in `Info.plist`.
-- Android requires BLE permissions (Android 12+) and location permission on Android 11 and below.
+- Android BLE and legacy location manifest declarations are supplied by the Barnard plugin. The app calls Barnard's permission API for runtime prompts.

--- a/examples/flutter/barnard_poc/README.md
+++ b/examples/flutter/barnard_poc/README.md
@@ -13,3 +13,4 @@ flutter run
 
 - iOS requires `NSBluetoothAlwaysUsageDescription` (and typically `NSBluetoothPeripheralUsageDescription`) in `Info.plist`.
 - Android BLE and legacy location manifest declarations are supplied by the Barnard plugin. The app calls Barnard's permission API for runtime prompts.
+- `flutter run` debug sessions may show iOS's Local Network dialog for Flutter tooling / VM Service discovery. That dialog is separate from Barnard's Bluetooth permission flow and is not triggered by Barnard BLE registration.

--- a/examples/flutter/barnard_poc/android/app/src/main/AndroidManifest.xml
+++ b/examples/flutter/barnard_poc/android/app/src/main/AndroidManifest.xml
@@ -1,17 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Bluetooth Permissions -->
-    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
-
-    <!-- Location Permissions (only needed for Android 11 and below when not using neverForLocation) -->
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
-
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
-
     <application
         android:label="barnard_ble_example"
         android:name="${applicationName}"

--- a/examples/flutter/barnard_poc/ios/Podfile.lock
+++ b/examples/flutter/barnard_poc/ios/Podfile.lock
@@ -1,21 +1,15 @@
 PODS:
   - Flutter (1.0.0)
-  - permission_handler_apple (9.3.0):
-    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  permission_handler_apple:
-    :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
 
 PODFILE CHECKSUM: d71a8f9d234bf288cee64b372c30c196c8075224
 

--- a/examples/flutter/barnard_poc/ios/Runner.xcodeproj/project.pbxproj
+++ b/examples/flutter/barnard_poc/ios/Runner.xcodeproj/project.pbxproj
@@ -201,7 +201,6 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				DF5A6CAE8359459D405F3871 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -353,23 +352,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		DF5A6CAE8359459D405F3871 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/examples/flutter/barnard_poc/lib/driver_main.dart
+++ b/examples/flutter/barnard_poc/lib/driver_main.dart
@@ -1,0 +1,9 @@
+// ignore: depend_on_referenced_packages
+import "package:flutter_driver/driver_extension.dart";
+
+import "main.dart" as app_main;
+
+void main() {
+  enableFlutterDriverExtension();
+  app_main.main();
+}

--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -58,6 +58,10 @@ ScanResolutionState scanResolutionForDebugEvent(
 bool isDebugPeerLocalName(String? name) =>
     name != null && RegExp(r"^BND-[0-9A-F]{4}$").hasMatch(name);
 
+bool shouldRefreshPermissionsForLifecycle(AppLifecycleState state) {
+  return state == AppLifecycleState.resumed;
+}
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -65,7 +69,7 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   final GlobalKey<ScaffoldMessengerState> _messengerKey =
       GlobalKey<ScaffoldMessengerState>();
   BarnardBleClient? _client;
@@ -125,6 +129,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _init();
     _uiTicker = Timer.periodic(const Duration(seconds: 1), (_) {
       if (!mounted) return;
@@ -134,12 +139,19 @@ class _MyAppState extends State<MyApp> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _eventsSub?.cancel();
     _debugSub?.cancel();
     _client?.dispose();
     _eventCodeController.dispose();
     _uiTicker?.cancel();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!shouldRefreshPermissionsForLifecycle(state)) return;
+    unawaited(_refreshPermissions());
   }
 
   Future<void> _init() async {
@@ -238,6 +250,14 @@ class _MyAppState extends State<MyApp> {
         _eventCodeController.text = client.currentEventCode!;
       }
     });
+  }
+
+  Future<void> _refreshPermissions() async {
+    final BarnardBleClient? client = _client;
+    if (client == null) return;
+    final BarnardPermissionStatus status = await client.getPermissionStatus();
+    if (!mounted) return;
+    setState(() => _permissionStatus = status);
   }
 
   Future<bool> _ensurePermissionsForStart(BarnardBleClient client) async {

--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -244,18 +244,37 @@ class _MyAppState extends State<MyApp> {
     final BarnardPermissionStatus status = await client.getPermissionStatus();
     if (mounted) setState(() => _permissionStatus = status);
     if (status.allGranted) return true;
+    if (status.hasBlockedPermissions) {
+      _showMessage("Enable Nearby devices in app settings");
+      return false;
+    }
 
     final BarnardPermissionStatus requested = await client.requestPermissions();
     if (mounted) setState(() => _permissionStatus = requested);
     if (requested.allGranted) return true;
+    if (requested.hasBlockedPermissions) {
+      _showMessage("Enable Nearby devices in app settings");
+      return false;
+    }
 
     _showMessage("Bluetooth permission is required");
     return false;
   }
 
   Future<void> _requestPermissionsNow() => _run((c) async {
+    final BarnardPermissionStatus status = await c.getPermissionStatus();
+    if (mounted) setState(() => _permissionStatus = status);
+    if (status.hasBlockedPermissions) {
+      await c.openAppSettings();
+      return;
+    }
+
     final BarnardPermissionStatus requested = await c.requestPermissions();
     if (mounted) setState(() => _permissionStatus = requested);
+    if (requested.hasBlockedPermissions) {
+      _showMessage("Enable Nearby devices in app settings");
+      return;
+    }
     if (!requested.allGranted) {
       _showMessage("Bluetooth permission is required");
     }
@@ -933,6 +952,7 @@ class _PermissionStrip extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme cs = Theme.of(context).colorScheme;
     final bool granted = status?.allGranted == true;
+    final bool blocked = status?.hasBlockedPermissions == true;
     final String label = _permissionLabel(status);
     return Container(
       key: barnardPermissionStripKey,
@@ -965,8 +985,11 @@ class _PermissionStrip extends StatelessWidget {
             TextButton.icon(
               key: barnardAllowBluetoothButtonKey,
               onPressed: busy ? null : onRequestPermissions,
-              icon: const Icon(Icons.verified_user, size: 16),
-              label: const Text("Allow"),
+              icon: Icon(
+                blocked ? Icons.settings : Icons.verified_user,
+                size: 16,
+              ),
+              label: Text(blocked ? "Settings" : "Allow"),
             ),
         ],
       ),
@@ -976,6 +999,7 @@ class _PermissionStrip extends StatelessWidget {
   String _permissionLabel(BarnardPermissionStatus? status) {
     if (status == null) return "Bluetooth: Checking";
     if (status.allGranted) return "Bluetooth: Allowed";
+    if (status.hasBlockedPermissions) return "Bluetooth: Open Settings";
     final String missing = status.missingPermissions.join(", ");
     if (missing.isEmpty) return "Bluetooth: Not allowed";
     return "Bluetooth: ${missing.replaceAll("ios.bluetooth", "Not determined")}";

--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -7,7 +7,6 @@ import "package:barnard/barnard.dart";
 import "package:barnard/barnard_ble.dart";
 import "package:flutter/material.dart";
 import "package:flutter/services.dart" show Clipboard, ClipboardData;
-import "package:permission_handler/permission_handler.dart";
 
 void main() => runApp(const MyApp());
 
@@ -130,9 +129,9 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _init() async {
-    await _ensurePermissions();
     await _smokeLog.reset();
     final BarnardBleClient client = await BarnardBleClient.create();
+    await _ensurePermissions(client);
 
     _eventsSub = client.events.listen((BarnardEvent e) {
       unawaited(_smokeLog.write(_formatEventForSmokeLog(e)));
@@ -225,13 +224,10 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-  Future<void> _ensurePermissions() async {
-    if (!Platform.isAndroid) return;
-    await <Permission>[
-      Permission.bluetoothScan,
-      Permission.bluetoothConnect,
-      Permission.bluetoothAdvertise,
-    ].request();
+  Future<void> _ensurePermissions(BarnardBleClient client) async {
+    final BarnardPermissionStatus status = await client.getPermissionStatus();
+    if (status.allGranted) return;
+    await client.requestPermissions();
   }
 
   String _formatEventForSmokeLog(BarnardEvent e) {

--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -64,6 +64,7 @@ class _MyAppState extends State<MyApp> {
   );
 
   BarnardState _state = BarnardState.idle;
+  BarnardPermissionStatus? _permissionStatus;
   final List<BarnardEvent> _events = <BarnardEvent>[];
   final List<BarnardDebugEvent> _debugEvents = <BarnardDebugEvent>[];
   final Map<String, _SeenEntry> _seenById = <String, _SeenEntry>{};
@@ -131,7 +132,8 @@ class _MyAppState extends State<MyApp> {
   Future<void> _init() async {
     await _smokeLog.reset();
     final BarnardBleClient client = await BarnardBleClient.create();
-    await _ensurePermissions(client);
+    final BarnardPermissionStatus permissionStatus = await client
+        .getPermissionStatus();
 
     _eventsSub = client.events.listen((BarnardEvent e) {
       unawaited(_smokeLog.write(_formatEventForSmokeLog(e)));
@@ -217,6 +219,7 @@ class _MyAppState extends State<MyApp> {
     setState(() {
       _client = client;
       _state = client.state;
+      _permissionStatus = permissionStatus;
       if (client.currentEventCode != null &&
           client.currentEventCode!.isNotEmpty) {
         _eventCodeController.text = client.currentEventCode!;
@@ -224,11 +227,26 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
-  Future<void> _ensurePermissions(BarnardBleClient client) async {
+  Future<bool> _ensurePermissionsForStart(BarnardBleClient client) async {
     final BarnardPermissionStatus status = await client.getPermissionStatus();
-    if (status.allGranted) return;
-    await client.requestPermissions();
+    if (mounted) setState(() => _permissionStatus = status);
+    if (status.allGranted) return true;
+
+    final BarnardPermissionStatus requested = await client.requestPermissions();
+    if (mounted) setState(() => _permissionStatus = requested);
+    if (requested.allGranted) return true;
+
+    _showMessage("Bluetooth permission is required");
+    return false;
   }
+
+  Future<void> _requestPermissionsNow() => _run((c) async {
+    final BarnardPermissionStatus requested = await c.requestPermissions();
+    if (mounted) setState(() => _permissionStatus = requested);
+    if (!requested.allGranted) {
+      _showMessage("Bluetooth permission is required");
+    }
+  });
 
   String _formatEventForSmokeLog(BarnardEvent e) {
     if (e is DetectionEvent) {
@@ -326,6 +344,7 @@ class _MyAppState extends State<MyApp> {
     if (_state.isScanning) {
       await c.stopScan();
     } else {
+      if (!await _ensurePermissionsForStart(c)) return;
       await _ensureEventJoined(c);
       await c.startScan(const ScanConfig(allowDuplicates: true));
     }
@@ -335,6 +354,7 @@ class _MyAppState extends State<MyApp> {
     if (_state.isAdvertising) {
       await c.stopAdvertise();
     } else {
+      if (!await _ensurePermissionsForStart(c)) return;
       await _ensureEventJoined(c);
       await c.startAdvertise(const AdvertiseConfig());
     }
@@ -344,6 +364,7 @@ class _MyAppState extends State<MyApp> {
     if (_state.isScanning || _state.isAdvertising) {
       await c.stopAuto();
     } else {
+      if (!await _ensurePermissionsForStart(c)) return;
       await _ensureEventJoined(c);
       await c.startAuto(const AutoConfig());
     }
@@ -447,11 +468,13 @@ class _MyAppState extends State<MyApp> {
                     _ControlPanel(
                       eventCodeController: _eventCodeController,
                       state: _state,
+                      permissionStatus: _permissionStatus,
                       busy: _busy,
                       onToggleScan: _toggleScan,
                       onToggleAdvertise: _toggleAdvertise,
                       onToggleAuto: _toggleAuto,
                       onExportTek: _exportTek,
+                      onRequestPermissions: _requestPermissionsNow,
                     ),
                     const Divider(height: 1),
                     Expanded(
@@ -813,20 +836,24 @@ class _ControlPanel extends StatelessWidget {
   const _ControlPanel({
     required this.eventCodeController,
     required this.state,
+    required this.permissionStatus,
     required this.busy,
     required this.onToggleScan,
     required this.onToggleAdvertise,
     required this.onToggleAuto,
     required this.onExportTek,
+    required this.onRequestPermissions,
   });
 
   final TextEditingController eventCodeController;
   final BarnardState state;
+  final BarnardPermissionStatus? permissionStatus;
   final bool busy;
   final VoidCallback onToggleScan;
   final VoidCallback onToggleAdvertise;
   final VoidCallback onToggleAuto;
   final VoidCallback onExportTek;
+  final VoidCallback onRequestPermissions;
 
   @override
   Widget build(BuildContext context) {
@@ -859,6 +886,12 @@ class _ControlPanel extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 8),
+          _PermissionStrip(
+            status: permissionStatus,
+            busy: busy,
+            onRequestPermissions: onRequestPermissions,
+          ),
+          const SizedBox(height: 8),
           _PrimaryActionButton(
             state: state,
             busy: busy,
@@ -869,6 +902,68 @@ class _ControlPanel extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+class _PermissionStrip extends StatelessWidget {
+  const _PermissionStrip({
+    required this.status,
+    required this.busy,
+    required this.onRequestPermissions,
+  });
+
+  final BarnardPermissionStatus? status;
+  final bool busy;
+  final VoidCallback onRequestPermissions;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    final bool granted = status?.allGranted == true;
+    final String label = _permissionLabel(status);
+    return Container(
+      height: 40,
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      decoration: BoxDecoration(
+        color: granted ? cs.secondaryContainer : cs.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: <Widget>[
+          Icon(
+            granted ? Icons.bluetooth_connected : Icons.bluetooth_disabled,
+            size: 18,
+            color: granted ? cs.onSecondaryContainer : cs.onErrorContainer,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: granted ? cs.onSecondaryContainer : cs.onErrorContainer,
+                fontWeight: FontWeight.w600,
+                fontSize: 13,
+              ),
+            ),
+          ),
+          if (!granted)
+            TextButton.icon(
+              onPressed: busy ? null : onRequestPermissions,
+              icon: const Icon(Icons.verified_user, size: 16),
+              label: const Text("Allow"),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _permissionLabel(BarnardPermissionStatus? status) {
+    if (status == null) return "Bluetooth: Checking";
+    if (status.allGranted) return "Bluetooth: Allowed";
+    final String missing = status.missingPermissions.join(", ");
+    if (missing.isEmpty) return "Bluetooth: Not allowed";
+    return "Bluetooth: ${missing.replaceAll("ios.bluetooth", "Not determined")}";
   }
 }
 

--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -10,6 +10,19 @@ import "package:flutter/services.dart" show Clipboard, ClipboardData;
 
 void main() => runApp(const MyApp());
 
+const Key barnardPermissionStripKey = ValueKey<String>(
+  "barnard_permission_strip",
+);
+const Key barnardAllowBluetoothButtonKey = ValueKey<String>(
+  "barnard_allow_bluetooth_button",
+);
+const Key barnardStartAutoButtonKey = ValueKey<String>(
+  "barnard_start_auto_button",
+);
+const Key barnardControlMenuButtonKey = ValueKey<String>(
+  "barnard_control_menu_button",
+);
+
 bool shouldJoinEventForInput(String? currentEventCode, String input) {
   final String code = input.trim();
   return code.isNotEmpty && currentEventCode != code;
@@ -922,6 +935,7 @@ class _PermissionStrip extends StatelessWidget {
     final bool granted = status?.allGranted == true;
     final String label = _permissionLabel(status);
     return Container(
+      key: barnardPermissionStripKey,
       height: 40,
       padding: const EdgeInsets.symmetric(horizontal: 10),
       decoration: BoxDecoration(
@@ -949,6 +963,7 @@ class _PermissionStrip extends StatelessWidget {
           ),
           if (!granted)
             TextButton.icon(
+              key: barnardAllowBluetoothButtonKey,
               onPressed: busy ? null : onRequestPermissions,
               icon: const Icon(Icons.verified_user, size: 16),
               label: const Text("Allow"),
@@ -1005,6 +1020,7 @@ class _PrimaryActionButton extends StatelessWidget {
                 bottomLeft: Radius.circular(22),
               ),
               child: InkWell(
+                key: barnardStartAutoButtonKey,
                 onTap: primaryOnTap,
                 borderRadius: const BorderRadius.only(
                   topLeft: Radius.circular(22),
@@ -1058,6 +1074,7 @@ class _PrimaryActionButton extends StatelessWidget {
               bottomRight: Radius.circular(22),
             ),
             child: PopupMenuButton<_ControlMenuAction>(
+              key: barnardControlMenuButtonKey,
               tooltip: "Scan / Advertise only",
               enabled: !busy,
               onSelected: (action) {

--- a/examples/flutter/barnard_poc/pubspec.yaml
+++ b/examples/flutter/barnard_poc/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
   cupertino_icons: ^1.0.8
 
 dev_dependencies:
+  flutter_driver:
+    sdk: flutter
   integration_test:
     sdk: flutter
   flutter_test:

--- a/examples/flutter/barnard_poc/pubspec.yaml
+++ b/examples/flutter/barnard_poc/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  permission_handler: ^11.4.0
 
 dev_dependencies:
   integration_test:

--- a/examples/flutter/barnard_poc/test/driver_entrypoint_test.dart
+++ b/examples/flutter/barnard_poc/test/driver_entrypoint_test.dart
@@ -1,0 +1,12 @@
+import "package:flutter/widgets.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:barnard_poc/main.dart";
+
+void main() {
+  test("exposes stable keys for Flutter Driver smoke checks", () {
+    expect(barnardPermissionStripKey, isA<ValueKey<String>>());
+    expect(barnardAllowBluetoothButtonKey, isA<ValueKey<String>>());
+    expect(barnardStartAutoButtonKey, isA<ValueKey<String>>());
+    expect(barnardControlMenuButtonKey, isA<ValueKey<String>>());
+  });
+}

--- a/examples/flutter/barnard_poc/test/smoke_test.dart
+++ b/examples/flutter/barnard_poc/test/smoke_test.dart
@@ -1,3 +1,4 @@
+import "package:flutter/widgets.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:barnard_poc/main.dart";
 
@@ -91,5 +92,32 @@ void main() {
       expect(isDebugPeerLocalName("BND-d6a7"), isFalse);
       expect(isDebugPeerLocalName(null), isFalse);
     });
+  });
+
+  group("shouldRefreshPermissionsForLifecycle", () {
+    test("refreshes permissions when returning to the app", () {
+      expect(
+        shouldRefreshPermissionsForLifecycle(AppLifecycleState.resumed),
+        isTrue,
+      );
+    });
+
+    test(
+      "does not refresh permissions while the app is leaving foreground",
+      () {
+        expect(
+          shouldRefreshPermissionsForLifecycle(AppLifecycleState.inactive),
+          isFalse,
+        );
+        expect(
+          shouldRefreshPermissionsForLifecycle(AppLifecycleState.paused),
+          isFalse,
+        );
+        expect(
+          shouldRefreshPermissionsForLifecycle(AppLifecycleState.detached),
+          isFalse,
+        );
+      },
+    );
   });
 }

--- a/examples/react-native/barnard_demo/README.md
+++ b/examples/react-native/barnard_demo/README.md
@@ -53,7 +53,7 @@ npx react-native run-android
 
 ## Usage
 
-1. **Grant Permissions**: When the app launches, it will request Bluetooth permissions
+1. **Grant Permissions**: The app calls Barnard's permission API when it is ready to show Bluetooth permission dialogs
 2. **Start All**: Tap "Start All" to begin scanning and advertising
 3. **View Detections**: Nearby devices running the same app will appear in the detection list
 4. **Individual Controls**: Use "Start Scan" and "Start Adv" for granular control
@@ -72,20 +72,20 @@ To test proximity detection:
 - **iOS**: Requires physical device (BLE not supported in simulator)
 - **Android**: Requires physical device with BLE support
 - **Background mode**: Not supported in this MVP version
-- **Permissions**: Make sure to grant all Bluetooth permissions when prompted
+- **Permissions**: Barnard supplies Android manifest declarations; grant the runtime permissions when prompted
 
 ## Troubleshooting
 
 ### iOS
 
 - If pods fail to install, try `pod repo update` then `pod install`
-- Ensure Bluetooth permissions are set in Info.plist
+- Ensure Bluetooth usage-description strings are set in Info.plist
 - Physical device required (simulator doesn't support BLE)
 
 ### Android
 
 - Ensure Android SDK is properly configured
-- Check that all Bluetooth permissions are granted
+- Check that Barnard runtime permissions are granted
 - Try rebuilding if native modules don't link: `cd android && ./gradlew clean`
 
 ## Related

--- a/examples/react-native/barnard_demo/README.md
+++ b/examples/react-native/barnard_demo/README.md
@@ -70,6 +70,7 @@ To test proximity detection:
 ## Notes
 
 - **iOS**: Requires physical device (BLE not supported in simulator)
+- **iOS Debug**: React Native / Flutter-style debug tooling can show the Local Network dialog for development server or VM Service discovery. That dialog is separate from Barnard's Bluetooth permission flow.
 - **Android**: Requires physical device with BLE support
 - **Background mode**: Not supported in this MVP version
 - **Permissions**: Barnard supplies Android manifest declarations; grant the runtime permissions when prompted

--- a/examples/react-native/barnard_demo/android/app/src/main/AndroidManifest.xml
+++ b/examples/react-native/barnard_demo/android/app/src/main/AndroidManifest.xml
@@ -1,22 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    
-    <!-- Bluetooth permissions for Android 12+ (API 31+) -->
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
-                     android:usesPermissionFlags="neverForLocation" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    
-    <!-- Legacy Bluetooth permissions for Android 11 and below -->
-    <uses-permission android:name="android.permission.BLUETOOTH" 
-                     android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" 
-                     android:maxSdkVersion="30" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" 
-                     android:maxSdkVersion="30" />
-    
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
 
     <application
       android:name=".MainApplication"

--- a/examples/react-native/barnard_demo/src/App.tsx
+++ b/examples/react-native/barnard_demo/src/App.tsx
@@ -7,6 +7,7 @@ import {
   View,
   Button,
   Alert,
+  AppState,
   Platform,
 } from 'react-native';
 import {
@@ -140,9 +141,15 @@ const App = () => {
     });
 
     const id = setInterval(refreshIdentity, 3000);
+    const appStateSubscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') {
+        refreshPermissions();
+      }
+    });
 
     return () => {
       clearInterval(id);
+      appStateSubscription.remove();
       unsubDetection();
       unsubState();
       unsubConstraint();

--- a/examples/react-native/barnard_demo/src/App.tsx
+++ b/examples/react-native/barnard_demo/src/App.tsx
@@ -6,8 +6,6 @@ import {
   Text,
   View,
   Button,
-  PermissionsAndroid,
-  Platform,
   Alert,
 } from 'react-native';
 import {
@@ -37,40 +35,14 @@ const App = () => {
   const [permissionsGranted, setPermissionsGranted] = useState(false);
 
   const requestPermissions = useCallback(async () => {
-    if (Platform.OS === 'android') {
-      if (Platform.Version >= 31) {
-        const result = await PermissionsAndroid.requestMultiple([
-          PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
-          PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
-          PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
-        ]);
-        const granted = Object.values(result).every(
-          (status) => status === PermissionsAndroid.RESULTS.GRANTED
-        );
-        setPermissionsGranted(granted);
-        if (!granted) {
-          Alert.alert('Permissions Required', 'Please grant all Bluetooth permissions');
-        }
-        return granted;
-      } else {
-        const result = await PermissionsAndroid.requestMultiple([
-          PermissionsAndroid.PERMISSIONS.BLUETOOTH,
-          PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADMIN,
-          PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
-        ]);
-        const granted = Object.values(result).every(
-          (status) => status === PermissionsAndroid.RESULTS.GRANTED
-        );
-        setPermissionsGranted(granted);
-        if (!granted) {
-          Alert.alert('Permissions Required', 'Please grant all Bluetooth permissions');
-        }
-        return granted;
-      }
+    const status = await manager.requestPermissions();
+    const granted = status.missingPermissions.length === 0;
+    setPermissionsGranted(granted);
+    if (!granted) {
+      Alert.alert('Permissions Required', 'Please grant all Bluetooth permissions');
     }
-    setPermissionsGranted(true);
-    return true;
-  }, []);
+    return granted;
+  }, [manager]);
 
   const refreshIdentity = useCallback(async () => {
     try {

--- a/examples/react-native/barnard_demo/src/App.tsx
+++ b/examples/react-native/barnard_demo/src/App.tsx
@@ -7,11 +7,13 @@ import {
   View,
   Button,
   Alert,
+  Platform,
 } from 'react-native';
 import {
   BarnardManager,
   DetectionEvent,
   BarnardCapabilities,
+  BarnardPermissionStatus,
   BarnardState,
 } from 'barnard';
 
@@ -24,6 +26,15 @@ interface Detection {
   transport: string;
 }
 
+const permissionStatusLabel = (status: BarnardPermissionStatus | null): string => {
+  if (!status) return 'Checking';
+  if (status.missingPermissions.length === 0) return 'Allowed';
+  if (status.missingPermissions.includes('ios.bluetooth')) {
+    return 'Not determined';
+  }
+  return status.missingPermissions.join(', ');
+};
+
 const App = () => {
   const [manager] = useState(() => new BarnardManager());
   const [capabilities, setCapabilities] = useState<BarnardCapabilities | null>(null);
@@ -33,9 +44,18 @@ const App = () => {
   const [currentEventCode, setCurrentEventCode] = useState<string | null>(null);
   const [detections, setDetections] = useState<Detection[]>([]);
   const [permissionsGranted, setPermissionsGranted] = useState(false);
+  const [permissionStatus, setPermissionStatus] = useState<BarnardPermissionStatus | null>(null);
+
+  const refreshPermissions = useCallback(async () => {
+    const status = await manager.getPermissionStatus();
+    setPermissionStatus(status);
+    setPermissionsGranted(status.missingPermissions.length === 0);
+    return status;
+  }, [manager]);
 
   const requestPermissions = useCallback(async () => {
     const status = await manager.requestPermissions();
+    setPermissionStatus(status);
     const granted = status.missingPermissions.length === 0;
     setPermissionsGranted(granted);
     if (!granted) {
@@ -60,7 +80,7 @@ const App = () => {
   }, [manager]);
 
   useEffect(() => {
-    requestPermissions();
+    refreshPermissions();
 
     manager.getCapabilities().then((caps) => {
       setCapabilities(caps);
@@ -117,7 +137,7 @@ const App = () => {
       unsubDebug();
       manager.dispose();
     };
-  }, [manager, refreshIdentity, requestPermissions]);
+  }, [manager, refreshIdentity, refreshPermissions]);
 
   const handleStartAuto = async () => {
     if (!permissionsGranted) {
@@ -192,6 +212,14 @@ const App = () => {
           <Text style={styles.infoText}>
             Permissions: {permissionsGranted ? '✓' : '✗'}
           </Text>
+          <Text style={styles.infoText}>
+            Bluetooth: {permissionStatusLabel(permissionStatus)}
+          </Text>
+          {!permissionsGranted && (
+            <View style={styles.buttonRow}>
+              <Button title="Allow Bluetooth" onPress={requestPermissions} />
+            </View>
+          )}
         </View>
 
         <View style={styles.section}>

--- a/examples/react-native/barnard_demo/src/App.tsx
+++ b/examples/react-native/barnard_demo/src/App.tsx
@@ -29,6 +29,7 @@ interface Detection {
 const permissionStatusLabel = (status: BarnardPermissionStatus | null): string => {
   if (!status) return 'Checking';
   if (status.missingPermissions.length === 0) return 'Allowed';
+  if (status.blockedPermissions.length > 0) return 'Open Settings';
   if (status.missingPermissions.includes('ios.bluetooth')) {
     return 'Not determined';
   }
@@ -54,12 +55,24 @@ const App = () => {
   }, [manager]);
 
   const requestPermissions = useCallback(async () => {
+    const current = await manager.getPermissionStatus();
+    setPermissionStatus(current);
+    if (current.blockedPermissions.length > 0) {
+      await manager.openAppSettings();
+      return false;
+    }
+
     const status = await manager.requestPermissions();
     setPermissionStatus(status);
     const granted = status.missingPermissions.length === 0;
     setPermissionsGranted(granted);
     if (!granted) {
-      Alert.alert('Permissions Required', 'Please grant all Bluetooth permissions');
+      Alert.alert(
+        'Permissions Required',
+        status.blockedPermissions.length > 0
+          ? 'Enable Nearby devices in app settings'
+          : 'Please grant all Bluetooth permissions',
+      );
     }
     return granted;
   }, [manager]);
@@ -217,7 +230,14 @@ const App = () => {
           </Text>
           {!permissionsGranted && (
             <View style={styles.buttonRow}>
-              <Button title="Allow Bluetooth" onPress={requestPermissions} />
+              <Button
+                title={
+                  permissionStatus?.blockedPermissions.length
+                    ? 'Open Settings'
+                    : 'Allow Bluetooth'
+                }
+                onPress={requestPermissions}
+              />
             </View>
           )}
         </View>

--- a/packages/dart/barnard/README.md
+++ b/packages/dart/barnard/README.md
@@ -182,6 +182,8 @@ if (!status.allGranted) {
 
 On iOS, `requestPermissions()` creates the CoreBluetooth managers and lets the system show the Bluetooth dialog if authorization is still undetermined. On Android, it requests the runtime permissions required for the current API level. If the user denies an Android 12+ Nearby devices request, Android may mark the Bluetooth permissions as blocked (`blockedPermissions` is non-empty) and will not show the dialog again. Use `openAppSettings()` and tell the user to enable **Nearby devices** for the app; Android Settings does not label this group as "Bluetooth".
 
+After calling `openAppSettings()`, refresh `getPermissionStatus()` when the app returns to the foreground (for example from `AppLifecycleState.resumed`). Android does not notify Barnard directly when the user changes Nearby devices in Settings, so the host app should update its cached permission UI on resume.
+
 ### Event Shape
 
 Barnard v2 emits byte-valued fields as lowercase hex strings at the native bridge boundary and as `Uint8List` in Dart events.

--- a/packages/dart/barnard/README.md
+++ b/packages/dart/barnard/README.md
@@ -167,12 +167,20 @@ Use `getPermissionStatus()` when you want to inspect current permissions without
 ```dart
 final status = await client.getPermissionStatus();
 if (!status.allGranted) {
+  if (status.hasBlockedPermissions) {
+    await client.openAppSettings();
+    return;
+  }
   final requested = await client.requestPermissions();
+  if (requested.hasBlockedPermissions) {
+    await client.openAppSettings();
+    return;
+  }
   if (!requested.allGranted) return;
 }
 ```
 
-On iOS, `requestPermissions()` creates the CoreBluetooth managers and lets the system show the Bluetooth dialog if authorization is still undetermined. On Android, it requests the runtime permissions required for the current API level.
+On iOS, `requestPermissions()` creates the CoreBluetooth managers and lets the system show the Bluetooth dialog if authorization is still undetermined. On Android, it requests the runtime permissions required for the current API level. If the user denies an Android 12+ Nearby devices request, Android may mark the Bluetooth permissions as blocked (`blockedPermissions` is non-empty) and will not show the dialog again. Use `openAppSettings()` and tell the user to enable **Nearby devices** for the app; Android Settings does not label this group as "Bluetooth".
 
 ### Event Shape
 
@@ -215,7 +223,7 @@ flutter precache --android
 
 ## Troubleshooting
 
-- `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`.
+- `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`. If `blockedPermissions` is non-empty, open app settings instead of requesting again.
 - `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
 - No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator.
 - Android app does not show permission dialogs: confirm the app is using the Barnard plugin package and did not remove merged permissions with manifest tools rules.

--- a/packages/dart/barnard/README.md
+++ b/packages/dart/barnard/README.md
@@ -77,6 +77,8 @@ Add Bluetooth usage-description strings to the host app `ios/Runner/Info.plist`:
 
 Barnard does not initialize CoreBluetooth during plugin registration. The iOS Bluetooth permission dialog can only be triggered by an explicit app action such as `requestPermissions()`, `startScan()`, `startAdvertise()`, or `startAuto()`.
 
+Barnard does not require iOS Local Network permission. If a debug run shows a "Find Devices on Local Networks" dialog, that is from development tooling such as Flutter VM Service discovery, not Barnard BLE registration.
+
 Barnard is foreground-only. iOS simulators do not support the BLE flows used by this Transport, so use physical devices for Scan / Advertise testing.
 
 ### Android

--- a/packages/dart/barnard/README.md
+++ b/packages/dart/barnard/README.md
@@ -12,16 +12,177 @@ The real BLE Transport implements **Scan / Advertise** with **GATT-first** RPID 
 - The receiver (Central) connects and reads a 17-byte payload from a readable characteristic:
   - `[formatVersion:uint8][rpid:16 bytes]`
 
-## Usage
+## Requirements
 
-Create a client and subscribe to streams:
+- Flutter 3.41.0 or newer
+- Dart 3.11.0 or newer
+- iOS 14.0 or newer
+- Android API 24 or newer for the Flutter plugin package
+
+Swift Package Manager support in Flutter depends on the Flutter 3.41 toolchain.
+
+## Installation
+
+Add Barnard to your Flutter app.
+
+For a local checkout:
+
+```yaml
+dependencies:
+  barnard:
+    path: ../path/to/barnard/packages/dart/barnard
+```
+
+For a Git dependency:
+
+```yaml
+dependencies:
+  barnard:
+    git:
+      url: https://github.com/thegreeting/barnard.git
+      path: packages/dart/barnard
+```
+
+Then fetch dependencies:
+
+```bash
+flutter pub get
+```
+
+Import the BLE Transport when you want real device Scan / Advertise:
 
 ```dart
 import "package:barnard/barnard_ble.dart";
+```
+
+Import the domain API when you only need shared types or the mock implementation:
+
+```dart
+import "package:barnard/barnard.dart";
+import "package:barnard/mock_barnard.dart";
+```
+
+## Platform Setup
+
+### iOS
+
+Add Bluetooth usage-description strings to the host app `ios/Runner/Info.plist`:
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>This app uses Bluetooth to detect nearby devices.</string>
+<key>NSBluetoothPeripheralUsageDescription</key>
+<string>This app uses Bluetooth to advertise to nearby devices.</string>
+```
+
+Barnard does not initialize CoreBluetooth during plugin registration. The iOS Bluetooth permission dialog can only be triggered by an explicit app action such as `requestPermissions()`, `startScan()`, `startAdvertise()`, or `startAuto()`.
+
+Barnard is foreground-only. iOS simulators do not support the BLE flows used by this Transport, so use physical devices for Scan / Advertise testing.
+
+### Android
+
+Barnard's Android library manifest is merged into the host app, so apps do not need to copy BLE permissions into their own manifest for the default foreground BLE Transport. The package declares:
+
+```xml
+<!-- BLE permissions for Android 12+ -->
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+    android:usesPermissionFlags="neverForLocation" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+
+<!-- Legacy permissions for Android 11 and below -->
+<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
+
+<uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
+```
+
+The `neverForLocation` flag on `BLUETOOTH_SCAN` means Android 12+ BLE Scan does not require location permission. This flag is scoped to the Bluetooth Scan permission and does not prevent the host app from requesting `ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION` for GPS, maps, geofencing, or other non-BLE location features. Android 11 and below still require legacy location permission for BLE Scan discovery.
+
+If the host app uses BLE Scan results themselves to infer physical location, do not use Barnard's default `neverForLocation` declaration. Android may filter some BLE beacons when this flag is present. Override the merged permission in the app manifest:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        tools:remove="android:usesPermissionFlags" />
+</manifest>
+```
+
+## Usage
+
+Create a client, request permissions at an app-controlled point, subscribe to events, and start Scan + Advertise:
+
+```dart
+import "dart:async";
+
+import "package:barnard/barnard.dart";
+import "package:barnard/barnard_ble.dart";
 
 final client = await BarnardBleClient.create();
+
+final BarnardPermissionStatus permissions = await client.requestPermissions();
+if (!permissions.allGranted) {
+  // Show app-specific guidance before starting BLE.
+  return;
+}
+
+final StreamSubscription<BarnardEvent> eventsSub = client.events.listen((
+  BarnardEvent event,
+) {
+  switch (event) {
+    case DetectionEvent():
+      print("Detected ${event.detectedDisplayId} rssi=${event.rssi}");
+    case RssiUpdateEvent():
+      print("RSSI update rssi=${event.rssi}");
+    case ConstraintEvent():
+      print("Constraint ${event.code}: ${event.message}");
+    case ErrorEvent():
+      print("Error ${event.code}: ${event.message}");
+    default:
+      break;
+  }
+});
+
+await client.joinEvent("EXAMPLE_EVENT");
 await client.startAuto();
+
+// Later:
+await client.stopAuto();
+await eventsSub.cancel();
+await client.dispose();
 ```
+
+Use `startScan()` or `startAdvertise()` instead of `startAuto()` when the app wants to control the Central and Peripheral roles independently.
+
+### Permission API
+
+Use `getPermissionStatus()` when you want to inspect current permissions without showing an OS dialog:
+
+```dart
+final status = await client.getPermissionStatus();
+if (!status.allGranted) {
+  final requested = await client.requestPermissions();
+  if (!requested.allGranted) return;
+}
+```
+
+On iOS, `requestPermissions()` creates the CoreBluetooth managers and lets the system show the Bluetooth dialog if authorization is still undetermined. On Android, it requests the runtime permissions required for the current API level.
+
+### Event Shape
+
+Barnard v2 emits byte-valued fields as lowercase hex strings at the native bridge boundary and as `Uint8List` in Dart events.
+
+Important fields:
+- `DetectionEvent.rpid`: 17-byte wire form `[formatVersion(1) + RPI(16)]`
+- `DetectionEvent.reporterRpid`: this device's 17-byte RPID at the observation timestamp
+- `DetectionEvent.detectedDisplayId`: 8-char lowercase hex `SHA256(peerTEK)[0:4]`, or `null` if the B003 GATT read failed
+- `DetectionEvent.enin`: ENIN at the observation timestamp
+
+The SDK never transmits TEK over BLE. `exportCurrentTek()` is an explicit host-app API for non-BLE egress.
 
 ## Example
 
@@ -50,65 +211,17 @@ flutter precache --android
 ./gradlew testDebugUnitTest
 ```
 
-## Requirements
+## Troubleshooting
 
-- Flutter 3.41.0 or newer
-- Dart 3.11.0 or newer
+- `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`.
+- `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
+- No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator.
+- Android app does not show permission dialogs: confirm the app is using the Barnard plugin package and did not remove merged permissions with manifest tools rules.
+- Cross-platform discovery is foreground-only. iOS background advertising may move Service UUIDs to the overflow area, making devices hard to discover.
 
-Swift Package Manager support in Flutter depends on the Flutter 3.41 toolchain.
-
-## Platform notes
-
-### iOS
-
-- Host app must include `NSBluetoothAlwaysUsageDescription` (and typically `NSBluetoothPeripheralUsageDescription`) in `Info.plist`.
-- Foreground-only.
-- Flutter 3.41+ can consume the plugin through Swift Package Manager. When SPM is enabled in the host app toolchain, Barnard no longer requires CocoaPods on iOS.
-
-### Android
-
-#### Permissions
-
-**Android 12+ (API 31+):**
-
-Add the following to your `AndroidManifest.xml`:
-
-```xml
-<!-- BLE permissions for Android 12+ -->
-<uses-permission android:name="android.permission.BLUETOOTH_SCAN"
-    android:usesPermissionFlags="neverForLocation" />
-<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
-
-<!-- Legacy permissions for Android 11 and below -->
-<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
-<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
-
-<uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
-```
-
-**Important:** The `neverForLocation` flag on `BLUETOOTH_SCAN` eliminates the need for location permission on Android 12+. Without this flag, `ACCESS_FINE_LOCATION` is required and users must grant "Precise location" (not just "Approximate") for BLE scanning to work.
-
-#### Runtime Permission Request
-
-With the `neverForLocation` flag, only request Bluetooth permissions at runtime:
-
-```dart
-// Android 12+ with neverForLocation flag - no location needed
-await [
-  Permission.bluetoothScan,
-  Permission.bluetoothConnect,
-  Permission.bluetoothAdvertise,
-].request();
-```
-
-#### Scan Filter
+## Scan Filter
 
 The SDK uses a Service UUID filter (`0000B001-0000-1000-8000-00805F9B34FB`) for efficient scanning. This reduces battery consumption and filters out non-Barnard devices at the system level.
-
-**Note:** iOS devices in background mode may not include the Service UUID in advertisement data (moved to "overflow area"). Foreground advertising works reliably.
 
 ## Channels
 

--- a/packages/dart/barnard/android/src/main/AndroidManifest.xml
+++ b/packages/dart/barnard/android/src/main/AndroidManifest.xml
@@ -6,9 +6,12 @@
   <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
 
   <!-- Android 12+ -->
-  <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+  <uses-permission
+    android:name="android.permission.BLUETOOTH_SCAN"
+    android:usesPermissionFlags="neverForLocation" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
   <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 </manifest>

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -24,12 +24,15 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
+import android.provider.Settings
 import android.util.Base64
 import android.util.Log
 import io.flutter.plugin.common.BinaryMessenger
@@ -42,6 +45,17 @@ import network.greeting.barnard.BuildConfig
 import java.util.UUID
 
 private const val TAG = "BarnardBLE"
+
+internal fun isRuntimePermissionRequestBlocked(
+    sdkInt: Int,
+    hasPermission: Boolean,
+    wasRequestedBefore: Boolean,
+    shouldShowRequestPermissionRationale: Boolean
+): Boolean {
+    if (sdkInt < 23 || hasPermission) return false
+    if (!wasRequestedBefore) return false
+    return !shouldShowRequestPermissionRationale
+}
 
 /**
  * Barnard v2 BLE controller.
@@ -59,6 +73,7 @@ internal class BarnardController(
 ) : MethodChannel.MethodCallHandler, PluginRegistry.RequestPermissionsResultListener {
     private companion object {
         const val permissionRequestCode = 0xB4D
+        const val permissionRequestedKeyPrefix = "permission_requested:"
     }
 
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -249,6 +264,11 @@ internal class BarnardController(
             "getPermissionStatus" -> result.success(getPermissionStatus())
 
             "requestPermissions" -> requestPermissions(result)
+
+            "openAppSettings" -> {
+                openAppSettings()
+                result.success(null)
+            }
 
             "startScan" -> {
                 val args = call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()
@@ -783,6 +803,8 @@ internal class BarnardController(
     fun getPermissionStatus(): Map<String, Any> {
         val required = requiredRuntimePermissions()
         val missing = required.filter { !hasPermission(it) }
+        val blocked = missing.filter { isPermissionRequestBlocked(it) }
+        val requestable = missing.filterNot { blocked.contains(it) }
         val permissions = required.associateWith { permission ->
             if (hasPermission(permission)) "granted" else "denied"
         }
@@ -791,6 +813,8 @@ internal class BarnardController(
             "permissions" to permissions,
             "requiredPermissions" to required,
             "missingPermissions" to missing,
+            "requestablePermissions" to requestable,
+            "blockedPermissions" to blocked,
             "canScan" to hasScanPermission(),
             "canAdvertise" to (hasAdvertisePermission() && hasConnectPermission()),
         )
@@ -799,6 +823,11 @@ internal class BarnardController(
     private fun requestPermissions(result: MethodChannel.Result) {
         val missing = requiredRuntimePermissions().filter { !hasPermission(it) }
         if (missing.isEmpty()) {
+            result.success(getPermissionStatus())
+            return
+        }
+        val requestable = missing.filterNot { isPermissionRequestBlocked(it) }
+        if (requestable.isEmpty()) {
             result.success(getPermissionStatus())
             return
         }
@@ -823,7 +852,16 @@ internal class BarnardController(
         }
 
         pendingPermissionResult = result
-        currentActivity.requestPermissions(missing.toTypedArray(), permissionRequestCode)
+        markPermissionsRequested(requestable)
+        currentActivity.requestPermissions(requestable.toTypedArray(), permissionRequestCode)
+    }
+
+    private fun openAppSettings() {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", appContext.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        (activity ?: appContext).startActivity(intent)
     }
 
     override fun onRequestPermissionsResult(
@@ -853,6 +891,35 @@ internal class BarnardController(
     private fun hasPermission(permission: String): Boolean {
         if (Build.VERSION.SDK_INT < 23) return true
         return appContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun isPermissionRequestBlocked(permission: String): Boolean {
+        if (Build.VERSION.SDK_INT < 23 || hasPermission(permission)) return false
+        val currentActivity = activity ?: return false
+        return isRuntimePermissionRequestBlocked(
+            sdkInt = Build.VERSION.SDK_INT,
+            hasPermission = false,
+            wasRequestedBefore = wasPermissionRequested(permission),
+            shouldShowRequestPermissionRationale =
+                currentActivity.shouldShowRequestPermissionRationale(permission)
+        )
+    }
+
+    private fun markPermissionsRequested(permissions: List<String>) {
+        if (permissions.isEmpty()) return
+        prefs.edit().apply {
+            for (permission in permissions) {
+                putBoolean(permissionRequestedKey(permission), true)
+            }
+        }.apply()
+    }
+
+    private fun wasPermissionRequested(permission: String): Boolean {
+        return prefs.getBoolean(permissionRequestedKey(permission), false)
+    }
+
+    private fun permissionRequestedKey(permission: String): String {
+        return "$permissionRequestedKeyPrefix$permission"
     }
 
     private fun hasScanPermission(): Boolean {

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -4,6 +4,7 @@
 package network.greeting.barnard
 
 import android.Manifest
+import android.app.Activity
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
@@ -35,6 +36,7 @@ import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
 import network.greeting.barnard.BarnardCrypto.toHex
 import network.greeting.barnard.BuildConfig
 import java.util.UUID
@@ -54,7 +56,11 @@ private const val TAG = "BarnardBLE"
 internal class BarnardController(
     private val appContext: Context,
     messenger: BinaryMessenger,
-) : MethodChannel.MethodCallHandler {
+) : MethodChannel.MethodCallHandler, PluginRegistry.RequestPermissionsResultListener {
+    private companion object {
+        const val permissionRequestCode = 0xB4D
+    }
+
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private val methods = MethodChannel(messenger, "barnard/methods")
@@ -63,6 +69,8 @@ internal class BarnardController(
 
     private var eventSink: EventChannel.EventSink? = null
     private var debugEventSink: EventChannel.EventSink? = null
+    private var activity: Activity? = null
+    private var pendingPermissionResult: MethodChannel.Result? = null
 
     // MARK: - UUIDs
 
@@ -186,10 +194,17 @@ internal class BarnardController(
         }
     }
 
+    fun setActivity(activity: Activity?) {
+        this.activity = activity
+    }
+
     fun dispose() {
         methods.setMethodCallHandler(null)
         stopScan()
         stopAdvertise()
+        pendingPermissionResult?.error("E_DISPOSED", "BarnardController disposed before permission result", null)
+        pendingPermissionResult = null
+        activity = null
         eventSink = null
         debugEventSink = null
     }
@@ -230,6 +245,10 @@ internal class BarnardController(
                 // Explicit privacy egress. SDK never transmits TEK over BLE.
                 result.success(currentTek.toHex())
             }
+
+            "getPermissionStatus" -> result.success(getPermissionStatus())
+
+            "requestPermissions" -> requestPermissions(result)
 
             "startScan" -> {
                 val args = call.arguments as? Map<*, *> ?: emptyMap<Any, Any>()
@@ -377,7 +396,7 @@ internal class BarnardController(
             return
         }
         if (!hasScanPermission()) {
-            emitConstraint("permission_denied", "Missing BLUETOOTH_SCAN permission", requiredAction = "grant_permission")
+            emitConstraint("permission_denied", "Missing ${requiredScanPermission()} permission", requiredAction = "grant_permission")
             return
         }
         val s = adapter?.bluetoothLeScanner ?: run {
@@ -761,19 +780,105 @@ internal class BarnardController(
 
     // MARK: - Permissions
 
+    fun getPermissionStatus(): Map<String, Any> {
+        val required = requiredRuntimePermissions()
+        val missing = required.filter { !hasPermission(it) }
+        val permissions = required.associateWith { permission ->
+            if (hasPermission(permission)) "granted" else "denied"
+        }
+        return mapOf(
+            "platform" to "android",
+            "permissions" to permissions,
+            "requiredPermissions" to required,
+            "missingPermissions" to missing,
+            "canScan" to hasScanPermission(),
+            "canAdvertise" to (hasAdvertisePermission() && hasConnectPermission()),
+        )
+    }
+
+    private fun requestPermissions(result: MethodChannel.Result) {
+        val missing = requiredRuntimePermissions().filter { !hasPermission(it) }
+        if (missing.isEmpty()) {
+            result.success(getPermissionStatus())
+            return
+        }
+
+        val currentActivity = activity
+        if (currentActivity == null) {
+            result.error(
+                "E_NO_ACTIVITY",
+                "requestPermissions requires an attached Activity",
+                getPermissionStatus()
+            )
+            return
+        }
+
+        if (pendingPermissionResult != null) {
+            result.error(
+                "E_PERMISSION_REQUEST_IN_PROGRESS",
+                "A Barnard permission request is already in progress",
+                getPermissionStatus()
+            )
+            return
+        }
+
+        pendingPermissionResult = result
+        currentActivity.requestPermissions(missing.toTypedArray(), permissionRequestCode)
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ): Boolean {
+        if (requestCode != permissionRequestCode) return false
+        val result = pendingPermissionResult ?: return false
+        pendingPermissionResult = null
+        result.success(getPermissionStatus())
+        return true
+    }
+
+    private fun requiredRuntimePermissions(): List<String> {
+        return when {
+            Build.VERSION.SDK_INT >= 31 -> listOf(
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.BLUETOOTH_CONNECT,
+            )
+            Build.VERSION.SDK_INT >= 23 -> listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            else -> emptyList()
+        }
+    }
+
+    private fun hasPermission(permission: String): Boolean {
+        if (Build.VERSION.SDK_INT < 23) return true
+        return appContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    }
+
     private fun hasScanPermission(): Boolean {
-        if (Build.VERSION.SDK_INT < 31) return true
-        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
+        return when {
+            Build.VERSION.SDK_INT >= 31 -> hasPermission(Manifest.permission.BLUETOOTH_SCAN)
+            Build.VERSION.SDK_INT >= 23 -> hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            else -> true
+        }
+    }
+
+    private fun requiredScanPermission(): String {
+        return if (Build.VERSION.SDK_INT >= 31) {
+            Manifest.permission.BLUETOOTH_SCAN
+        } else {
+            Manifest.permission.ACCESS_FINE_LOCATION
+        }
     }
 
     private fun hasAdvertisePermission(): Boolean {
         if (Build.VERSION.SDK_INT < 31) return true
-        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_ADVERTISE) == PackageManager.PERMISSION_GRANTED
+        return hasPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
     }
 
     private fun hasConnectPermission(): Boolean {
         if (Build.VERSION.SDK_INT < 31) return true
-        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+        return hasPermission(Manifest.permission.BLUETOOTH_CONNECT)
     }
 
     // MARK: - Advertise Callback

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPlugin.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPlugin.kt
@@ -1,17 +1,53 @@
 package network.greeting.barnard
 
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 
-class BarnardPlugin : FlutterPlugin {
+class BarnardPlugin : FlutterPlugin, ActivityAware {
     private var controller: BarnardController? = null
+    private var activityBinding: ActivityPluginBinding? = null
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         controller = BarnardController(binding.applicationContext, binding.binaryMessenger)
+        activityBinding?.let { attachControllerToActivity(it) }
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        activityBinding?.let { detachControllerFromActivity(it) }
         controller?.dispose()
         controller = null
     }
-}
 
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        activityBinding = binding
+        attachControllerToActivity(binding)
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        activityBinding?.let { detachControllerFromActivity(it) }
+        activityBinding = null
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        activityBinding = binding
+        attachControllerToActivity(binding)
+    }
+
+    override fun onDetachedFromActivity() {
+        activityBinding?.let { detachControllerFromActivity(it) }
+        activityBinding = null
+    }
+
+    private fun attachControllerToActivity(binding: ActivityPluginBinding) {
+        val ctrl = controller ?: return
+        ctrl.setActivity(binding.activity)
+        binding.addRequestPermissionsResultListener(ctrl)
+    }
+
+    private fun detachControllerFromActivity(binding: ActivityPluginBinding) {
+        val ctrl = controller ?: return
+        binding.removeRequestPermissionsResultListener(ctrl)
+        ctrl.setActivity(null)
+    }
+}

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPermissionStatusTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPermissionStatusTest.kt
@@ -1,0 +1,55 @@
+package network.greeting.barnard
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+internal class BarnardPermissionStatusTest {
+    @Test
+    fun firstMissingRuntimePermissionIsStillRequestableWhenRationaleIsFalse() {
+        assertFalse(
+            isRuntimePermissionRequestBlocked(
+                sdkInt = 36,
+                hasPermission = false,
+                wasRequestedBefore = false,
+                shouldShowRequestPermissionRationale = false
+            )
+        )
+    }
+
+    @Test
+    fun deniedRuntimePermissionIsBlockedWhenAndroidWillNotShowRationale() {
+        assertTrue(
+            isRuntimePermissionRequestBlocked(
+                sdkInt = 36,
+                hasPermission = false,
+                wasRequestedBefore = true,
+                shouldShowRequestPermissionRationale = false
+            )
+        )
+    }
+
+    @Test
+    fun deniedRuntimePermissionRemainsRequestableWhenAndroidShowsRationale() {
+        assertFalse(
+            isRuntimePermissionRequestBlocked(
+                sdkInt = 36,
+                hasPermission = false,
+                wasRequestedBefore = true,
+                shouldShowRequestPermissionRationale = true
+            )
+        )
+    }
+
+    @Test
+    fun grantedRuntimePermissionIsNeverBlocked() {
+        assertFalse(
+            isRuntimePermissionRequestBlocked(
+                sdkInt = 36,
+                hasPermission = true,
+                wasRequestedBefore = true,
+                shouldShowRequestPermissionRationale = false
+            )
+        )
+    }
+}

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPluginTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPluginTest.kt
@@ -11,6 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 internal class BarnardPluginTest {
@@ -36,6 +37,25 @@ internal class BarnardPluginTest {
         controller.onMethodCall(call, result)
 
         assertTrue(result.value is Map<*, *>)
+    }
+
+    @Test
+    @Config(sdk = [31])
+    fun onMethodCall_getPermissionStatus_returnsStableShape() {
+        val messenger = RecordingBinaryMessenger()
+        val result = RecordingResult()
+
+        val controller = BarnardController(context, messenger)
+        val call = MethodCall("getPermissionStatus", null)
+        controller.onMethodCall(call, result)
+
+        val value = result.value as Map<*, *>
+        assertTrue(value["platform"] == "android")
+        assertTrue(value["permissions"] is Map<*, *>)
+        assertTrue(value["requiredPermissions"] is List<*>)
+        assertTrue(value["missingPermissions"] is List<*>)
+        assertTrue(value["canScan"] is Boolean)
+        assertTrue(value["canAdvertise"] is Boolean)
     }
 
     private class RecordingBinaryMessenger : BinaryMessenger {

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPluginTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPluginTest.kt
@@ -54,6 +54,8 @@ internal class BarnardPluginTest {
         assertTrue(value["permissions"] is Map<*, *>)
         assertTrue(value["requiredPermissions"] is List<*>)
         assertTrue(value["missingPermissions"] is List<*>)
+        assertTrue(value["requestablePermissions"] is List<*>)
+        assertTrue(value["blockedPermissions"] is List<*>)
         assertTrue(value["canScan"] is Boolean)
         assertTrue(value["canAdvertise"] is Boolean)
     }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -52,8 +52,9 @@ final class BarnardBleController: NSObject {
 
   // MARK: - BLE Managers
 
-  private var centralManager: CBCentralManager!
-  private var peripheralManager: CBPeripheralManager!
+  private var centralManager: CBCentralManager?
+  private var peripheralManager: CBPeripheralManager?
+  private var pendingPermissionCompletions: [([String: Any]) -> Void] = []
 
   // MARK: - GATT Characteristics (Peripheral)
 
@@ -65,6 +66,8 @@ final class BarnardBleController: NSObject {
 
   private var isScanning = false
   private var isAdvertising = false
+  private var shouldStartScanWhenReady = false
+  private var shouldStartAdvertiseWhenReady = false
   private var allowDuplicates = true
   private var formatVersion: UInt8 = 1
 
@@ -150,9 +153,6 @@ final class BarnardBleController: NSObject {
     debugHandler.onListen = { [weak self] sink in self?.debugEventSink = sink }
     debugHandler.onCancel = { [weak self] in self?.debugEventSink = nil }
 
-    centralManager = CBCentralManager(delegate: self, queue: nil)
-    peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
-
     NotificationCenter.default.addObserver(
       self,
       selector: #selector(appDidBecomeActive),
@@ -171,6 +171,81 @@ final class BarnardBleController: NSObject {
     NotificationCenter.default.removeObserver(self)
   }
 
+  private func ensureCentralManager() -> CBCentralManager {
+    if let manager = centralManager {
+      return manager
+    }
+    let manager = CBCentralManager(delegate: self, queue: nil)
+    centralManager = manager
+    return manager
+  }
+
+  private func ensurePeripheralManager() -> CBPeripheralManager {
+    if let manager = peripheralManager {
+      return manager
+    }
+    let manager = CBPeripheralManager(delegate: self, queue: nil)
+    peripheralManager = manager
+    return manager
+  }
+
+  private func ensureBleManagers() {
+    _ = ensureCentralManager()
+    _ = ensurePeripheralManager()
+  }
+
+  private func bluetoothPermissionStatus() -> String {
+    switch CBManager.authorization {
+    case .allowedAlways:
+      return "granted"
+    case .denied:
+      return "denied"
+    case .restricted:
+      return "restricted"
+    case .notDetermined:
+      return "notDetermined"
+    @unknown default:
+      return "unknown"
+    }
+  }
+
+  private func permissionStatusPayload() -> [String: Any] {
+    let permissionName = "ios.bluetooth"
+    let status = bluetoothPermissionStatus()
+    let missing = status == "granted" ? [] : [permissionName]
+    return [
+      "platform": "ios",
+      "permissions": [permissionName: status],
+      "requiredPermissions": [permissionName],
+      "missingPermissions": missing,
+      "canScan": status == "granted",
+      "canAdvertise": status == "granted",
+    ]
+  }
+
+  private func requestPermissions(completion: @escaping ([String: Any]) -> Void) {
+    if bluetoothPermissionStatus() != "notDetermined" {
+      completion(permissionStatusPayload())
+      return
+    }
+
+    pendingPermissionCompletions.append(completion)
+    ensureBleManagers()
+    resolvePendingPermissionCompletionsIfPossible()
+  }
+
+  private func resolvePendingPermissionCompletionsIfPossible() {
+    guard !pendingPermissionCompletions.isEmpty else { return }
+    guard bluetoothPermissionStatus() != "notDetermined" else { return }
+
+    let payload = permissionStatusPayload()
+    let completions = pendingPermissionCompletions
+    pendingPermissionCompletions.removeAll()
+    for completion in completions {
+      completion(payload)
+    }
+  }
+
   // MARK: - Lifecycle
 
   // On background, iOS demotes our advertised service UUID from the AdvData
@@ -184,7 +259,7 @@ final class BarnardBleController: NSObject {
       emitDebug(level: "trace", name: "foreground_resume", data: ["isAdvertising": false])
       return
     }
-    peripheralManager.stopAdvertising()
+    peripheralManager?.stopAdvertising()
     isAdvertising = false
     startAdvertise()
     emitDebug(level: "info", name: "advertise_restart_on_foreground", data: nil)
@@ -234,6 +309,14 @@ final class BarnardBleController: NSObject {
       // Explicit privacy egress. SDK never transmits TEK over BLE; caller
       // decides whether/how to transmit it via another channel.
       result(rpid.getCurrentTek().hexString)
+
+    case "getPermissionStatus":
+      result(permissionStatusPayload())
+
+    case "requestPermissions":
+      requestPermissions { payload in
+        result(payload)
+      }
 
     case "startScan":
       let args = (call.arguments as? [String: Any]) ?? [:]
@@ -317,21 +400,35 @@ final class BarnardBleController: NSObject {
   // MARK: - Scan Control
 
   private func startScan() {
-    guard centralManager.state == .poweredOn else {
-      emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(centralManager.state.rawValue)")
+    let manager = ensureCentralManager()
+    if isScanning {
+      shouldStartScanWhenReady = false
       return
     }
-    if isScanning { return }
+    guard manager.state == .poweredOn else {
+      if manager.state == .unknown || manager.state == .resetting {
+        shouldStartScanWhenReady = true
+        emitDebug(level: "info", name: "scan_waiting_for_powered_on", data: [
+          "state": manager.state.rawValue,
+        ])
+      } else {
+        shouldStartScanWhenReady = false
+        emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(manager.state.rawValue)")
+      }
+      return
+    }
+    shouldStartScanWhenReady = false
     let options: [String: Any] = [CBCentralManagerScanOptionAllowDuplicatesKey: allowDuplicates]
-    centralManager.scanForPeripherals(withServices: [discoveryServiceUUID], options: options)
+    manager.scanForPeripherals(withServices: [discoveryServiceUUID], options: options)
     isScanning = true
     emitState(reasonCode: "scan_start")
     emitDebug(level: "info", name: "scan_start", data: ["allowDuplicates": allowDuplicates])
   }
 
   private func stopScan() {
+    shouldStartScanWhenReady = false
     if !isScanning { return }
-    centralManager.stopScan()
+    centralManager?.stopScan()
     isScanning = false
     resetPeerDiscoveryState(reason: "scan_stop")
 
@@ -342,7 +439,7 @@ final class BarnardBleController: NSObject {
   private func resetPeerDiscoveryState(reason: String) {
     connectQueue.removeAll()
     if let active = activePeripheral {
-      centralManager.cancelPeripheralConnection(active)
+      centralManager?.cancelPeripheralConnection(active)
     }
     activePeripheral = nil
     cancelConnectWatchdog()
@@ -365,11 +462,24 @@ final class BarnardBleController: NSObject {
   // MARK: - Advertise Control
 
   private func startAdvertise() {
-    guard peripheralManager.state == .poweredOn else {
-      emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(peripheralManager.state.rawValue)")
+    let manager = ensurePeripheralManager()
+    if isAdvertising {
+      shouldStartAdvertiseWhenReady = false
       return
     }
-    if isAdvertising { return }
+    guard manager.state == .poweredOn else {
+      if manager.state == .unknown || manager.state == .resetting {
+        shouldStartAdvertiseWhenReady = true
+        emitDebug(level: "info", name: "advertise_waiting_for_powered_on", data: [
+          "state": manager.state.rawValue,
+        ])
+      } else {
+        shouldStartAdvertiseWhenReady = false
+        emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(manager.state.rawValue)")
+      }
+      return
+    }
+    shouldStartAdvertiseWhenReady = false
     ensureGattService()
     var ad: [String: Any] = [
       CBAdvertisementDataServiceUUIDsKey: [discoveryServiceUUID],
@@ -377,7 +487,7 @@ final class BarnardBleController: NSObject {
     #if DEBUG
     ad[CBAdvertisementDataLocalNameKey] = debugLocalName
     #endif
-    peripheralManager.startAdvertising(ad)
+    manager.startAdvertising(ad)
     isAdvertising = true
     emitState(reasonCode: "advertise_start")
     emitDebug(
@@ -392,8 +502,9 @@ final class BarnardBleController: NSObject {
   }
 
   private func stopAdvertise() {
+    shouldStartAdvertiseWhenReady = false
     if !isAdvertising { return }
-    peripheralManager.stopAdvertising()
+    peripheralManager?.stopAdvertising()
     isAdvertising = false
     emitState(reasonCode: "advertise_stop")
     emitDebug(level: "info", name: "advertise_stop", data: nil)
@@ -402,14 +513,15 @@ final class BarnardBleController: NSObject {
   // MARK: - GATT Service Management
 
   private func ensureGattService() {
+    _ = ensurePeripheralManager()
     if rpidCharacteristic != nil { return }
     buildAndAddGattService()
   }
 
   private func rebuildGattServiceIfNeeded() {
-    guard peripheralManager.state == .poweredOn else { return }
+    guard let manager = peripheralManager, manager.state == .poweredOn else { return }
 
-    peripheralManager.removeAllServices()
+    manager.removeAllServices()
     rpidCharacteristic = nil
     displayIdCharacteristic = nil
     eventCodeHashCharacteristic = nil
@@ -420,6 +532,8 @@ final class BarnardBleController: NSObject {
   }
 
   private func buildAndAddGattService() {
+    guard let manager = peripheralManager else { return }
+
     // B002 RPID (Read only)
     let rpidCh = CBMutableCharacteristic(
       type: rpidCharacteristicUUID,
@@ -446,7 +560,7 @@ final class BarnardBleController: NSObject {
 
     let svc = CBMutableService(type: discoveryServiceUUID, primary: true)
     svc.characteristics = [rpidCh, displayIdCh, eventCodeHashCh]
-    peripheralManager.add(svc)
+    manager.add(svc)
 
     rpidCharacteristic = rpidCh
     displayIdCharacteristic = displayIdCh
@@ -500,6 +614,7 @@ final class BarnardBleController: NSObject {
       connectQueue.removeFirst()
       return
     }
+    guard let manager = centralManager else { return }
 
     connectQueue.removeFirst()
     activePeripheral = p
@@ -509,7 +624,7 @@ final class BarnardBleController: NSObject {
     b004ReadRetries[nextId] = 0
 
     p.delegate = self
-    centralManager.connect(p, options: nil)
+    manager.connect(p, options: nil)
     emitDebug(level: "trace", name: "connect_attempt", data: ["id": nextId.uuidString])
     armConnectWatchdog(for: nextId)
   }
@@ -531,7 +646,7 @@ final class BarnardBleController: NSObject {
         recoverable: true,
         extra: ["seconds": self.connectTimeoutSeconds]
       )
-      self.centralManager.cancelPeripheralConnection(pinned)
+      self.centralManager?.cancelPeripheralConnection(pinned)
       self.peripheralCharacteristics.removeValue(forKey: id)
       self.peripheralReadValues.removeValue(forKey: id)
       self.lastDiscoveryNameById.removeValue(forKey: id)
@@ -705,7 +820,7 @@ final class BarnardBleController: NSObject {
     peripheralReadValues.removeValue(forKey: id)
     b004ReadRetries.removeValue(forKey: id)
     lastDiscoveryNameById.removeValue(forKey: id)
-    centralManager.cancelPeripheralConnection(peripheral)
+    centralManager?.cancelPeripheralConnection(peripheral)
   }
 
   // MARK: - Event Emission
@@ -889,8 +1004,11 @@ final class BarnardBleController: NSObject {
 
 extension BarnardBleController: CBCentralManagerDelegate {
   func centralManagerDidUpdateState(_ central: CBCentralManager) {
+    resolvePendingPermissionCompletionsIfPossible()
     emitDebug(level: "info", name: "central_state", data: ["state": central.state.rawValue])
-    if central.state != .poweredOn, isScanning {
+    if central.state == .poweredOn, shouldStartScanWhenReady {
+      startScan()
+    } else if central.state != .poweredOn, isScanning {
       stopScan()
     }
   }
@@ -1156,8 +1274,11 @@ extension BarnardBleController: CBPeripheralDelegate {
 
 extension BarnardBleController: CBPeripheralManagerDelegate {
   func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+    resolvePendingPermissionCompletionsIfPossible()
     emitDebug(level: "info", name: "peripheral_state", data: ["state": peripheral.state.rawValue])
-    if peripheral.state != .poweredOn, isAdvertising {
+    if peripheral.state == .poweredOn, shouldStartAdvertiseWhenReady {
+      startAdvertise()
+    } else if peripheral.state != .poweredOn, isAdvertising {
       stopAdvertise()
     }
   }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -213,11 +213,15 @@ final class BarnardBleController: NSObject {
     let permissionName = "ios.bluetooth"
     let status = bluetoothPermissionStatus()
     let missing = status == "granted" ? [] : [permissionName]
+    let blocked = (status == "denied" || status == "restricted") ? [permissionName] : []
+    let requestable = missing.filter { !blocked.contains($0) }
     return [
       "platform": "ios",
       "permissions": [permissionName: status],
       "requiredPermissions": [permissionName],
       "missingPermissions": missing,
+      "requestablePermissions": requestable,
+      "blockedPermissions": blocked,
       "canScan": status == "granted",
       "canAdvertise": status == "granted",
     ]
@@ -243,6 +247,13 @@ final class BarnardBleController: NSObject {
     pendingPermissionCompletions.removeAll()
     for completion in completions {
       completion(payload)
+    }
+  }
+
+  private func openAppSettings() {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+    DispatchQueue.main.async {
+      UIApplication.shared.open(url)
     }
   }
 
@@ -317,6 +328,10 @@ final class BarnardBleController: NSObject {
       requestPermissions { payload in
         result(payload)
       }
+
+    case "openAppSettings":
+      openAppSettings()
+      result(nil)
 
     case "startScan":
       let args = (call.arguments as? [String: Any]) ?? [:]

--- a/packages/dart/barnard/lib/barnard.dart
+++ b/packages/dart/barnard/lib/barnard.dart
@@ -4,6 +4,7 @@ export "src/domain/config.dart";
 export "src/domain/crypto.dart";
 export "src/domain/events.dart";
 export "src/domain/hex.dart";
+export "src/domain/permissions.dart";
 export "src/domain/rssi.dart";
 export "src/domain/state.dart";
 export "src/domain/transport.dart";

--- a/packages/dart/barnard/lib/src/domain/permissions.dart
+++ b/packages/dart/barnard/lib/src/domain/permissions.dart
@@ -7,6 +7,8 @@ class BarnardPermissionStatus {
     required this.permissions,
     required this.requiredPermissions,
     required this.missingPermissions,
+    required this.requestablePermissions,
+    required this.blockedPermissions,
     required this.canScan,
     required this.canAdvertise,
   });
@@ -31,6 +33,8 @@ class BarnardPermissionStatus {
       ),
       requiredPermissions: _stringList(map["requiredPermissions"]),
       missingPermissions: _stringList(map["missingPermissions"]),
+      requestablePermissions: _stringList(map["requestablePermissions"]),
+      blockedPermissions: _stringList(map["blockedPermissions"]),
       canScan: map["canScan"] == true,
       canAdvertise: map["canAdvertise"] == true,
     );
@@ -40,10 +44,14 @@ class BarnardPermissionStatus {
   final Map<String, BarnardPermissionDecision> permissions;
   final List<String> requiredPermissions;
   final List<String> missingPermissions;
+  final List<String> requestablePermissions;
+  final List<String> blockedPermissions;
   final bool canScan;
   final bool canAdvertise;
 
   bool get allGranted => missingPermissions.isEmpty;
+  bool get canRequest => requestablePermissions.isNotEmpty;
+  bool get hasBlockedPermissions => blockedPermissions.isNotEmpty;
 }
 
 enum BarnardPermissionDecision {

--- a/packages/dart/barnard/lib/src/domain/permissions.dart
+++ b/packages/dart/barnard/lib/src/domain/permissions.dart
@@ -1,0 +1,72 @@
+import "package:meta/meta.dart";
+
+@immutable
+class BarnardPermissionStatus {
+  const BarnardPermissionStatus({
+    required this.platform,
+    required this.permissions,
+    required this.requiredPermissions,
+    required this.missingPermissions,
+    required this.canScan,
+    required this.canAdvertise,
+  });
+
+  factory BarnardPermissionStatus.fromMap(Map<Object?, Object?> map) {
+    final Map<String, BarnardPermissionDecision> permissions =
+        <String, BarnardPermissionDecision>{};
+    final Object? rawPermissions = map["permissions"];
+    if (rawPermissions is Map) {
+      rawPermissions.forEach((Object? key, Object? value) {
+        if (key == null) return;
+        permissions[key.toString()] = BarnardPermissionDecision.fromName(
+          value?.toString(),
+        );
+      });
+    }
+
+    return BarnardPermissionStatus(
+      platform: (map["platform"] as String?) ?? "unknown",
+      permissions: Map<String, BarnardPermissionDecision>.unmodifiable(
+        permissions,
+      ),
+      requiredPermissions: _stringList(map["requiredPermissions"]),
+      missingPermissions: _stringList(map["missingPermissions"]),
+      canScan: map["canScan"] == true,
+      canAdvertise: map["canAdvertise"] == true,
+    );
+  }
+
+  final String platform;
+  final Map<String, BarnardPermissionDecision> permissions;
+  final List<String> requiredPermissions;
+  final List<String> missingPermissions;
+  final bool canScan;
+  final bool canAdvertise;
+
+  bool get allGranted => missingPermissions.isEmpty;
+}
+
+enum BarnardPermissionDecision {
+  granted,
+  denied,
+  notDetermined,
+  restricted,
+  unsupported,
+  unknown;
+
+  static BarnardPermissionDecision fromName(String? name) {
+    return switch (name) {
+      "granted" => BarnardPermissionDecision.granted,
+      "denied" => BarnardPermissionDecision.denied,
+      "notDetermined" => BarnardPermissionDecision.notDetermined,
+      "restricted" => BarnardPermissionDecision.restricted,
+      "unsupported" => BarnardPermissionDecision.unsupported,
+      _ => BarnardPermissionDecision.unknown,
+    };
+  }
+}
+
+List<String> _stringList(Object? value) {
+  if (value is! List) return const <String>[];
+  return List<String>.unmodifiable(value.whereType<String>());
+}

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
@@ -163,6 +163,12 @@ class BarnardBleClient implements BarnardClient {
   }
 
   @override
+  Future<void> openAppSettings() async {
+    _ensureNotDisposed();
+    await _methods.invokeMethod<void>("openAppSettings");
+  }
+
+  @override
   Future<void> startScan([ScanConfig? config]) async {
     _ensureNotDisposed();
     await _methods.invokeMethod<void>("startScan", _encodeScanConfig(config));

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_client.dart
@@ -4,6 +4,7 @@ import "../../domain/capabilities.dart";
 import "../../domain/config.dart";
 import "../../domain/events.dart";
 import "../../domain/hex.dart";
+import "../../domain/permissions.dart";
 import "../../domain/rssi.dart";
 import "../../domain/state.dart";
 import "../../domain/transport.dart";
@@ -138,6 +139,28 @@ class BarnardBleClient implements BarnardClient {
 
   @override
   Stream<BarnardDebugEvent> get debugEvents => _debugEventsController.stream;
+
+  @override
+  Future<BarnardPermissionStatus> getPermissionStatus() async {
+    _ensureNotDisposed();
+    final Map<Object?, Object?> map =
+        (await _methods.invokeMethod<Map<Object?, Object?>>(
+          "getPermissionStatus",
+        )) ??
+        <Object?, Object?>{};
+    return BarnardPermissionStatus.fromMap(map);
+  }
+
+  @override
+  Future<BarnardPermissionStatus> requestPermissions() async {
+    _ensureNotDisposed();
+    final Map<Object?, Object?> map =
+        (await _methods.invokeMethod<Map<Object?, Object?>>(
+          "requestPermissions",
+        )) ??
+        <Object?, Object?>{};
+    return BarnardPermissionStatus.fromMap(map);
+  }
 
   @override
   Future<void> startScan([ScanConfig? config]) async {

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
@@ -8,6 +8,7 @@ import "../../domain/capabilities.dart";
 import "../../domain/config.dart";
 import "../../domain/crypto.dart";
 import "../../domain/events.dart";
+import "../../domain/permissions.dart";
 import "../../domain/rssi.dart";
 import "../../domain/state.dart";
 import "../../domain/transport.dart";
@@ -36,6 +37,18 @@ class MockBarnardOverrides {
   /// [DetectionEvent.detectedDisplayId] to be `null`. Defaults to 0.1 (10%).
   final double? b003FailureRate;
 }
+
+const BarnardPermissionStatus _grantedPermissionStatus =
+    BarnardPermissionStatus(
+      platform: "mock",
+      permissions: <String, BarnardPermissionDecision>{
+        "mock.bluetooth": BarnardPermissionDecision.granted,
+      },
+      requiredPermissions: <String>["mock.bluetooth"],
+      missingPermissions: <String>[],
+      canScan: true,
+      canAdvertise: true,
+    );
 
 class MockBarnard implements BarnardClient {
   MockBarnard({
@@ -124,6 +137,18 @@ class MockBarnard implements BarnardClient {
 
   @override
   Stream<BarnardDebugEvent> get debugEvents => _debugEvents.stream;
+
+  @override
+  Future<BarnardPermissionStatus> getPermissionStatus() async {
+    _ensureNotDisposed();
+    return _grantedPermissionStatus;
+  }
+
+  @override
+  Future<BarnardPermissionStatus> requestPermissions() async {
+    _ensureNotDisposed();
+    return _grantedPermissionStatus;
+  }
 
   @override
   Future<void> startScan([ScanConfig? config]) async {

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
@@ -46,6 +46,8 @@ const BarnardPermissionStatus _grantedPermissionStatus =
       },
       requiredPermissions: <String>["mock.bluetooth"],
       missingPermissions: <String>[],
+      requestablePermissions: <String>[],
+      blockedPermissions: <String>[],
       canScan: true,
       canAdvertise: true,
     );
@@ -148,6 +150,11 @@ class MockBarnard implements BarnardClient {
   Future<BarnardPermissionStatus> requestPermissions() async {
     _ensureNotDisposed();
     return _grantedPermissionStatus;
+  }
+
+  @override
+  Future<void> openAppSettings() async {
+    _ensureNotDisposed();
   }
 
   @override

--- a/packages/dart/barnard/lib/src/usecase/barnard_client.dart
+++ b/packages/dart/barnard/lib/src/usecase/barnard_client.dart
@@ -55,6 +55,10 @@ abstract class BarnardClient {
   /// Requests platform BLE permissions at an app-controlled moment.
   Future<BarnardPermissionStatus> requestPermissions();
 
+  /// Opens the host app's system settings page for permissions that the OS no
+  /// longer allows to be requested with a runtime dialog.
+  Future<void> openAppSettings();
+
   Future<void> startScan([ScanConfig? config]);
   Future<void> stopScan();
 

--- a/packages/dart/barnard/lib/src/usecase/barnard_client.dart
+++ b/packages/dart/barnard/lib/src/usecase/barnard_client.dart
@@ -4,6 +4,7 @@ import "../domain/rssi.dart";
 import "../domain/capabilities.dart";
 import "../domain/config.dart";
 import "../domain/events.dart";
+import "../domain/permissions.dart";
 import "../domain/state.dart";
 
 class BarnardStartResult {
@@ -47,6 +48,12 @@ abstract class BarnardClient {
 
   Stream<BarnardEvent> get events;
   Stream<BarnardDebugEvent> get debugEvents;
+
+  /// Returns the current platform BLE permission state without prompting.
+  Future<BarnardPermissionStatus> getPermissionStatus();
+
+  /// Requests platform BLE permissions at an app-controlled moment.
+  Future<BarnardPermissionStatus> requestPermissions();
 
   Future<void> startScan([ScanConfig? config]);
   Future<void> stopScan();

--- a/packages/dart/barnard/test/ble_client_parser_test.dart
+++ b/packages/dart/barnard/test/ble_client_parser_test.dart
@@ -8,24 +8,23 @@ import "package:flutter_test/flutter_test.dart";
 void main() {
   group("BarnardPermissionStatus", () {
     test("parses stable permission result fields", () {
-      final BarnardPermissionStatus status = BarnardPermissionStatus.fromMap(
-        <Object?, Object?>{
-          "platform": "android",
-          "permissions": <Object?, Object?>{
-            "android.permission.BLUETOOTH_SCAN": "granted",
-            "android.permission.BLUETOOTH_CONNECT": "denied",
-          },
-          "requiredPermissions": <Object?>[
-            "android.permission.BLUETOOTH_SCAN",
-            "android.permission.BLUETOOTH_CONNECT",
-          ],
-          "missingPermissions": <Object?>[
-            "android.permission.BLUETOOTH_CONNECT",
-          ],
-          "canScan": true,
-          "canAdvertise": false,
+      final BarnardPermissionStatus
+      status = BarnardPermissionStatus.fromMap(<Object?, Object?>{
+        "platform": "android",
+        "permissions": <Object?, Object?>{
+          "android.permission.BLUETOOTH_SCAN": "granted",
+          "android.permission.BLUETOOTH_CONNECT": "denied",
         },
-      );
+        "requiredPermissions": <Object?>[
+          "android.permission.BLUETOOTH_SCAN",
+          "android.permission.BLUETOOTH_CONNECT",
+        ],
+        "missingPermissions": <Object?>["android.permission.BLUETOOTH_CONNECT"],
+        "requestablePermissions": <Object?>[],
+        "blockedPermissions": <Object?>["android.permission.BLUETOOTH_CONNECT"],
+        "canScan": true,
+        "canAdvertise": false,
+      });
 
       expect(status.platform, equals("android"));
       expect(
@@ -44,6 +43,12 @@ void main() {
         status.missingPermissions,
         equals(<String>["android.permission.BLUETOOTH_CONNECT"]),
       );
+      expect(status.requestablePermissions, isEmpty);
+      expect(
+        status.blockedPermissions,
+        equals(<String>["android.permission.BLUETOOTH_CONNECT"]),
+      );
+      expect(status.canRequest, isFalse);
       expect(status.canScan, isTrue);
       expect(status.canAdvertise, isFalse);
       expect(status.allGranted, isFalse);

--- a/packages/dart/barnard/test/ble_client_parser_test.dart
+++ b/packages/dart/barnard/test/ble_client_parser_test.dart
@@ -6,6 +6,50 @@ import "package:barnard/src/interface_adapter/ble/barnard_ble_client.dart";
 import "package:flutter_test/flutter_test.dart";
 
 void main() {
+  group("BarnardPermissionStatus", () {
+    test("parses stable permission result fields", () {
+      final BarnardPermissionStatus status = BarnardPermissionStatus.fromMap(
+        <Object?, Object?>{
+          "platform": "android",
+          "permissions": <Object?, Object?>{
+            "android.permission.BLUETOOTH_SCAN": "granted",
+            "android.permission.BLUETOOTH_CONNECT": "denied",
+          },
+          "requiredPermissions": <Object?>[
+            "android.permission.BLUETOOTH_SCAN",
+            "android.permission.BLUETOOTH_CONNECT",
+          ],
+          "missingPermissions": <Object?>[
+            "android.permission.BLUETOOTH_CONNECT",
+          ],
+          "canScan": true,
+          "canAdvertise": false,
+        },
+      );
+
+      expect(status.platform, equals("android"));
+      expect(
+        status.permissions["android.permission.BLUETOOTH_SCAN"],
+        equals(BarnardPermissionDecision.granted),
+      );
+      expect(
+        status.permissions["android.permission.BLUETOOTH_CONNECT"],
+        equals(BarnardPermissionDecision.denied),
+      );
+      expect(
+        status.requiredPermissions,
+        contains("android.permission.BLUETOOTH_SCAN"),
+      );
+      expect(
+        status.missingPermissions,
+        equals(<String>["android.permission.BLUETOOTH_CONNECT"]),
+      );
+      expect(status.canScan, isTrue);
+      expect(status.canAdvertise, isFalse);
+      expect(status.allGranted, isFalse);
+    });
+  });
+
   group("RSSI helpers", () {
     test("treats CoreBluetooth unavailable RSSI as unusable", () {
       expect(isUsableBleRssi(unavailableBleRssi), isFalse);

--- a/packages/react-native/barnard/README.md
+++ b/packages/react-native/barnard/README.md
@@ -4,12 +4,12 @@ React Native plugin for Barnard SDK - BLE Scan/Advertise + GATT-based RPID detec
 
 ## Features
 
-- ✅ BLE Central role (scanning for nearby devices)
-- ✅ BLE Peripheral role (advertising + GATT server)
-- ✅ GATT-based RPID exchange
-- ✅ iOS support via CoreBluetooth
-- ✅ Android support (API 21+)
-- ✅ TypeScript API
+- BLE Central role (Scan)
+- BLE Peripheral role (Advertise + GATT server)
+- GATT-based v2 RPID exchange
+- iOS support via CoreBluetooth
+- Android support via platform BLE APIs
+- TypeScript API
 
 ## Installation
 
@@ -18,6 +18,11 @@ npm install barnard
 # or
 yarn add barnard
 ```
+
+Minimum platform versions:
+- React Native 0.71+
+- iOS 14.0+
+- Android API 21+
 
 ### iOS Setup
 
@@ -36,26 +41,30 @@ cd ios && pod install
 <string>This app uses Bluetooth to advertise to nearby devices</string>
 ```
 
+Barnard does not initialize CoreBluetooth when the native module is registered. The iOS Bluetooth permission dialog can only be triggered by an explicit app action such as `requestPermissions()`, `startScan()`, `startAdvertise()`, or `startAuto()`.
+
 ### Android Setup
 
-The plugin automatically adds the required permissions to `AndroidManifest.xml`. You need to request permissions at runtime:
+The plugin automatically adds the required BLE and legacy location declarations to `AndroidManifest.xml` through manifest merge. Use Barnard's permission API so the app controls when Android shows runtime permission dialogs:
 
 ```typescript
-import { PermissionsAndroid, Platform } from 'react-native';
-
-async function requestBluetoothPermissions() {
-  if (Platform.OS === 'android' && Platform.Version >= 31) {
-    const granted = await PermissionsAndroid.requestMultiple([
-      PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
-      PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
-      PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
-    ]);
-    return Object.values(granted).every(
-      status => status === PermissionsAndroid.RESULTS.GRANTED
-    );
-  }
-  return true;
+const status = await barnard.getPermissionStatus();
+if (status.missingPermissions.length > 0) {
+  await barnard.requestPermissions();
 }
+```
+
+On Android 12+ Barnard requests Bluetooth runtime permissions and declares `BLUETOOTH_SCAN` with `neverForLocation`, so location permission is not required for BLE Scan. This flag is scoped to the Bluetooth Scan permission and does not prevent the host app from requesting `ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION` for GPS, maps, geofencing, or other non-BLE location features. On Android 11 and below Barnard requests the legacy location permission required by Android BLE Scan.
+
+If the host app uses BLE Scan results themselves to infer physical location, do not use Barnard's default `neverForLocation` declaration. Android may filter some BLE beacons when this flag is present. Override the merged permission in the app manifest:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_SCAN"
+        tools:remove="android:usesPermissionFlags" />
+</manifest>
 ```
 
 ## Usage
@@ -65,27 +74,31 @@ async function requestBluetoothPermissions() {
 ```typescript
 import { BarnardManager } from 'barnard';
 
-// Create manager instance
 const barnard = new BarnardManager();
 
-// Check capabilities
 const capabilities = await barnard.getCapabilities();
 console.log('Supported transports:', capabilities.supportedTransports);
 
-// Listen for detections
+const permissions = await barnard.requestPermissions();
+if (permissions.missingPermissions.length > 0) {
+  // Show app-specific guidance before starting BLE.
+  return;
+}
+
 const unsubscribe = barnard.onDetection((event) => {
-  console.log('Detected:', event.displayId);
+  console.log('Detected:', event.detectedDisplayId);
   console.log('RSSI:', event.rssi);
-  console.log('Transport:', event.transport);
+  console.log('ENIN:', event.enin);
 });
 
-// Start scanning and advertising
+await barnard.joinEvent('EXAMPLE_EVENT');
 await barnard.startAuto({
   scan: { allowDuplicates: true },
   advertise: { formatVersion: 1 },
 });
 
 // Later: cleanup
+await barnard.stopAuto();
 unsubscribe();
 await barnard.dispose();
 ```
@@ -97,7 +110,12 @@ The SDK emits several event types:
 ```typescript
 // Detection events (RPID detections)
 barnard.onDetection((event) => {
-  console.log('Detected:', event.displayId, event.rssi);
+  console.log('Detected:', event.detectedDisplayId, event.rssi);
+});
+
+// High-rate RSSI updates for known peers
+barnard.onRssiUpdate((event) => {
+  console.log('RSSI:', event.rssi, event.enin);
 });
 
 // State changes (scanning/advertising status)
@@ -133,6 +151,27 @@ barnard.onDebug((event) => {
 - **`getState()`**: Get current state (scanning/advertising status)
   - Returns: `Promise<BarnardState>`
 
+- **`getPermissionStatus()`**: Inspect platform BLE permissions without prompting
+  - Returns: `Promise<BarnardPermissionStatus>`
+
+- **`requestPermissions()`**: Request platform BLE permissions at an app-controlled moment
+  - Returns: `Promise<BarnardPermissionStatus>`
+
+- **`getCurrentEventCode()`**: Get the joined event code, or `null`
+  - Returns: `Promise<string | null>`
+
+- **`getMyDisplayId()`**: Get this device's 8-char v2 displayId
+  - Returns: `Promise<string>`
+
+- **`getCurrentRpi()`**: Get the current 16-byte inner RPI as 32-char lowercase hex
+  - Returns: `Promise<string>`
+
+- **`getCurrentEnin()`**: Get the current ENIN
+  - Returns: `Promise<number>`
+
+- **`exportCurrentTek()`**: Explicitly export the current 16-byte TEK as 32-char lowercase hex
+  - Returns: `Promise<string>`
+
 - **`startScan(config?)`**: Start BLE scanning
   - Parameters: `ScanConfig` (optional)
   - Returns: `Promise<void>`
@@ -154,12 +193,21 @@ barnard.onDebug((event) => {
 - **`stopAuto()`**: Stop both scanning and advertising
   - Returns: `Promise<void>`
 
+- **`joinEvent(eventCode)`**: Join an event and derive event-scoped TEK/RPID/displayId values
+  - Returns: `Promise<void>`
+
+- **`leaveEvent()`**: Leave the current event and return to anonymous derivation
+  - Returns: `Promise<void>`
+
 - **`dispose()`**: Dispose of the manager and release resources
-  - Returns: `void`
+  - Returns: `Promise<void>`
 
 ##### Event Listeners
 
 - **`onDetection(callback)`**: Subscribe to detection events
+  - Returns: Unsubscribe function
+
+- **`onRssiUpdate(callback)`**: Subscribe to high-rate RSSI update events for known peers
   - Returns: Unsubscribe function
 
 - **`onStateChange(callback)`**: Subscribe to state change events
@@ -185,9 +233,27 @@ interface BarnardCapabilities {
   supportsHighRateRssi: boolean;
 }
 
+type BarnardPermissionDecision =
+  | 'granted'
+  | 'denied'
+  | 'notDetermined'
+  | 'restricted'
+  | 'unsupported'
+  | 'unknown';
+
+interface BarnardPermissionStatus {
+  platform: string;
+  permissions: Record<string, BarnardPermissionDecision>;
+  requiredPermissions: string[];
+  missingPermissions: string[];
+  canScan: boolean;
+  canAdvertise: boolean;
+}
+
 interface BarnardState {
   isScanning: boolean;
   isAdvertising: boolean;
+  eventCode?: string | null;
 }
 
 interface DetectionEvent {
@@ -195,24 +261,39 @@ interface DetectionEvent {
   timestamp: string;
   transport: TransportKind;
   formatVersion: number;
-  rpid: string;        // base64
-  displayId: string;   // hex (first 4 bytes)
+  rpid: string;               // 34-char lowercase hex, [formatVersion + RPI]
+  reporterRpid: string;       // 34-char lowercase hex for this device
+  detectedDisplayId: string | null; // 8-char lowercase hex, or null
+  enin: number;
   rssi: number;
-  payloadRaw?: string; // base64
+  payloadRaw?: string | null; // 34-char lowercase hex when available
+  debugLocalName?: string | null;
+}
+
+interface RssiUpdateEvent {
+  type: 'rssi_update';
+  timestamp: string;
+  rpid: string;
+  reporterRpid: string;
+  enin: number;
+  rssi: number;
+  detectedDisplayId?: string | null;
 }
 ```
 
 ## Security & Privacy
 
-- **No device-unique persistent identifiers on-wire**: The RPID rotates every 600 seconds using HMAC-SHA256
-- **Local seed storage**: A 32-byte random seed is generated and stored locally (UserDefaults on iOS, SharedPreferences on Android)
-- **GATT-based exchange**: RPIDs are transmitted via GATT characteristic reads, not in advertisement data
+- **No device-unique persistent identifiers on-wire**: Barnard transmits rotating v2 RPID values, not device-unique persistent IDs.
+- **TEK is not transmitted over BLE**: `exportCurrentTek()` is an explicit host-app egress API, not part of Scan / Advertise / GATT delivery.
+- **GATT-based exchange**: Advertise is used for discovery; RPIDs are read through GATT characteristics.
 
-## Minimum Requirements
+## Troubleshooting
 
-- **React Native**: 0.71+
-- **iOS**: 14.0+
-- **Android**: API 21+ (Android 5.0+)
+- `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`.
+- `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
+- No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator.
+- Android app does not show permission dialogs: confirm the package manifest is being merged and the app did not remove Barnard permissions with manifest tools rules.
+- Cross-platform discovery is foreground-only. iOS background advertising may move Service UUIDs to the overflow area, making devices hard to discover.
 
 ## License
 
@@ -220,5 +301,5 @@ MIT
 
 ## Related
 
-- [Barnard Spec](../../specs/001-barnard-core-sdk/spec.md)
-- [Flutter Implementation](../dart/barnard)
+- [Barnard Spec](../../../specs/001-barnard-core-sdk/spec.md)
+- [Flutter Implementation](../../dart/barnard)

--- a/packages/react-native/barnard/README.md
+++ b/packages/react-native/barnard/README.md
@@ -67,6 +67,8 @@ On Android 12+ Barnard requests Bluetooth runtime permissions and declares `BLUE
 
 If the user denies the Android 12+ Nearby devices request, Android may mark the Bluetooth permissions as blocked (`blockedPermissions` is non-empty) and will not show the dialog again. Use `openAppSettings()` and tell the user to enable **Nearby devices** for the app; Android Settings does not label this group as "Bluetooth".
 
+After calling `openAppSettings()`, refresh `getPermissionStatus()` when the app returns to the foreground (for example when React Native `AppState` becomes `active`). Android does not notify Barnard directly when the user changes Nearby devices in Settings, so the host app should update its cached permission UI on foreground resume.
+
 If the host app uses BLE Scan results themselves to infer physical location, do not use Barnard's default `neverForLocation` declaration. Android may filter some BLE beacons when this flag is present. Override the merged permission in the app manifest:
 
 ```xml

--- a/packages/react-native/barnard/README.md
+++ b/packages/react-native/barnard/README.md
@@ -52,11 +52,20 @@ The plugin automatically adds the required BLE and legacy location declarations 
 ```typescript
 const status = await barnard.getPermissionStatus();
 if (status.missingPermissions.length > 0) {
-  await barnard.requestPermissions();
+  if (status.blockedPermissions.length > 0) {
+    await barnard.openAppSettings();
+  } else {
+    const requested = await barnard.requestPermissions();
+    if (requested.blockedPermissions.length > 0) {
+      await barnard.openAppSettings();
+    }
+  }
 }
 ```
 
 On Android 12+ Barnard requests Bluetooth runtime permissions and declares `BLUETOOTH_SCAN` with `neverForLocation`, so location permission is not required for BLE Scan. This flag is scoped to the Bluetooth Scan permission and does not prevent the host app from requesting `ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION` for GPS, maps, geofencing, or other non-BLE location features. On Android 11 and below Barnard requests the legacy location permission required by Android BLE Scan.
+
+If the user denies the Android 12+ Nearby devices request, Android may mark the Bluetooth permissions as blocked (`blockedPermissions` is non-empty) and will not show the dialog again. Use `openAppSettings()` and tell the user to enable **Nearby devices** for the app; Android Settings does not label this group as "Bluetooth".
 
 If the host app uses BLE Scan results themselves to infer physical location, do not use Barnard's default `neverForLocation` declaration. Android may filter some BLE beacons when this flag is present. Override the merged permission in the app manifest:
 
@@ -158,6 +167,9 @@ barnard.onDebug((event) => {
 
 - **`requestPermissions()`**: Request platform BLE permissions at an app-controlled moment
   - Returns: `Promise<BarnardPermissionStatus>`
+
+- **`openAppSettings()`**: Open the host app's system settings page when permissions are blocked
+  - Returns: `Promise<void>`
 
 - **`getCurrentEventCode()`**: Get the joined event code, or `null`
   - Returns: `Promise<string | null>`
@@ -291,7 +303,7 @@ interface RssiUpdateEvent {
 
 ## Troubleshooting
 
-- `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`.
+- `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`. If `blockedPermissions` is non-empty, open app settings instead of requesting again.
 - `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
 - No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator.
 - Android app does not show permission dialogs: confirm the package manifest is being merged and the app did not remove Barnard permissions with manifest tools rules.

--- a/packages/react-native/barnard/README.md
+++ b/packages/react-native/barnard/README.md
@@ -43,6 +43,8 @@ cd ios && pod install
 
 Barnard does not initialize CoreBluetooth when the native module is registered. The iOS Bluetooth permission dialog can only be triggered by an explicit app action such as `requestPermissions()`, `startScan()`, `startAdvertise()`, or `startAuto()`.
 
+Barnard does not require iOS Local Network permission. If a debug run shows a "Find Devices on Local Networks" dialog, that is from development tooling such as Metro, not Barnard BLE registration.
+
 ### Android Setup
 
 The plugin automatically adds the required BLE and legacy location declarations to `AndroidManifest.xml` through manifest merge. Use Barnard's permission API so the app controls when Android shows runtime permission dialogs:

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -9,6 +9,8 @@ jest.mock('react-native', () => {
       permissions: { 'mock.bluetooth': 'granted' },
       requiredPermissions: ['mock.bluetooth'],
       missingPermissions: [],
+      requestablePermissions: [],
+      blockedPermissions: [],
       canScan: true,
       canAdvertise: true,
     }),
@@ -17,9 +19,12 @@ jest.mock('react-native', () => {
       permissions: { 'mock.bluetooth': 'granted' },
       requiredPermissions: ['mock.bluetooth'],
       missingPermissions: [],
+      requestablePermissions: [],
+      blockedPermissions: [],
       canScan: true,
       canAdvertise: true,
     }),
+    openAppSettings: jest.fn().mockResolvedValue(undefined),
     getCurrentEventCode: jest.fn().mockResolvedValue(null),
     getMyDisplayId: jest.fn().mockResolvedValue('374708ff'),
     getCurrentRpi: jest.fn().mockResolvedValue('00'.repeat(16)),
@@ -157,6 +162,15 @@ describe('BarnardManager v2 API', () => {
 
     expect(nativeModule.getPermissionStatus).toHaveBeenCalledTimes(1);
     expect(nativeModule.requestPermissions).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates opening app settings to native module', async () => {
+    const { BarnardManager, nativeModule } = setup();
+    const manager = new BarnardManager();
+
+    await manager.openAppSettings();
+
+    expect(nativeModule.openAppSettings).toHaveBeenCalledTimes(1);
   });
 
   it('forwards joinEvent argument to native module', async () => {

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -4,6 +4,22 @@ jest.mock('react-native', () => {
   const Barnard = {
     getCapabilities: jest.fn().mockResolvedValue({ supportedTransports: ['ble'] }),
     getState: jest.fn().mockResolvedValue({ isScanning: false, isAdvertising: false }),
+    getPermissionStatus: jest.fn().mockResolvedValue({
+      platform: 'mock',
+      permissions: { 'mock.bluetooth': 'granted' },
+      requiredPermissions: ['mock.bluetooth'],
+      missingPermissions: [],
+      canScan: true,
+      canAdvertise: true,
+    }),
+    requestPermissions: jest.fn().mockResolvedValue({
+      platform: 'mock',
+      permissions: { 'mock.bluetooth': 'granted' },
+      requiredPermissions: ['mock.bluetooth'],
+      missingPermissions: [],
+      canScan: true,
+      canAdvertise: true,
+    }),
     getCurrentEventCode: jest.fn().mockResolvedValue(null),
     getMyDisplayId: jest.fn().mockResolvedValue('374708ff'),
     getCurrentRpi: jest.fn().mockResolvedValue('00'.repeat(16)),
@@ -69,6 +85,8 @@ const setup = () => {
       getCurrentRpi: () => Promise<string>;
       getCurrentEnin: () => Promise<number>;
       exportCurrentTek: () => Promise<string>;
+      getPermissionStatus: () => Promise<unknown>;
+      requestPermissions: () => Promise<unknown>;
       joinEvent: (eventCode: string) => Promise<void>;
       onDetection: (callback: (event: unknown) => void) => () => void;
       onRssiUpdate: (callback: (event: unknown) => void) => () => void;
@@ -120,6 +138,25 @@ describe('BarnardManager v2 API', () => {
     const manager = new BarnardManager();
     const tek = await manager.exportCurrentTek();
     expect(tek).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('delegates permission status APIs to native module', async () => {
+    const { BarnardManager, nativeModule } = setup();
+    const manager = new BarnardManager();
+
+    await expect(manager.getPermissionStatus()).resolves.toMatchObject({
+      platform: 'mock',
+      canScan: true,
+      canAdvertise: true,
+    });
+    await expect(manager.requestPermissions()).resolves.toMatchObject({
+      platform: 'mock',
+      canScan: true,
+      canAdvertise: true,
+    });
+
+    expect(nativeModule.getPermissionStatus).toHaveBeenCalledTimes(1);
+    expect(nativeModule.requestPermissions).toHaveBeenCalledTimes(1);
   });
 
   it('forwards joinEvent argument to native module', async () => {

--- a/packages/react-native/barnard/android/src/main/AndroidManifest.xml
+++ b/packages/react-native/barnard/android/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
                      android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" 
                      android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
+                     android:maxSdkVersion="28" />
     
-    <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
 </manifest>

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -187,6 +187,10 @@ internal class BarnardController(
         }
     }
 
+    fun getPermissionStatus(): WritableMap {
+        return toWritableMap(permissionStatusPayload())
+    }
+
     /** v2 API: current event code (or null). */
     fun getCurrentEventCode(): String? = eventCode
 
@@ -300,7 +304,7 @@ internal class BarnardController(
         if (!hasScanPermission()) {
             emitConstraint(
                 "permission_denied",
-                "Missing BLUETOOTH_SCAN permission",
+                "Missing ${requiredScanPermission()} permission",
                 requiredAction = "grant_permission"
             )
             return
@@ -704,19 +708,63 @@ internal class BarnardController(
 
     // MARK: - Permissions
 
+    fun requiredRuntimePermissions(): List<String> {
+        return when {
+            Build.VERSION.SDK_INT >= 31 -> listOf(
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.BLUETOOTH_CONNECT,
+            )
+            Build.VERSION.SDK_INT >= 23 -> listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            else -> emptyList()
+        }
+    }
+
+    fun hasPermission(permission: String): Boolean {
+        if (Build.VERSION.SDK_INT < 23) return true
+        return appContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun permissionStatusPayload(): Map<String, Any> {
+        val required = requiredRuntimePermissions()
+        val missing = required.filter { !hasPermission(it) }
+        val permissions = required.associateWith { permission ->
+            if (hasPermission(permission)) "granted" else "denied"
+        }
+        return mapOf(
+            "platform" to "android",
+            "permissions" to permissions,
+            "requiredPermissions" to required,
+            "missingPermissions" to missing,
+            "canScan" to hasScanPermission(),
+            "canAdvertise" to (hasAdvertisePermission() && hasConnectPermission()),
+        )
+    }
+
     private fun hasScanPermission(): Boolean {
-        if (Build.VERSION.SDK_INT < 31) return true
-        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED
+        return when {
+            Build.VERSION.SDK_INT >= 31 -> hasPermission(Manifest.permission.BLUETOOTH_SCAN)
+            Build.VERSION.SDK_INT >= 23 -> hasPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            else -> true
+        }
+    }
+
+    private fun requiredScanPermission(): String {
+        return if (Build.VERSION.SDK_INT >= 31) {
+            Manifest.permission.BLUETOOTH_SCAN
+        } else {
+            Manifest.permission.ACCESS_FINE_LOCATION
+        }
     }
 
     private fun hasAdvertisePermission(): Boolean {
         if (Build.VERSION.SDK_INT < 31) return true
-        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_ADVERTISE) == PackageManager.PERMISSION_GRANTED
+        return hasPermission(Manifest.permission.BLUETOOTH_ADVERTISE)
     }
 
     private fun hasConnectPermission(): Boolean {
         if (Build.VERSION.SDK_INT < 31) return true
-        return appContext.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED
+        return hasPermission(Manifest.permission.BLUETOOTH_CONNECT)
     }
 
     // MARK: - Advertise Callback

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -4,6 +4,7 @@
 package network.greeting.barnard
 
 import android.Manifest
+import android.app.Activity
 import android.annotation.SuppressLint
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
@@ -23,12 +24,15 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
+import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
+import android.provider.Settings
 import android.util.Base64
 import android.util.Log
 import com.facebook.react.bridge.Arguments
@@ -38,6 +42,17 @@ import network.greeting.barnard.BarnardCrypto.toHex
 import java.util.UUID
 
 private const val TAG = "BarnardBLE"
+
+internal fun isRuntimePermissionRequestBlocked(
+    sdkInt: Int,
+    hasPermission: Boolean,
+    wasRequestedBefore: Boolean,
+    shouldShowRequestPermissionRationale: Boolean
+): Boolean {
+    if (sdkInt < 23 || hasPermission) return false
+    if (!wasRequestedBefore) return false
+    return !shouldShowRequestPermissionRationale
+}
 
 /**
  * Barnard v2 BLE controller (React Native bridge variant).
@@ -54,6 +69,10 @@ private const val TAG = "BarnardBLE"
 internal class BarnardController(
     private val appContext: Context
 ) {
+    private companion object {
+        const val permissionRequestedKeyPrefix = "permission_requested:"
+    }
+
     private val mainHandler = Handler(Looper.getMainLooper())
 
     var onEvent: ((String, WritableMap) -> Unit)? = null
@@ -187,8 +206,8 @@ internal class BarnardController(
         }
     }
 
-    fun getPermissionStatus(): WritableMap {
-        return toWritableMap(permissionStatusPayload())
+    fun getPermissionStatus(activity: Activity? = null): WritableMap {
+        return toWritableMap(permissionStatusPayload(activity))
     }
 
     /** v2 API: current event code (or null). */
@@ -725,9 +744,40 @@ internal class BarnardController(
         return appContext.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
     }
 
-    private fun permissionStatusPayload(): Map<String, Any> {
+    fun isPermissionRequestBlocked(permission: String, activity: Activity?): Boolean {
+        if (Build.VERSION.SDK_INT < 23 || hasPermission(permission)) return false
+        val currentActivity = activity ?: return false
+        return isRuntimePermissionRequestBlocked(
+            sdkInt = Build.VERSION.SDK_INT,
+            hasPermission = false,
+            wasRequestedBefore = wasPermissionRequested(permission),
+            shouldShowRequestPermissionRationale =
+                currentActivity.shouldShowRequestPermissionRationale(permission)
+        )
+    }
+
+    fun markPermissionsRequested(permissions: List<String>) {
+        if (permissions.isEmpty()) return
+        prefs.edit().apply {
+            for (permission in permissions) {
+                putBoolean(permissionRequestedKey(permission), true)
+            }
+        }.apply()
+    }
+
+    private fun wasPermissionRequested(permission: String): Boolean {
+        return prefs.getBoolean(permissionRequestedKey(permission), false)
+    }
+
+    private fun permissionRequestedKey(permission: String): String {
+        return "$permissionRequestedKeyPrefix$permission"
+    }
+
+    private fun permissionStatusPayload(activity: Activity?): Map<String, Any> {
         val required = requiredRuntimePermissions()
         val missing = required.filter { !hasPermission(it) }
+        val blocked = missing.filter { isPermissionRequestBlocked(it, activity) }
+        val requestable = missing.filterNot { blocked.contains(it) }
         val permissions = required.associateWith { permission ->
             if (hasPermission(permission)) "granted" else "denied"
         }
@@ -736,9 +786,19 @@ internal class BarnardController(
             "permissions" to permissions,
             "requiredPermissions" to required,
             "missingPermissions" to missing,
+            "requestablePermissions" to requestable,
+            "blockedPermissions" to blocked,
             "canScan" to hasScanPermission(),
             "canAdvertise" to (hasAdvertisePermission() && hasConnectPermission()),
         )
+    }
+
+    fun openAppSettings() {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", appContext.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        appContext.startActivity(intent)
     }
 
     private fun hasScanPermission(): Boolean {

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
@@ -8,9 +8,18 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
+import com.facebook.react.modules.core.PermissionAwareActivity
+import com.facebook.react.modules.core.PermissionListener
 
-class BarnardModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+class BarnardModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext),
+    PermissionListener {
+    private companion object {
+        const val permissionRequestCode = 0xB4D
+    }
+
     private var controller: BarnardController? = null
+    private var pendingPermissionPromise: Promise? = null
 
     init {
         setupController(reactContext)
@@ -72,6 +81,77 @@ class BarnardModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
         } catch (e: Exception) {
             promise.reject("E_GET_STATE", e.message, e)
         }
+    }
+
+    @ReactMethod
+    fun getPermissionStatus(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            promise.resolve(ctrl.getPermissionStatus())
+        } catch (e: Exception) {
+            promise.reject("E_GET_PERMISSION_STATUS", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun requestPermissions(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            val missing = ctrl.requiredRuntimePermissions().filter { !ctrl.hasPermission(it) }
+            if (missing.isEmpty()) {
+                promise.resolve(ctrl.getPermissionStatus())
+                return
+            }
+
+            val permissionActivity = currentActivity as? PermissionAwareActivity
+            if (permissionActivity == null) {
+                promise.reject(
+                    "E_NO_ACTIVITY",
+                    "requestPermissions requires a PermissionAwareActivity"
+                )
+                return
+            }
+            if (pendingPermissionPromise != null) {
+                promise.reject(
+                    "E_PERMISSION_REQUEST_IN_PROGRESS",
+                    "A Barnard permission request is already in progress"
+                )
+                return
+            }
+
+            pendingPermissionPromise = promise
+            permissionActivity.requestPermissions(
+                missing.toTypedArray(),
+                permissionRequestCode,
+                this
+            )
+        } catch (e: Exception) {
+            pendingPermissionPromise = null
+            promise.reject("E_REQUEST_PERMISSIONS", e.message, e)
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ): Boolean {
+        if (requestCode != permissionRequestCode) return false
+        val promise = pendingPermissionPromise ?: return false
+        pendingPermissionPromise = null
+        val ctrl = controller
+        if (ctrl == null) {
+            promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+        } else {
+            promise.resolve(ctrl.getPermissionStatus())
+        }
+        return true
     }
 
     // MARK: - v2 API

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
@@ -90,7 +90,7 @@ class BarnardModule(reactContext: ReactApplicationContext) :
                 promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
                 return
             }
-            promise.resolve(ctrl.getPermissionStatus())
+            promise.resolve(ctrl.getPermissionStatus(currentActivity))
         } catch (e: Exception) {
             promise.reject("E_GET_PERMISSION_STATUS", e.message, e)
         }
@@ -105,11 +105,17 @@ class BarnardModule(reactContext: ReactApplicationContext) :
             }
             val missing = ctrl.requiredRuntimePermissions().filter { !ctrl.hasPermission(it) }
             if (missing.isEmpty()) {
-                promise.resolve(ctrl.getPermissionStatus())
+                promise.resolve(ctrl.getPermissionStatus(currentActivity))
+                return
+            }
+            val activeActivity = currentActivity
+            val requestable = missing.filterNot { ctrl.isPermissionRequestBlocked(it, activeActivity) }
+            if (requestable.isEmpty()) {
+                promise.resolve(ctrl.getPermissionStatus(activeActivity))
                 return
             }
 
-            val permissionActivity = currentActivity as? PermissionAwareActivity
+            val permissionActivity = activeActivity as? PermissionAwareActivity
             if (permissionActivity == null) {
                 promise.reject(
                     "E_NO_ACTIVITY",
@@ -126,14 +132,29 @@ class BarnardModule(reactContext: ReactApplicationContext) :
             }
 
             pendingPermissionPromise = promise
+            ctrl.markPermissionsRequested(requestable)
             permissionActivity.requestPermissions(
-                missing.toTypedArray(),
+                requestable.toTypedArray(),
                 permissionRequestCode,
                 this
             )
         } catch (e: Exception) {
             pendingPermissionPromise = null
             promise.reject("E_REQUEST_PERMISSIONS", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun openAppSettings(promise: Promise) {
+        try {
+            val ctrl = controller ?: run {
+                promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
+                return
+            }
+            ctrl.openAppSettings()
+            promise.resolve(null)
+        } catch (e: Exception) {
+            promise.reject("E_OPEN_APP_SETTINGS", e.message, e)
         }
     }
 
@@ -149,7 +170,7 @@ class BarnardModule(reactContext: ReactApplicationContext) :
         if (ctrl == null) {
             promise.reject("E_NOT_INITIALIZED", "Controller not initialized")
         } else {
-            promise.resolve(ctrl.getPermissionStatus())
+            promise.resolve(ctrl.getPermissionStatus(currentActivity))
         }
         return true
     }

--- a/packages/react-native/barnard/ios/Barnard.m
+++ b/packages/react-native/barnard/ios/Barnard.m
@@ -15,6 +15,9 @@ RCT_EXTERN_METHOD(getPermissionStatus:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(requestPermissions:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(openAppSettings:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 // v2 API
 
 RCT_EXTERN_METHOD(getCurrentEventCode:(RCTPromiseResolveBlock)resolve

--- a/packages/react-native/barnard/ios/Barnard.m
+++ b/packages/react-native/barnard/ios/Barnard.m
@@ -9,6 +9,12 @@ RCT_EXTERN_METHOD(getCapabilities:(RCTPromiseResolveBlock)resolve
 RCT_EXTERN_METHOD(getState:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getPermissionStatus:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(requestPermissions:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 // v2 API
 
 RCT_EXTERN_METHOD(getCurrentEventCode:(RCTPromiseResolveBlock)resolve

--- a/packages/react-native/barnard/ios/Barnard.swift
+++ b/packages/react-native/barnard/ios/Barnard.swift
@@ -100,6 +100,19 @@ class Barnard: RCTEventEmitter {
     }
   }
 
+  @objc
+  func openAppSettings(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    controller.openAppSettings()
+    resolve(nil)
+  }
+
   // v2 API
 
   @objc

--- a/packages/react-native/barnard/ios/Barnard.swift
+++ b/packages/react-native/barnard/ios/Barnard.swift
@@ -74,6 +74,32 @@ class Barnard: RCTEventEmitter {
     resolve(controller.getState())
   }
 
+  @objc
+  func getPermissionStatus(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    resolve(controller.getPermissionStatus())
+  }
+
+  @objc
+  func requestPermissions(
+    _ resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    guard let controller = controller else {
+      reject("E_NOT_INITIALIZED", "Controller not initialized", nil)
+      return
+    }
+    controller.requestPermissions { payload in
+      resolve(payload)
+    }
+  }
+
   // v2 API
 
   @objc

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -44,8 +44,9 @@ final class BarnardBleController: NSObject {
 
   private let rpid = BarnardRpidGenerator()
 
-  private var centralManager: CBCentralManager!
-  private var peripheralManager: CBPeripheralManager!
+  private var centralManager: CBCentralManager?
+  private var peripheralManager: CBPeripheralManager?
+  private var pendingPermissionCompletions: [([String: Any]) -> Void] = []
 
   private var rpidCharacteristic: CBMutableCharacteristic?
   private var displayIdCharacteristic: CBMutableCharacteristic?
@@ -110,8 +111,6 @@ final class BarnardBleController: NSObject {
 
   override init() {
     super.init()
-    centralManager = CBCentralManager(delegate: self, queue: nil)
-    peripheralManager = CBPeripheralManager(delegate: self, queue: nil)
 
     NotificationCenter.default.addObserver(
       self,
@@ -129,6 +128,81 @@ final class BarnardBleController: NSObject {
 
   deinit {
     NotificationCenter.default.removeObserver(self)
+  }
+
+  private func ensureCentralManager() -> CBCentralManager {
+    if let manager = centralManager {
+      return manager
+    }
+    let manager = CBCentralManager(delegate: self, queue: nil)
+    centralManager = manager
+    return manager
+  }
+
+  private func ensurePeripheralManager() -> CBPeripheralManager {
+    if let manager = peripheralManager {
+      return manager
+    }
+    let manager = CBPeripheralManager(delegate: self, queue: nil)
+    peripheralManager = manager
+    return manager
+  }
+
+  private func ensureBleManagers() {
+    _ = ensureCentralManager()
+    _ = ensurePeripheralManager()
+  }
+
+  private func bluetoothPermissionStatus() -> String {
+    switch CBManager.authorization {
+    case .allowedAlways:
+      return "granted"
+    case .denied:
+      return "denied"
+    case .restricted:
+      return "restricted"
+    case .notDetermined:
+      return "notDetermined"
+    @unknown default:
+      return "unknown"
+    }
+  }
+
+  func getPermissionStatus() -> [String: Any] {
+    let permissionName = "ios.bluetooth"
+    let status = bluetoothPermissionStatus()
+    let missing = status == "granted" ? [] : [permissionName]
+    return [
+      "platform": "ios",
+      "permissions": [permissionName: status],
+      "requiredPermissions": [permissionName],
+      "missingPermissions": missing,
+      "canScan": status == "granted",
+      "canAdvertise": status == "granted",
+    ]
+  }
+
+  func requestPermissions(completion: @escaping ([String: Any]) -> Void) {
+    if bluetoothPermissionStatus() != "notDetermined" {
+      completion(getPermissionStatus())
+      return
+    }
+
+    pendingPermissionCompletions.append(completion)
+    ensureBleManagers()
+    resolvePendingPermissionCompletionsIfPossible()
+  }
+
+  private func resolvePendingPermissionCompletionsIfPossible() {
+    guard !pendingPermissionCompletions.isEmpty else { return }
+    guard bluetoothPermissionStatus() != "notDetermined" else { return }
+
+    let payload = getPermissionStatus()
+    let completions = pendingPermissionCompletions
+    pendingPermissionCompletions.removeAll()
+    for completion in completions {
+      completion(payload)
+    }
   }
 
   func dispose() {
@@ -150,7 +224,7 @@ final class BarnardBleController: NSObject {
       return
     }
     let activeFormat = Int(formatVersion)
-    peripheralManager.stopAdvertising()
+    peripheralManager?.stopAdvertising()
     isAdvertising = false
     startAdvertise(formatVersion: activeFormat)
     emitDebug(level: "info", name: "advertise_restart_on_foreground", data: nil)
@@ -211,14 +285,15 @@ final class BarnardBleController: NSObject {
   }
 
   func startScan(allowDuplicates: Bool) {
+    let manager = ensureCentralManager()
     self.allowDuplicates = allowDuplicates
-    guard centralManager.state == .poweredOn else {
-      emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(centralManager.state.rawValue)")
+    guard manager.state == .poweredOn else {
+      emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(manager.state.rawValue)")
       return
     }
     if isScanning { return }
     let options: [String: Any] = [CBCentralManagerScanOptionAllowDuplicatesKey: allowDuplicates]
-    centralManager.scanForPeripherals(withServices: [discoveryServiceUUID], options: options)
+    manager.scanForPeripherals(withServices: [discoveryServiceUUID], options: options)
     isScanning = true
     emitState(reasonCode: "scan_start")
     emitDebug(level: "info", name: "scan_start", data: ["allowDuplicates": allowDuplicates])
@@ -226,7 +301,7 @@ final class BarnardBleController: NSObject {
 
   func stopScan() {
     if !isScanning { return }
-    centralManager.stopScan()
+    centralManager?.stopScan()
     isScanning = false
     resetPeerDiscoveryState(reason: "scan_stop")
 
@@ -237,7 +312,7 @@ final class BarnardBleController: NSObject {
   private func resetPeerDiscoveryState(reason: String) {
     connectQueue.removeAll()
     if let active = activePeripheral {
-      centralManager.cancelPeripheralConnection(active)
+      centralManager?.cancelPeripheralConnection(active)
     }
     activePeripheral = nil
     cancelConnectWatchdog()
@@ -258,9 +333,10 @@ final class BarnardBleController: NSObject {
   }
 
   func startAdvertise(formatVersion: Int) {
+    let manager = ensurePeripheralManager()
     self.formatVersion = acceptFormatVersion(formatVersion)
-    guard peripheralManager.state == .poweredOn else {
-      emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(peripheralManager.state.rawValue)")
+    guard manager.state == .poweredOn else {
+      emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(manager.state.rawValue)")
       return
     }
     if isAdvertising { return }
@@ -271,7 +347,7 @@ final class BarnardBleController: NSObject {
     #if DEBUG
     ad[CBAdvertisementDataLocalNameKey] = debugLocalName
     #endif
-    peripheralManager.startAdvertising(ad)
+    manager.startAdvertising(ad)
     isAdvertising = true
     emitState(reasonCode: "advertise_start")
     emitDebug(
@@ -287,7 +363,7 @@ final class BarnardBleController: NSObject {
 
   func stopAdvertise() {
     if !isAdvertising { return }
-    peripheralManager.stopAdvertising()
+    peripheralManager?.stopAdvertising()
     isAdvertising = false
     emitState(reasonCode: "advertise_stop")
     emitDebug(level: "info", name: "advertise_stop", data: nil)
@@ -315,14 +391,15 @@ final class BarnardBleController: NSObject {
   // MARK: - GATT Service Management
 
   private func ensureGattService() {
+    _ = ensurePeripheralManager()
     if rpidCharacteristic != nil { return }
     buildAndAddGattService()
   }
 
   private func rebuildGattServiceIfNeeded() {
-    guard peripheralManager.state == .poweredOn else { return }
+    guard let manager = peripheralManager, manager.state == .poweredOn else { return }
 
-    peripheralManager.removeAllServices()
+    manager.removeAllServices()
     rpidCharacteristic = nil
     displayIdCharacteristic = nil
     eventCodeHashCharacteristic = nil
@@ -333,6 +410,8 @@ final class BarnardBleController: NSObject {
   }
 
   private func buildAndAddGattService() {
+    guard let manager = peripheralManager else { return }
+
     let rpidCh = CBMutableCharacteristic(
       type: rpidCharacteristicUUID,
       properties: [.read],
@@ -357,7 +436,7 @@ final class BarnardBleController: NSObject {
 
     let svc = CBMutableService(type: discoveryServiceUUID, primary: true)
     svc.characteristics = [rpidCh, displayIdCh, eventCodeHashCh]
-    peripheralManager.add(svc)
+    manager.add(svc)
 
     rpidCharacteristic = rpidCh
     displayIdCharacteristic = displayIdCh
@@ -411,6 +490,7 @@ final class BarnardBleController: NSObject {
       connectQueue.removeFirst()
       return
     }
+    guard let manager = centralManager else { return }
 
     connectQueue.removeFirst()
     activePeripheral = p
@@ -420,7 +500,7 @@ final class BarnardBleController: NSObject {
     b004ReadRetries[nextId] = 0
 
     p.delegate = self
-    centralManager.connect(p, options: nil)
+    manager.connect(p, options: nil)
     emitDebug(level: "trace", name: "connect_attempt", data: ["id": nextId.uuidString])
     armConnectWatchdog(for: nextId)
   }
@@ -442,7 +522,7 @@ final class BarnardBleController: NSObject {
         recoverable: true,
         extra: ["seconds": self.connectTimeoutSeconds]
       )
-      self.centralManager.cancelPeripheralConnection(pinned)
+      self.centralManager?.cancelPeripheralConnection(pinned)
       self.peripheralCharacteristics.removeValue(forKey: id)
       self.peripheralReadValues.removeValue(forKey: id)
       self.lastDiscoveryNameById.removeValue(forKey: id)
@@ -613,7 +693,7 @@ final class BarnardBleController: NSObject {
     peripheralReadValues.removeValue(forKey: id)
     b004ReadRetries.removeValue(forKey: id)
     lastDiscoveryNameById.removeValue(forKey: id)
-    centralManager.cancelPeripheralConnection(peripheral)
+    centralManager?.cancelPeripheralConnection(peripheral)
   }
 
   private func characteristicName(_ uuid: CBUUID) -> String {
@@ -793,6 +873,7 @@ final class BarnardBleController: NSObject {
 
 extension BarnardBleController: CBCentralManagerDelegate {
   func centralManagerDidUpdateState(_ central: CBCentralManager) {
+    resolvePendingPermissionCompletionsIfPossible()
     emitDebug(level: "info", name: "central_state", data: ["state": central.state.rawValue])
     if central.state != .poweredOn, isScanning {
       stopScan()
@@ -1063,6 +1144,7 @@ extension BarnardBleController: CBPeripheralDelegate {
 
 extension BarnardBleController: CBPeripheralManagerDelegate {
   func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+    resolvePendingPermissionCompletionsIfPossible()
     emitDebug(level: "info", name: "peripheral_state", data: ["state": peripheral.state.rawValue])
     if peripheral.state != .poweredOn, isAdvertising {
       stopAdvertise()

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -54,6 +54,8 @@ final class BarnardBleController: NSObject {
 
   private var isScanning = false
   private var isAdvertising = false
+  private var shouldStartScanWhenReady = false
+  private var shouldStartAdvertiseWhenReady = false
   private var allowDuplicates = true
   private var formatVersion: UInt8 = 1
 
@@ -298,11 +300,23 @@ final class BarnardBleController: NSObject {
   func startScan(allowDuplicates: Bool) {
     let manager = ensureCentralManager()
     self.allowDuplicates = allowDuplicates
-    guard manager.state == .poweredOn else {
-      emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(manager.state.rawValue)")
+    if isScanning {
+      shouldStartScanWhenReady = false
       return
     }
-    if isScanning { return }
+    guard manager.state == .poweredOn else {
+      if manager.state == .unknown || manager.state == .resetting {
+        shouldStartScanWhenReady = true
+        emitDebug(level: "info", name: "scan_waiting_for_powered_on", data: [
+          "state": manager.state.rawValue,
+        ])
+      } else {
+        shouldStartScanWhenReady = false
+        emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(manager.state.rawValue)")
+      }
+      return
+    }
+    shouldStartScanWhenReady = false
     let options: [String: Any] = [CBCentralManagerScanOptionAllowDuplicatesKey: allowDuplicates]
     manager.scanForPeripherals(withServices: [discoveryServiceUUID], options: options)
     isScanning = true
@@ -311,6 +325,7 @@ final class BarnardBleController: NSObject {
   }
 
   func stopScan() {
+    shouldStartScanWhenReady = false
     if !isScanning { return }
     centralManager?.stopScan()
     isScanning = false
@@ -346,11 +361,23 @@ final class BarnardBleController: NSObject {
   func startAdvertise(formatVersion: Int) {
     let manager = ensurePeripheralManager()
     self.formatVersion = acceptFormatVersion(formatVersion)
-    guard manager.state == .poweredOn else {
-      emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(manager.state.rawValue)")
+    if isAdvertising {
+      shouldStartAdvertiseWhenReady = false
       return
     }
-    if isAdvertising { return }
+    guard manager.state == .poweredOn else {
+      if manager.state == .unknown || manager.state == .resetting {
+        shouldStartAdvertiseWhenReady = true
+        emitDebug(level: "info", name: "advertise_waiting_for_powered_on", data: [
+          "state": manager.state.rawValue,
+        ])
+      } else {
+        shouldStartAdvertiseWhenReady = false
+        emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(manager.state.rawValue)")
+      }
+      return
+    }
+    shouldStartAdvertiseWhenReady = false
     ensureGattService()
     var ad: [String: Any] = [
       CBAdvertisementDataServiceUUIDsKey: [discoveryServiceUUID],
@@ -373,6 +400,7 @@ final class BarnardBleController: NSObject {
   }
 
   func stopAdvertise() {
+    shouldStartAdvertiseWhenReady = false
     if !isAdvertising { return }
     peripheralManager?.stopAdvertising()
     isAdvertising = false
@@ -886,7 +914,9 @@ extension BarnardBleController: CBCentralManagerDelegate {
   func centralManagerDidUpdateState(_ central: CBCentralManager) {
     resolvePendingPermissionCompletionsIfPossible()
     emitDebug(level: "info", name: "central_state", data: ["state": central.state.rawValue])
-    if central.state != .poweredOn, isScanning {
+    if central.state == .poweredOn, shouldStartScanWhenReady {
+      startScan(allowDuplicates: allowDuplicates)
+    } else if central.state != .poweredOn, isScanning {
       stopScan()
     }
   }
@@ -1157,7 +1187,9 @@ extension BarnardBleController: CBPeripheralManagerDelegate {
   func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
     resolvePendingPermissionCompletionsIfPossible()
     emitDebug(level: "info", name: "peripheral_state", data: ["state": peripheral.state.rawValue])
-    if peripheral.state != .poweredOn, isAdvertising {
+    if peripheral.state == .poweredOn, shouldStartAdvertiseWhenReady {
+      startAdvertise(formatVersion: Int(formatVersion))
+    } else if peripheral.state != .poweredOn, isAdvertising {
       stopAdvertise()
     }
   }

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -172,11 +172,15 @@ final class BarnardBleController: NSObject {
     let permissionName = "ios.bluetooth"
     let status = bluetoothPermissionStatus()
     let missing = status == "granted" ? [] : [permissionName]
+    let blocked = (status == "denied" || status == "restricted") ? [permissionName] : []
+    let requestable = missing.filter { !blocked.contains($0) }
     return [
       "platform": "ios",
       "permissions": [permissionName: status],
       "requiredPermissions": [permissionName],
       "missingPermissions": missing,
+      "requestablePermissions": requestable,
+      "blockedPermissions": blocked,
       "canScan": status == "granted",
       "canAdvertise": status == "granted",
     ]
@@ -202,6 +206,13 @@ final class BarnardBleController: NSObject {
     pendingPermissionCompletions.removeAll()
     for completion in completions {
       completion(payload)
+    }
+  }
+
+  func openAppSettings() {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+    DispatchQueue.main.async {
+      UIApplication.shared.open(url)
     }
   }
 

--- a/packages/react-native/barnard/src/BarnardManager.ts
+++ b/packages/react-native/barnard/src/BarnardManager.ts
@@ -2,6 +2,7 @@ import { EmitterSubscription } from 'react-native';
 import { BarnardModule, BarnardEventEmitter } from './NativeBarnard';
 import type {
   BarnardCapabilities,
+  BarnardPermissionStatus,
   BarnardState,
   ScanConfig,
   AdvertiseConfig,
@@ -50,6 +51,14 @@ export class BarnardManager {
 
   async getState(): Promise<BarnardState> {
     return BarnardModule.getState();
+  }
+
+  async getPermissionStatus(): Promise<BarnardPermissionStatus> {
+    return BarnardModule.getPermissionStatus();
+  }
+
+  async requestPermissions(): Promise<BarnardPermissionStatus> {
+    return BarnardModule.requestPermissions();
   }
 
   /** v2: currently joined event code, or null. */

--- a/packages/react-native/barnard/src/BarnardManager.ts
+++ b/packages/react-native/barnard/src/BarnardManager.ts
@@ -61,6 +61,10 @@ export class BarnardManager {
     return BarnardModule.requestPermissions();
   }
 
+  async openAppSettings(): Promise<void> {
+    return BarnardModule.openAppSettings();
+  }
+
   /** v2: currently joined event code, or null. */
   async getCurrentEventCode(): Promise<string | null> {
     return BarnardModule.getCurrentEventCode();

--- a/packages/react-native/barnard/src/NativeBarnard.ts
+++ b/packages/react-native/barnard/src/NativeBarnard.ts
@@ -1,6 +1,7 @@
 import { NativeModules, NativeEventEmitter } from 'react-native';
 import type {
   BarnardCapabilities,
+  BarnardPermissionStatus,
   BarnardState,
   ScanConfig,
   AdvertiseConfig,
@@ -24,6 +25,8 @@ const LINKING_ERROR =
 interface BarnardNativeModule {
   getCapabilities(): Promise<BarnardCapabilities>;
   getState(): Promise<BarnardState>;
+  getPermissionStatus(): Promise<BarnardPermissionStatus>;
+  requestPermissions(): Promise<BarnardPermissionStatus>;
 
   // v2 API
   getCurrentEventCode(): Promise<string | null>;

--- a/packages/react-native/barnard/src/NativeBarnard.ts
+++ b/packages/react-native/barnard/src/NativeBarnard.ts
@@ -27,6 +27,7 @@ interface BarnardNativeModule {
   getState(): Promise<BarnardState>;
   getPermissionStatus(): Promise<BarnardPermissionStatus>;
   requestPermissions(): Promise<BarnardPermissionStatus>;
+  openAppSettings(): Promise<void>;
 
   // v2 API
   getCurrentEventCode(): Promise<string | null>;

--- a/packages/react-native/barnard/src/index.ts
+++ b/packages/react-native/barnard/src/index.ts
@@ -10,6 +10,8 @@ export { BarnardManager } from './BarnardManager';
 export type {
   TransportKind,
   BarnardCapabilities,
+  BarnardPermissionDecision,
+  BarnardPermissionStatus,
   BarnardState,
   ScanConfig,
   AdvertiseConfig,

--- a/packages/react-native/barnard/src/types.ts
+++ b/packages/react-native/barnard/src/types.ts
@@ -14,6 +14,23 @@ export interface BarnardCapabilities {
   supportsHighRateRssi: boolean;
 }
 
+export type BarnardPermissionDecision =
+  | 'granted'
+  | 'denied'
+  | 'notDetermined'
+  | 'restricted'
+  | 'unsupported'
+  | 'unknown';
+
+export interface BarnardPermissionStatus {
+  platform: string;
+  permissions: Record<string, BarnardPermissionDecision>;
+  requiredPermissions: string[];
+  missingPermissions: string[];
+  canScan: boolean;
+  canAdvertise: boolean;
+}
+
 /**
  * Current state of scanning and advertising operations.
  *

--- a/packages/react-native/barnard/src/types.ts
+++ b/packages/react-native/barnard/src/types.ts
@@ -27,6 +27,8 @@ export interface BarnardPermissionStatus {
   permissions: Record<string, BarnardPermissionDecision>;
   requiredPermissions: string[];
   missingPermissions: string[];
+  requestablePermissions: string[];
+  blockedPermissions: string[];
   canScan: boolean;
   canAdvertise: boolean;
 }

--- a/schema/README.md
+++ b/schema/README.md
@@ -9,4 +9,4 @@ Goals
 
 Layout
 - `schema/barnard/v1/`: Barnard v1 JSON Schemas
-
+- `schema/barnard/v2/`: Barnard v2 JSON Schemas for event streams, permissions, and shared types

--- a/schema/barnard/v2/README.md
+++ b/schema/barnard/v2/README.md
@@ -4,6 +4,7 @@ JSON Schema (draft 2020-12) for the Barnard SDK v2 event stream.
 
 - [`common.schema.json`](common.schema.json) — shared type definitions (`RpidHex`, `DisplayIdHex`, `TekHex`, etc.).
 - [`events.schema.json`](events.schema.json) — `DetectionEvent`, `RssiUpdateEvent`, `StateEvent`, `ConstraintEvent`, `ErrorEvent`, `DebugEvent`.
+- [`permissions.schema.json`](permissions.schema.json) — normalized host-visible permission status returned by `getPermissionStatus()` / `requestPermissions()`.
 
 Byte-valued fields are lowercase hex strings at the method-channel / RN bridge boundary. TEK is never emitted over BLE and therefore never appears in a DetectionEvent — it is only exposed to host apps via `exportCurrentTek()` / `exportCurrentTek` on the respective SDK.
 

--- a/schema/barnard/v2/permissions.schema.json
+++ b/schema/barnard/v2/permissions.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thegreeting.github.io/barnard/schema/barnard/v2/permissions.schema.json",
+  "title": "Barnard Permission Status (v2)",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "platform": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Native platform that produced the permission status, e.g. ios, android, or mock."
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "enum": [
+          "granted",
+          "denied",
+          "notDetermined",
+          "restricted",
+          "unsupported",
+          "unknown"
+        ]
+      },
+      "description": "Map from platform permission name to Barnard's normalized decision string."
+    },
+    "requiredPermissions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Runtime permissions Barnard needs on this platform/API level."
+    },
+    "missingPermissions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Required runtime permissions that are not currently granted."
+    },
+    "canScan": {
+      "type": "boolean",
+      "description": "Whether Barnard has the permissions required to start Scan."
+    },
+    "canAdvertise": {
+      "type": "boolean",
+      "description": "Whether Barnard has the permissions required to start Advertise."
+    }
+  },
+  "required": [
+    "platform",
+    "permissions",
+    "requiredPermissions",
+    "missingPermissions",
+    "canScan",
+    "canAdvertise"
+  ]
+}

--- a/schema/barnard/v2/permissions.schema.json
+++ b/schema/barnard/v2/permissions.schema.json
@@ -35,6 +35,16 @@
       "items": { "type": "string", "minLength": 1 },
       "description": "Required runtime permissions that are not currently granted."
     },
+    "requestablePermissions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Missing permissions that the OS may still present through a runtime permission dialog."
+    },
+    "blockedPermissions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Missing permissions that the OS no longer allows to be requested with a runtime dialog. The host app should guide the user to system settings."
+    },
     "canScan": {
       "type": "boolean",
       "description": "Whether Barnard has the permissions required to start Scan."
@@ -49,6 +59,8 @@
     "permissions",
     "requiredPermissions",
     "missingPermissions",
+    "requestablePermissions",
+    "blockedPermissions",
     "canScan",
     "canAdvertise"
   ]

--- a/specs/001-barnard-core-sdk/spec.md
+++ b/specs/001-barnard-core-sdk/spec.md
@@ -104,6 +104,7 @@ As a maintainer, I want a core SDK structure that can be distributed as iOS (SPM
 ### Edge Cases
 
 - Repeated `startScan()` calls (idempotent vs error vs restart)
+- Package/plugin registration before the host app is ready to show OS permission dialogs
 - Permission revoked during Scan (state + events)
 - Bluetooth turns OFF mid-session
 - Foreground/background transitions (prototype is foreground-only; must be explicit)
@@ -135,12 +136,17 @@ As a maintainer, I want a core SDK structure that can be distributed as iOS (SPM
 - **FR-019**: RPID `rotationSeconds` MUST be adjustable by upper layers for debugging (with safe bounds)
 - **FR-020**: Prototype `ScanConfig` / `AdvertiseConfig` MUST be minimal and have safe defaults when omitted
 - **FR-021**: Barnard MUST support connection-based data exchange via GATT as an optional fallback (connect/reconnect + minimal Read/Notify/Write)
+- **FR-022**: Barnard MUST NOT instantiate OS BLE managers during package/plugin registration if that can show a permission dialog; the first permission-triggering action MUST be controlled by the host app (`requestPermissions`, `startScan`, `startAdvertise`, or `startAuto`)
+- **FR-023**: Barnard MUST expose normalized permission status/request APIs so host apps can schedule permission prompts without duplicating platform-version-specific BLE permission lists
 
 ### Platform Requirements
 
 - **FR-IOS-001**: iOS host apps MUST provide `NSBluetoothAlwaysUsageDescription` (documented requirement)
 - **FR-IOS-002**: If background Scan/Advertise is ever supported, host apps MUST provide `UIBackgroundModes` (`bluetooth-central` / `bluetooth-peripheral`) (documented requirement)
 - **FR-IOS-003**: iOS implementation SHOULD allow State Restoration (`CBCentralManagerOptionRestoreIdentifierKey` / `CBPeripheralManagerOptionRestoreIdentifierKey`) when needed
+- **FR-IOS-004**: iOS wrappers MUST defer `CBCentralManager` / `CBPeripheralManager` construction until an explicit host-app action to avoid Bluetooth permission prompts during app launch
+- **FR-ANDROID-001**: Android packages MUST ship manifest declarations for BLE Scan, Advertise, Connect, legacy Bluetooth, legacy location, and BLE feature support so host apps receive them through manifest merge
+- **FR-ANDROID-002**: Android 12+ `BLUETOOTH_SCAN` MUST use `neverForLocation` by default so BLE Scan does not require location permission on API 31+
 
 ### Prototype API Sketch (minimal config)
 
@@ -149,6 +155,7 @@ Prototype prioritizes “works with no config”. Config is primarily for debug 
 - `startScan(config?)` / `stopScan()`
 - `startAdvertise(config?)` / `stopAdvertise()`
 - `startAuto(config?)` / `stopAuto()` (first-class)
+- `getPermissionStatus()` / `requestPermissions()`
 - `events` (detection / state / constraint / error)
 - `debugEvents` (push) + `getDebugBuffer()` (pull)
 - `getRssiSamples({ since?, limit?, rpid? })` (pull; time series)

--- a/specs/003-flutter-poc-real-ble/spec.md
+++ b/specs/003-flutter-poc-real-ble/spec.md
@@ -70,6 +70,8 @@ Recommended channels:
 MethodChannel calls (conceptual):
 - `getCapabilities() -> BarnardCapabilities`
 - `getState() -> BarnardState`
+- `getPermissionStatus() -> BarnardPermissionStatus`
+- `requestPermissions() -> BarnardPermissionStatus`
 - `startScan(config?) -> void`
 - `stopScan() -> void`
 - `startAdvertise(config?) -> void`
@@ -179,6 +181,7 @@ Both platforms MUST use the same service UUID, characteristic UUID, and 17-byte 
 ### iOS
 
 - Host app MUST provide required Info.plist keys (documented in README for the PoC app).
+- The plugin MUST NOT create `CBCentralManager` or `CBPeripheralManager` during registration. Creating those managers can show the Bluetooth permission dialog, so manager construction is deferred until `requestPermissions()`, `startScan()`, `startAdvertise()`, or `startAuto()`.
 - Advertise constraints MUST be surfaced as ConstraintEvent/ErrorEvent with reason codes (no silent failure).
 
 #### iOS Advertise constraints (CoreBluetooth)
@@ -199,7 +202,10 @@ CoreBluetooth imposes strict limits on what iOS can Advertise and how reliably i
 
 ### Android
 
-- Required permissions MUST be documented and validated (ConstraintEvent/ErrorEvent on missing permissions).
+- Required permissions MUST be declared by the plugin Android manifest where manifest merge can carry them into the host app.
+- Runtime permissions MUST be exposed through `getPermissionStatus()` and `requestPermissions()` so host apps can trigger permission dialogs at a deliberate point in their own UX.
+- Missing permissions MUST still be validated at Scan/Advertise time and surfaced as ConstraintEvent/ErrorEvent.
+- On Android 12+ (`API 31+`), `BLUETOOTH_SCAN` MUST use `android:usesPermissionFlags="neverForLocation"` by default; location runtime permission is only required for legacy Android Scan paths (`API 23..30`).
 - Advertise limitations (device does not support, settings disabled, etc.) MUST be surfaced with reason codes.
 - Scan SHOULD apply a local filter fallback for iOS foreground advertising:
   - Prefer Discovery Service UUID match when available.


### PR DESCRIPTION
## Summary

Closes #54.

- Defer BLE permission dialogs until the host app explicitly calls Barnard permission or Scan / Advertise APIs.
- Add Flutter/Dart and React Native permission APIs for `getPermissionStatus()`, `requestPermissions()`, and `openAppSettings()`.
- Surface `requestablePermissions` and `blockedPermissions` so Android denial states can be handled without repeatedly calling dialogs the OS will not show.
- Add Android BLE manifest declarations in the library manifests, including Android 12+ Nearby devices permissions and legacy Android 11-and-below location permissions.
- Update Flutter and React Native demos so permission prompts are gated behind UI actions, blocked permissions route to app settings, and permission state refreshes when the app returns to the foreground.
- Document install/setup, `neverForLocation`, Android Nearby devices settings behavior, iOS Local Network debug-tooling prompts, and foreground-resume permission refresh after `openAppSettings()`.

## Compatibility / Privacy

- No on-wire payload shape changes.
- No device-unique persistent identifiers are added to BLE / GATT payloads.
- `BLUETOOTH_SCAN` uses `android:usesPermissionFlags="neverForLocation"` by default; host apps that use BLE Scan results themselves for physical location can override that merged permission declaration.

## Validation

- `dart analyze` in `packages/dart/barnard`
- `dart analyze` in `examples/flutter/barnard_poc`
- `flutter test` in `packages/dart/barnard`
- `flutter test` in `examples/flutter/barnard_poc`
- `flutter test test/smoke_test.dart` in `examples/flutter/barnard_poc`
- `./gradlew testDebugUnitTest` in `packages/dart/barnard/android`

## Manual Device Validation

- iPhone Air / iOS 26.4.2: fresh install did not show the Bluetooth dialog during plugin registration; explicit Allow showed the Bluetooth dialog; Start Auto reached Scan / Advertise UI state after permission grant.
- Pixel 8a / Android 16: fresh install did not show the Nearby devices dialog during plugin registration.
- Pixel 8a / Android 16: first Allow showed the Nearby devices runtime dialog; first Deny left permissions requestable (`USER_SET`).
- Pixel 8a / Android 16: second Allow re-showed the dialog; second Deny set BLE permissions to `USER_SET|USER_FIXED`; the demo UI changed to `Bluetooth: Open Settings` with a `Settings` action.
- Pixel 8a / Android 16: tapping `Settings` opened Android permission settings showing the `Nearby devices` permission group and the Bluetooth capabilities.
- Pixel 8a / Android 16: after the app was backgrounded and BLE permissions were granted externally, returning to the app refreshed the UI to `Bluetooth: Allowed` via lifecycle resume.
- Nexus 5X / Android 8.1.0 (API 27): fresh install did not show a runtime permission dialog during app launch; the merged app manifest requested legacy `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`; explicit Allow showed the Location permission dialog; granting it set `ACCESS_FINE_LOCATION: granted=true`; Start Auto reached `Scanning` / `Advertising` with `scan_start`, `advertise_start`, and `advertise_started` logs and no `permission_denied`.
- Nexus 5X / Android 8.1.0 (API 27): after Location was revoked outside the app, the demo showed `Bluetooth: Open Settings`; tapping `Settings` opened Android App info, `権限` showed no granted permissions, enabling `位置情報` in Settings granted `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION`, and returning to the app refreshed the UI to `Bluetooth: Allowed`.

## Not Run / Expected Gaps

- React Native Jest tests were not runnable locally because the package has no installed `node_modules` (`jest: command not found`).
- Standalone SwiftPM build for the Flutter iOS plugin still cannot resolve the `Flutter` module outside a Flutter build context.