### PR TITLE
fix(ble): report no BLE capability on iOS Simulator / Android Emulator (#57)

### DIFF
--- a/examples/flutter/barnard_poc/lib/main.dart
+++ b/examples/flutter/barnard_poc/lib/main.dart
@@ -62,6 +62,63 @@ bool shouldRefreshPermissionsForLifecycle(AppLifecycleState state) {
   return state == AppLifecycleState.resumed;
 }
 
+/// Whether Barnard reports the device as capable of BLE Scan + Advertise
+/// right now. Combines authorization state with hardware capability flags so
+/// the UI does not enable Start on iOS Simulator / Android Emulator / BLE-less
+/// devices, where authorization can be granted but Scan / Advertise are not
+/// actually available. See issue #57.
+bool canStartBleFromStatus(BarnardPermissionStatus? status) {
+  if (status == null) return false;
+  return status.allGranted && status.canScan && status.canAdvertise;
+}
+
+bool canStartScanFromStatus(BarnardPermissionStatus? status) {
+  if (status == null) return false;
+  return status.allGranted && status.canScan;
+}
+
+bool canStartAdvertiseFromStatus(BarnardPermissionStatus? status) {
+  if (status == null) return false;
+  return status.allGranted && status.canAdvertise;
+}
+
+/// High-level UI state for the BLE permission strip. Captures the three cases
+/// the host app must distinguish:
+/// * permission missing / blocked,
+/// * permission granted but device lacks BLE capability (simulator / emulator
+///   / BLE-less hardware),
+/// * permission granted and device is capable.
+enum BlePermissionStripState { checking, missing, blocked, unsupported, ready }
+
+BlePermissionStripState blePermissionStripStateFor(
+  BarnardPermissionStatus? status,
+) {
+  if (status == null) return BlePermissionStripState.checking;
+  if (status.hasBlockedPermissions) return BlePermissionStripState.blocked;
+  if (!status.allGranted) return BlePermissionStripState.missing;
+  if (!status.canScan || !status.canAdvertise) {
+    return BlePermissionStripState.unsupported;
+  }
+  return BlePermissionStripState.ready;
+}
+
+String blePermissionStripLabel(BarnardPermissionStatus? status) {
+  switch (blePermissionStripStateFor(status)) {
+    case BlePermissionStripState.checking:
+      return "Bluetooth: Checking";
+    case BlePermissionStripState.blocked:
+      return "Bluetooth: Open Settings";
+    case BlePermissionStripState.missing:
+      final String missing = status!.missingPermissions.join(", ");
+      if (missing.isEmpty) return "Bluetooth: Not allowed";
+      return "Bluetooth: ${missing.replaceAll("ios.bluetooth", "Not determined")}";
+    case BlePermissionStripState.unsupported:
+      return "Bluetooth: Not available on this device";
+    case BlePermissionStripState.ready:
+      return "Bluetooth: Allowed";
+  }
+}
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -261,24 +318,31 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   }
 
   Future<bool> _ensurePermissionsForStart(BarnardBleClient client) async {
-    final BarnardPermissionStatus status = await client.getPermissionStatus();
+    BarnardPermissionStatus status = await client.getPermissionStatus();
     if (mounted) setState(() => _permissionStatus = status);
-    if (status.allGranted) return true;
-    if (status.hasBlockedPermissions) {
-      _showMessage("Enable Nearby devices in app settings");
-      return false;
+
+    if (!status.allGranted) {
+      if (status.hasBlockedPermissions) {
+        _showMessage("Enable Nearby devices in app settings");
+        return false;
+      }
+      status = await client.requestPermissions();
+      if (mounted) setState(() => _permissionStatus = status);
+      if (status.hasBlockedPermissions) {
+        _showMessage("Enable Nearby devices in app settings");
+        return false;
+      }
+      if (!status.allGranted) {
+        _showMessage("Bluetooth permission is required");
+        return false;
+      }
     }
 
-    final BarnardPermissionStatus requested = await client.requestPermissions();
-    if (mounted) setState(() => _permissionStatus = requested);
-    if (requested.allGranted) return true;
-    if (requested.hasBlockedPermissions) {
-      _showMessage("Enable Nearby devices in app settings");
+    if (!canStartBleFromStatus(status)) {
+      _showMessage("BLE Scan / Advertise is not available on this device");
       return false;
     }
-
-    _showMessage("Bluetooth permission is required");
-    return false;
+    return true;
   }
 
   Future<void> _requestPermissionsNow() => _run((c) async {
@@ -297,6 +361,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     }
     if (!requested.allGranted) {
       _showMessage("Bluetooth permission is required");
+      return;
+    }
+    if (!canStartBleFromStatus(requested)) {
+      _showMessage("BLE Scan / Advertise is not available on this device");
     }
   });
 
@@ -584,6 +652,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                           ),
                           _DiagnosticsTab(
                             state: _state,
+                            permissionStatus: _permissionStatus,
                             selfInfo: _selfInfo,
                             seen: _seenById.values.toList()
                               ..sort(
@@ -947,6 +1016,8 @@ class _ControlPanel extends StatelessWidget {
           _PrimaryActionButton(
             state: state,
             busy: busy,
+            canStartScan: canStartScanFromStatus(permissionStatus),
+            canStartAdvertise: canStartAdvertiseFromStatus(permissionStatus),
             onToggleAuto: onToggleAuto,
             onToggleScan: onToggleScan,
             onToggleAdvertise: onToggleAdvertise,
@@ -971,58 +1042,74 @@ class _PermissionStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme cs = Theme.of(context).colorScheme;
-    final bool granted = status?.allGranted == true;
-    final bool blocked = status?.hasBlockedPermissions == true;
-    final String label = _permissionLabel(status);
+    final BlePermissionStripState stripState = blePermissionStripStateFor(
+      status,
+    );
+    final String label = blePermissionStripLabel(status);
+
+    final Color bg;
+    final Color fg;
+    final IconData icon;
+    switch (stripState) {
+      case BlePermissionStripState.ready:
+        bg = cs.secondaryContainer;
+        fg = cs.onSecondaryContainer;
+        icon = Icons.bluetooth_connected;
+      case BlePermissionStripState.unsupported:
+        bg = cs.surfaceContainerHighest;
+        fg = cs.onSurfaceVariant;
+        icon = Icons.info_outline;
+      case BlePermissionStripState.checking:
+      case BlePermissionStripState.missing:
+      case BlePermissionStripState.blocked:
+        bg = cs.errorContainer;
+        fg = cs.onErrorContainer;
+        icon = Icons.bluetooth_disabled;
+    }
+
     return Container(
       key: barnardPermissionStripKey,
       height: 40,
       padding: const EdgeInsets.symmetric(horizontal: 10),
       decoration: BoxDecoration(
-        color: granted ? cs.secondaryContainer : cs.errorContainer,
+        color: bg,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
         children: <Widget>[
-          Icon(
-            granted ? Icons.bluetooth_connected : Icons.bluetooth_disabled,
-            size: 18,
-            color: granted ? cs.onSecondaryContainer : cs.onErrorContainer,
-          ),
+          Icon(icon, size: 18, color: fg),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               label,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
-                color: granted ? cs.onSecondaryContainer : cs.onErrorContainer,
+                color: fg,
                 fontWeight: FontWeight.w600,
                 fontSize: 13,
               ),
             ),
           ),
-          if (!granted)
+          if (stripState == BlePermissionStripState.missing ||
+              stripState == BlePermissionStripState.blocked)
             TextButton.icon(
               key: barnardAllowBluetoothButtonKey,
               onPressed: busy ? null : onRequestPermissions,
               icon: Icon(
-                blocked ? Icons.settings : Icons.verified_user,
+                stripState == BlePermissionStripState.blocked
+                    ? Icons.settings
+                    : Icons.verified_user,
                 size: 16,
               ),
-              label: Text(blocked ? "Settings" : "Allow"),
+              label: Text(
+                stripState == BlePermissionStripState.blocked
+                    ? "Settings"
+                    : "Allow",
+              ),
             ),
         ],
       ),
     );
-  }
-
-  String _permissionLabel(BarnardPermissionStatus? status) {
-    if (status == null) return "Bluetooth: Checking";
-    if (status.allGranted) return "Bluetooth: Allowed";
-    if (status.hasBlockedPermissions) return "Bluetooth: Open Settings";
-    final String missing = status.missingPermissions.join(", ");
-    if (missing.isEmpty) return "Bluetooth: Not allowed";
-    return "Bluetooth: ${missing.replaceAll("ios.bluetooth", "Not determined")}";
   }
 }
 
@@ -1033,6 +1120,8 @@ class _PrimaryActionButton extends StatelessWidget {
   const _PrimaryActionButton({
     required this.state,
     required this.busy,
+    required this.canStartScan,
+    required this.canStartAdvertise,
     required this.onToggleAuto,
     required this.onToggleScan,
     required this.onToggleAdvertise,
@@ -1040,6 +1129,8 @@ class _PrimaryActionButton extends StatelessWidget {
 
   final BarnardState state;
   final bool busy;
+  final bool canStartScan;
+  final bool canStartAdvertise;
   final VoidCallback onToggleAuto;
   final VoidCallback onToggleScan;
   final VoidCallback onToggleAdvertise;
@@ -1048,9 +1139,20 @@ class _PrimaryActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme cs = Theme.of(context).colorScheme;
     final bool autoRunning = state.isScanning || state.isAdvertising;
-    final Color bg = autoRunning ? cs.error : cs.primary;
-    final Color fg = autoRunning ? cs.onError : cs.onPrimary;
-    final VoidCallback? primaryOnTap = busy ? null : onToggleAuto;
+    // Both Scan and Advertise must be available to start Auto. Already-running
+    // sessions remain stoppable so the user can recover from a permission /
+    // capability change that landed after Start.
+    final bool autoEnabled =
+        autoRunning || (canStartScan && canStartAdvertise);
+    final Color bg = autoRunning
+        ? cs.error
+        : (autoEnabled ? cs.primary : cs.surfaceContainerHighest);
+    final Color fg = autoRunning
+        ? cs.onError
+        : (autoEnabled ? cs.onPrimary : cs.onSurfaceVariant);
+    final VoidCallback? primaryOnTap = (busy || !autoEnabled)
+        ? null
+        : onToggleAuto;
     return SizedBox(
       height: 44,
       child: Row(
@@ -1134,6 +1236,7 @@ class _PrimaryActionButton extends StatelessWidget {
               itemBuilder: (context) => <PopupMenuEntry<_ControlMenuAction>>[
                 PopupMenuItem<_ControlMenuAction>(
                   value: _ControlMenuAction.toggleScan,
+                  enabled: state.isScanning || canStartScan,
                   child: _MenuRow(
                     icon: state.isScanning ? Icons.stop : Icons.radar,
                     text: state.isScanning ? "Stop Scan" : "Start Scan only",
@@ -1141,6 +1244,7 @@ class _PrimaryActionButton extends StatelessWidget {
                 ),
                 PopupMenuItem<_ControlMenuAction>(
                   value: _ControlMenuAction.toggleAdvertise,
+                  enabled: state.isAdvertising || canStartAdvertise,
                   child: _MenuRow(
                     icon: state.isAdvertising ? Icons.stop : Icons.cell_tower,
                     text: state.isAdvertising
@@ -1550,6 +1654,7 @@ class _DebugTab extends StatelessWidget {
 class _DiagnosticsTab extends StatelessWidget {
   const _DiagnosticsTab({
     required this.state,
+    required this.permissionStatus,
     required this.selfInfo,
     required this.seen,
     required this.staleAfter,
@@ -1563,6 +1668,7 @@ class _DiagnosticsTab extends StatelessWidget {
   });
 
   final BarnardState state;
+  final BarnardPermissionStatus? permissionStatus;
   final _SelfAdvertiseInfo selfInfo;
   final List<_SeenEntry> seen;
   final Duration staleAfter;
@@ -1585,6 +1691,52 @@ class _DiagnosticsTab extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(12),
       children: <Widget>[
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                _sectionHeader(context, "BLE permissions"),
+                const SizedBox(height: 8),
+                _kv("Platform", permissionStatus?.platform ?? "—"),
+                _kv(
+                  "All granted",
+                  permissionStatus == null
+                      ? "—"
+                      : (permissionStatus!.allGranted ? "yes" : "no"),
+                ),
+                _kv(
+                  "canScan",
+                  permissionStatus == null
+                      ? "—"
+                      : (permissionStatus!.canScan ? "yes" : "no"),
+                ),
+                _kv(
+                  "canAdvertise",
+                  permissionStatus == null
+                      ? "—"
+                      : (permissionStatus!.canAdvertise ? "yes" : "no"),
+                ),
+                if (permissionStatus != null &&
+                    permissionStatus!.missingPermissions.isNotEmpty)
+                  _kv(
+                    "Missing",
+                    permissionStatus!.missingPermissions.join(", "),
+                    softWrap: true,
+                  ),
+                if (permissionStatus != null &&
+                    permissionStatus!.blockedPermissions.isNotEmpty)
+                  _kv(
+                    "Blocked",
+                    permissionStatus!.blockedPermissions.join(", "),
+                    softWrap: true,
+                  ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
         Card(
           child: Padding(
             padding: const EdgeInsets.all(12),

--- a/examples/flutter/barnard_poc/test/smoke_test.dart
+++ b/examples/flutter/barnard_poc/test/smoke_test.dart
@@ -1,6 +1,22 @@
+import "package:barnard/barnard.dart";
 import "package:flutter/widgets.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:barnard_poc/main.dart";
+
+BarnardPermissionStatus _statusFromMap(Map<Object?, Object?> overrides) {
+  final Map<Object?, Object?> base = <Object?, Object?>{
+    "platform": "ios",
+    "permissions": <Object?, Object?>{"ios.bluetooth": "granted"},
+    "requiredPermissions": <Object?>["ios.bluetooth"],
+    "missingPermissions": <Object?>[],
+    "requestablePermissions": <Object?>[],
+    "blockedPermissions": <Object?>[],
+    "canScan": true,
+    "canAdvertise": true,
+    ...overrides,
+  };
+  return BarnardPermissionStatus.fromMap(base);
+}
 
 void main() {
   test("smoke", () {
@@ -119,5 +135,107 @@ void main() {
         );
       },
     );
+  });
+
+  group("canStartBleFromStatus", () {
+    test("null status (initial check still pending) blocks Start", () {
+      expect(canStartBleFromStatus(null), isFalse);
+    });
+
+    test("returns true when permissions granted and BLE is available", () {
+      expect(canStartBleFromStatus(_statusFromMap(<Object?, Object?>{})), isTrue);
+    });
+
+    test(
+      "returns false on iOS Simulator where authorization is granted but "
+      "BLE capability is not (issue #57)",
+      () {
+        final BarnardPermissionStatus simulatorStatus = _statusFromMap(
+          <Object?, Object?>{"canScan": false, "canAdvertise": false},
+        );
+        expect(simulatorStatus.allGranted, isTrue);
+        expect(canStartBleFromStatus(simulatorStatus), isFalse);
+        expect(canStartScanFromStatus(simulatorStatus), isFalse);
+        expect(canStartAdvertiseFromStatus(simulatorStatus), isFalse);
+      },
+    );
+
+    test("scan-capable advertise-incapable device blocks Auto only", () {
+      // Some Android devices support BLE scan but not advertise (no multi-
+      // advertisement support / null bluetoothLeAdvertiser). The user can
+      // still scan, so individual Scan-only should remain enabled.
+      final BarnardPermissionStatus partial = _statusFromMap(
+        <Object?, Object?>{"canAdvertise": false},
+      );
+      expect(canStartBleFromStatus(partial), isFalse);
+      expect(canStartScanFromStatus(partial), isTrue);
+      expect(canStartAdvertiseFromStatus(partial), isFalse);
+    });
+
+    test("permission missing blocks Start regardless of capability", () {
+      final BarnardPermissionStatus missing = _statusFromMap(<Object?, Object?>{
+        "permissions": <Object?, Object?>{"ios.bluetooth": "notDetermined"},
+        "missingPermissions": <Object?>["ios.bluetooth"],
+        "requestablePermissions": <Object?>["ios.bluetooth"],
+      });
+      expect(canStartBleFromStatus(missing), isFalse);
+      expect(canStartScanFromStatus(missing), isFalse);
+      expect(canStartAdvertiseFromStatus(missing), isFalse);
+    });
+  });
+
+  group("blePermissionStripStateFor", () {
+    test("null → checking", () {
+      expect(blePermissionStripStateFor(null), BlePermissionStripState.checking);
+    });
+
+    test("blocked permission → blocked", () {
+      final BarnardPermissionStatus blocked = _statusFromMap(<Object?, Object?>{
+        "permissions": <Object?, Object?>{"ios.bluetooth": "denied"},
+        "missingPermissions": <Object?>["ios.bluetooth"],
+        "blockedPermissions": <Object?>["ios.bluetooth"],
+        "canScan": false,
+        "canAdvertise": false,
+      });
+      expect(
+        blePermissionStripStateFor(blocked),
+        BlePermissionStripState.blocked,
+      );
+    });
+
+    test("missing permission → missing", () {
+      final BarnardPermissionStatus missing = _statusFromMap(<Object?, Object?>{
+        "permissions": <Object?, Object?>{"ios.bluetooth": "notDetermined"},
+        "missingPermissions": <Object?>["ios.bluetooth"],
+        "requestablePermissions": <Object?>["ios.bluetooth"],
+        "canScan": false,
+        "canAdvertise": false,
+      });
+      expect(
+        blePermissionStripStateFor(missing),
+        BlePermissionStripState.missing,
+      );
+    });
+
+    test("granted but no BLE capability → unsupported (issue #57)", () {
+      final BarnardPermissionStatus simulator = _statusFromMap(
+        <Object?, Object?>{"canScan": false, "canAdvertise": false},
+      );
+      expect(
+        blePermissionStripStateFor(simulator),
+        BlePermissionStripState.unsupported,
+      );
+      expect(
+        blePermissionStripLabel(simulator),
+        "Bluetooth: Not available on this device",
+      );
+    });
+
+    test("granted and capable → ready", () {
+      expect(
+        blePermissionStripStateFor(_statusFromMap(<Object?, Object?>{})),
+        BlePermissionStripState.ready,
+      );
+    });
   });
 }

--- a/packages/dart/barnard/CHANGELOG.md
+++ b/packages/dart/barnard/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- iOS Simulator now reports `canScan: false` and `canAdvertise: false` from
+  `getPermissionStatus()` / `requestPermissions()` even when CoreBluetooth
+  authorization is granted, reflecting the fact that CoreBluetooth Scan /
+  Advertise are not available on iOS Simulator. Host apps can drop any
+  simulator-detection workarounds and branch on these capability flags
+  directly. See issue #57.
+
 ## 0.1.0 — Barnard v2 BLE protocol (#42)
 
 ### Breaking changes (v1 → v2)

--- a/packages/dart/barnard/CHANGELOG.md
+++ b/packages/dart/barnard/CHANGELOG.md
@@ -10,6 +10,12 @@
   Advertise are not available on iOS Simulator. Host apps can drop any
   simulator-detection workarounds and branch on these capability flags
   directly. See issue #57.
+- Android `getPermissionStatus()` now also checks hardware capability
+  (`PackageManager.FEATURE_BLUETOOTH_LE`, `BluetoothLeAdvertiser`
+  availability, `isMultipleAdvertisementSupported`) in addition to runtime
+  permissions. Android Emulators and BLE-less devices therefore report
+  `canScan: false` / `canAdvertise: false` even when permissions are
+  granted, matching the iOS Simulator behavior above. See issue #57.
 
 ## 0.1.0 — Barnard v2 BLE protocol (#42)
 

--- a/packages/dart/barnard/README.md
+++ b/packages/dart/barnard/README.md
@@ -227,7 +227,7 @@ flutter precache --android
 
 - `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`. If `blockedPermissions` is non-empty, open app settings instead of requesting again.
 - `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
-- No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator.
+- No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator. On iOS Simulator `getPermissionStatus()` / `requestPermissions()` return `canScan: false` and `canAdvertise: false` even when authorization is granted, so host apps should branch on those capability flags rather than on `allGranted` alone.
 - Android app does not show permission dialogs: confirm the app is using the Barnard plugin package and did not remove merged permissions with manifest tools rules.
 - Cross-platform discovery is foreground-only. iOS background advertising may move Service UUIDs to the overflow area, making devices hard to discover.
 

--- a/packages/dart/barnard/README.md
+++ b/packages/dart/barnard/README.md
@@ -228,6 +228,7 @@ flutter precache --android
 - `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`. If `blockedPermissions` is non-empty, open app settings instead of requesting again.
 - `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
 - No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator. On iOS Simulator `getPermissionStatus()` / `requestPermissions()` return `canScan: false` and `canAdvertise: false` even when authorization is granted, so host apps should branch on those capability flags rather than on `allGranted` alone.
+- No Android detections in emulator or on BLE-less devices: Android Emulator does not virtualize BLE and some devices lack BLE / multi-advertisement hardware. `getPermissionStatus()` returns `canScan: false` / `canAdvertise: false` on these devices regardless of permission grants. As on iOS, branch on the capability flags rather than on `allGranted`.
 - Android app does not show permission dialogs: confirm the app is using the Barnard plugin package and did not remove merged permissions with manifest tools rules.
 - Cross-platform discovery is foreground-only. iOS background advertising may move Service UUIDs to the overflow area, making devices hard to discover.
 

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -808,6 +808,17 @@ internal class BarnardController(
         val permissions = required.associateWith { permission ->
             if (hasPermission(permission)) "granted" else "denied"
         }
+        // BLE capability requires both runtime permission AND hardware support.
+        // Android Emulator and BLE-less devices report permission grants but
+        // cannot actually scan or advertise — host apps would otherwise enable
+        // BLE-only UI based on permission state alone. See issue #57.
+        val hasBleHardware = appContext.packageManager
+            .hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
+        val a = adapter
+        val hasAdvertiseHardware = hasBleHardware &&
+            a != null &&
+            a.bluetoothLeAdvertiser != null &&
+            a.isMultipleAdvertisementSupported
         return mapOf(
             "platform" to "android",
             "permissions" to permissions,
@@ -815,8 +826,10 @@ internal class BarnardController(
             "missingPermissions" to missing,
             "requestablePermissions" to requestable,
             "blockedPermissions" to blocked,
-            "canScan" to hasScanPermission(),
-            "canAdvertise" to (hasAdvertisePermission() && hasConnectPermission()),
+            "canScan" to (hasScanPermission() && hasBleHardware),
+            "canAdvertise" to (
+                hasAdvertisePermission() && hasConnectPermission() && hasAdvertiseHardware
+            ),
         )
     }
 

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPluginTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardPluginTest.kt
@@ -1,6 +1,7 @@
 package network.greeting.barnard
 
 import android.content.Context
+import android.content.pm.PackageManager
 import androidx.test.core.app.ApplicationProvider
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
@@ -10,7 +11,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -58,6 +61,28 @@ internal class BarnardPluginTest {
         assertTrue(value["blockedPermissions"] is List<*>)
         assertTrue(value["canScan"] is Boolean)
         assertTrue(value["canAdvertise"] is Boolean)
+    }
+
+    @Test
+    @Config(sdk = [31])
+    fun onMethodCall_getPermissionStatus_reportsNoBleCapabilityWithoutHardware() {
+        // Android Emulator and BLE-less devices do not advertise the
+        // FEATURE_BLUETOOTH_LE system feature. Capability flags must reflect
+        // that gap independently of permission grants so host apps can hide
+        // BLE-only UI on these devices. See issue #57.
+        Shadows.shadowOf(context.packageManager)
+            .setSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE, false)
+
+        val messenger = RecordingBinaryMessenger()
+        val result = RecordingResult()
+
+        val controller = BarnardController(context, messenger)
+        val call = MethodCall("getPermissionStatus", null)
+        controller.onMethodCall(call, result)
+
+        val value = result.value as Map<*, *>
+        assertEquals(false, value["canScan"])
+        assertEquals(false, value["canAdvertise"])
     }
 
     private class RecordingBinaryMessenger : BinaryMessenger {

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -215,6 +215,10 @@ final class BarnardBleController: NSObject {
     let missing = status == "granted" ? [] : [permissionName]
     let blocked = (status == "denied" || status == "restricted") ? [permissionName] : []
     let requestable = missing.filter { !blocked.contains($0) }
+    // iOS Simulator cannot scan or advertise over BLE even when CoreBluetooth
+    // authorization is granted, so capability flags must reflect that gap
+    // independently of authorization state. See issue #57.
+    let canBle = status == "granted" && !Self.isIosSimulator
     return [
       "platform": "ios",
       "permissions": [permissionName: status],
@@ -222,9 +226,17 @@ final class BarnardBleController: NSObject {
       "missingPermissions": missing,
       "requestablePermissions": requestable,
       "blockedPermissions": blocked,
-      "canScan": status == "granted",
-      "canAdvertise": status == "granted",
+      "canScan": canBle,
+      "canAdvertise": canBle,
     ]
+  }
+
+  private static var isIosSimulator: Bool {
+    #if targetEnvironment(simulator)
+    return true
+    #else
+    return false
+    #endif
   }
 
   private func requestPermissions(completion: @escaping ([String: Any]) -> Void) {

--- a/packages/dart/barnard/test/ble_client_parser_test.dart
+++ b/packages/dart/barnard/test/ble_client_parser_test.dart
@@ -53,6 +53,37 @@ void main() {
       expect(status.canAdvertise, isFalse);
       expect(status.allGranted, isFalse);
     });
+
+    test(
+      "iOS Simulator reports granted authorization but no BLE capability",
+      () {
+        // iOS Simulator cannot scan/advertise over CoreBluetooth even when
+        // authorization is granted. The iOS plugin therefore overrides
+        // canScan/canAdvertise to false on simulator. Consumers should rely
+        // on these capability flags, not on allGranted alone, when deciding
+        // whether BLE is usable. See issue #57.
+        final BarnardPermissionStatus
+        status = BarnardPermissionStatus.fromMap(<Object?, Object?>{
+          "platform": "ios",
+          "permissions": <Object?, Object?>{"ios.bluetooth": "granted"},
+          "requiredPermissions": <Object?>["ios.bluetooth"],
+          "missingPermissions": <Object?>[],
+          "requestablePermissions": <Object?>[],
+          "blockedPermissions": <Object?>[],
+          "canScan": false,
+          "canAdvertise": false,
+        });
+
+        expect(status.platform, equals("ios"));
+        expect(
+          status.permissions["ios.bluetooth"],
+          equals(BarnardPermissionDecision.granted),
+        );
+        expect(status.allGranted, isTrue);
+        expect(status.canScan, isFalse);
+        expect(status.canAdvertise, isFalse);
+      },
+    );
   });
 
   group("RSSI helpers", () {

--- a/packages/react-native/barnard/CHANGELOG.md
+++ b/packages/react-native/barnard/CHANGELOG.md
@@ -10,6 +10,12 @@
   Advertise are not available on iOS Simulator. Host apps can drop any
   simulator-detection workarounds and branch on these capability flags
   directly. See issue #57.
+- Android `getPermissionStatus()` now also checks hardware capability
+  (`PackageManager.FEATURE_BLUETOOTH_LE`, `BluetoothLeAdvertiser`
+  availability, `isMultipleAdvertisementSupported`) in addition to runtime
+  permissions. Android Emulators and BLE-less devices therefore report
+  `canScan: false` / `canAdvertise: false` even when permissions are
+  granted, matching the iOS Simulator behavior above. See issue #57.
 
 ## 0.2.0 — Barnard v2 BLE protocol (#42)
 

--- a/packages/react-native/barnard/CHANGELOG.md
+++ b/packages/react-native/barnard/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- iOS Simulator now reports `canScan: false` and `canAdvertise: false` from
+  `getPermissionStatus()` / `requestPermissions()` even when CoreBluetooth
+  authorization is granted, reflecting the fact that CoreBluetooth Scan /
+  Advertise are not available on iOS Simulator. Host apps can drop any
+  simulator-detection workarounds and branch on these capability flags
+  directly. See issue #57.
+
 ## 0.2.0 — Barnard v2 BLE protocol (#42)
 
 ### Breaking changes (v1 → v2)

--- a/packages/react-native/barnard/README.md
+++ b/packages/react-native/barnard/README.md
@@ -308,6 +308,7 @@ interface RssiUpdateEvent {
 - `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`. If `blockedPermissions` is non-empty, open app settings instead of requesting again.
 - `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
 - No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator. On iOS Simulator `getPermissionStatus()` / `requestPermissions()` return `canScan: false` and `canAdvertise: false` even when authorization is granted, so host apps should branch on those capability flags rather than on `allGranted` alone.
+- No Android detections in emulator or on BLE-less devices: Android Emulator does not virtualize BLE and some devices lack BLE / multi-advertisement hardware. `getPermissionStatus()` returns `canScan: false` / `canAdvertise: false` on these devices regardless of permission grants. As on iOS, branch on the capability flags rather than on `allGranted`.
 - Android app does not show permission dialogs: confirm the package manifest is being merged and the app did not remove Barnard permissions with manifest tools rules.
 - Cross-platform discovery is foreground-only. iOS background advertising may move Service UUIDs to the overflow area, making devices hard to discover.
 

--- a/packages/react-native/barnard/README.md
+++ b/packages/react-native/barnard/README.md
@@ -307,7 +307,7 @@ interface RssiUpdateEvent {
 
 - `permission_denied` constraint: call `requestPermissions()` from an app-controlled UX point and retry after the returned status has no `missingPermissions`. If `blockedPermissions` is non-empty, open app settings instead of requesting again.
 - `bluetooth_off` or `bluetooth_not_ready`: ask the user to enable Bluetooth and retry.
-- No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator.
+- No iOS detections in simulator: use physical devices. CoreBluetooth Scan / Advertise is not available in the simulator. On iOS Simulator `getPermissionStatus()` / `requestPermissions()` return `canScan: false` and `canAdvertise: false` even when authorization is granted, so host apps should branch on those capability flags rather than on `allGranted` alone.
 - Android app does not show permission dialogs: confirm the package manifest is being merged and the app did not remove Barnard permissions with manifest tools rules.
 - Cross-platform discovery is foreground-only. iOS background advertising may move Service UUIDs to the overflow area, making devices hard to discover.
 

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -781,6 +781,17 @@ internal class BarnardController(
         val permissions = required.associateWith { permission ->
             if (hasPermission(permission)) "granted" else "denied"
         }
+        // BLE capability requires both runtime permission AND hardware support.
+        // Android Emulator and BLE-less devices report permission grants but
+        // cannot actually scan or advertise — host apps would otherwise enable
+        // BLE-only UI based on permission state alone. See issue #57.
+        val hasBleHardware = appContext.packageManager
+            .hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)
+        val a = adapter
+        val hasAdvertiseHardware = hasBleHardware &&
+            a != null &&
+            a.bluetoothLeAdvertiser != null &&
+            a.isMultipleAdvertisementSupported
         return mapOf(
             "platform" to "android",
             "permissions" to permissions,
@@ -788,8 +799,10 @@ internal class BarnardController(
             "missingPermissions" to missing,
             "requestablePermissions" to requestable,
             "blockedPermissions" to blocked,
-            "canScan" to hasScanPermission(),
-            "canAdvertise" to (hasAdvertisePermission() && hasConnectPermission()),
+            "canScan" to (hasScanPermission() && hasBleHardware),
+            "canAdvertise" to (
+                hasAdvertisePermission() && hasConnectPermission() && hasAdvertiseHardware
+            ),
         )
     }
 

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -176,6 +176,10 @@ final class BarnardBleController: NSObject {
     let missing = status == "granted" ? [] : [permissionName]
     let blocked = (status == "denied" || status == "restricted") ? [permissionName] : []
     let requestable = missing.filter { !blocked.contains($0) }
+    // iOS Simulator cannot scan or advertise over BLE even when CoreBluetooth
+    // authorization is granted, so capability flags must reflect that gap
+    // independently of authorization state. See issue #57.
+    let canBle = status == "granted" && !Self.isIosSimulator
     return [
       "platform": "ios",
       "permissions": [permissionName: status],
@@ -183,9 +187,17 @@ final class BarnardBleController: NSObject {
       "missingPermissions": missing,
       "requestablePermissions": requestable,
       "blockedPermissions": blocked,
-      "canScan": status == "granted",
-      "canAdvertise": status == "granted",
+      "canScan": canBle,
+      "canAdvertise": canBle,
     ]
+  }
+
+  private static var isIosSimulator: Bool {
+    #if targetEnvironment(simulator)
+    return true
+    #else
+    return false
+    #endif
   }
 
   func requestPermissions(completion: @escaping ([String: Any]) -> Void) {


### PR DESCRIPTION
## Summary

CoreBluetooth Scan / Advertise are not available on iOS Simulator even when authorization is granted, but the iOS plugin previously derived `canScan` / `canAdvertise` purely from authorization state. Host apps therefore had to detect simulator themselves and override capability flags (e.g. Meissa PR #44 added an `isIosSimulator` MethodChannel).

The same shape of bug exists on Android: Android Emulator and BLE-less devices report permissions as granted but cannot actually scan or advertise, and the old `getPermissionStatus()` would still return `canScan: true` / `canAdvertise: true`. This PR fixes both platforms so consumers can branch on the capability flags directly without per-platform workarounds.

## Changes

### iOS (Dart + RN packages)
- In the permission-status payload builder, compute `canBle = (status == "granted") && !isIosSimulator`, where `isIosSimulator` is derived at compile time via `#if targetEnvironment(simulator)`.
- README + CHANGELOG entries documenting the new contract.

### Android (Dart + RN packages)
- In `getPermissionStatus()`, also check hardware capability:
  - `PackageManager.FEATURE_BLUETOOTH_LE` for scan support.
  - `BluetoothLeAdvertiser != null` + `isMultipleAdvertisementSupported` for advertise support.
- `canScan` / `canAdvertise` now require both the runtime permission AND hardware support. The `startAdvertise()` path already enforced these hardware checks at call time, so this just surfaces them in `getPermissionStatus()`.
- Robolectric test (Dart pkg) covers the no-hardware case using `Shadows.shadowOf(packageManager).setSystemFeature(FEATURE_BLUETOOTH_LE, false)`.
- README + CHANGELOG entries documenting the new contract.

### Flutter example (`examples/flutter/barnard_poc`)
- The example was previously rendering `Bluetooth: Allowed` with an enabled `Start Auto` button on iOS Simulator (now that `canScan`/`canAdvertise` correctly return `false`, the UI must visibly reflect the gap). Rebuilt the permission strip + action buttons to demonstrate the correct host-app pattern:
  - New `BlePermissionStripState` enum (`checking` / `missing` / `blocked` / `unsupported` / `ready`); `unsupported` is the new state introduced by issue #57.
  - Permission strip renders `Bluetooth: Not available on this device` as an info-style chip when granted-but-uncapable, without the `Allow` button.
  - `Start Auto` and the individual `Scan only` / `Advertise only` menu items are disabled when the corresponding capability flag is `false`. Stop remains enabled if a session is already running.
  - `_ensurePermissionsForStart` and `_requestPermissionsNow` add an explicit `BLE Scan / Advertise is not available on this device` snackbar path.
  - Diagnostics tab exposes the raw `canScan` / `canAdvertise` / missing / blocked values for runtime verification.
- New pure helpers (`canStartBleFromStatus`, `canStartScanFromStatus`, `canStartAdvertiseFromStatus`, `blePermissionStripStateFor`, `blePermissionStripLabel`) covered by `smoke_test.dart`.

### Dart parser tests
- Added an iOS-Simulator-style payload case (`granted` + `canScan: false` + `canAdvertise: false`) — `allGranted` stays true while `canScan` / `canAdvertise` correctly read as false, which is the contract host apps should branch on.

## Acceptance Criteria (issue #57)

- [x] On iOS Simulator, `getPermissionStatus()` returns `canScan: false` and `canAdvertise: false`.
- [x] On iOS Simulator, `requestPermissions()` returns `canScan: false` and `canAdvertise: false` after the request flow completes.
- [x] On physical iOS devices, capability flags continue to reflect the real CoreBluetooth permission/capability state.
- [x] Tests cover simulator capability normalization (Dart parser test + Android Robolectric test + Flutter example smoke tests).
- [x] (Beyond issue scope) Android Emulator / BLE-less devices likewise report `canScan: false` / `canAdvertise: false`.

## Test plan

- [x] `flutter analyze` clean across the package and the example.
- [x] `flutter test` (Dart pkg) — 75/75 pass, including the new Dart simulator-payload case.
- [x] `flutter test` (Flutter example) — 26/26 pass, including new strip-state + can-start helper cases.
- [x] `./gradlew testDebugUnitTest` (Dart pkg Android) — 3/3 pass, including new emulator-style case.
- [x] **Manual on iOS 26.4 Simulator (iPhone 17)**: `BarnardBleClient.getPermissionStatus()` returns `platform=ios allGranted=true canScan=false canAdvertise=false`. Permission strip renders `Bluetooth: Not available on this device` (info chip). `Start Auto` is disabled. Diagnostics tab exposes the raw flags.
- [x] **Manual on physical iOS 26.5 device**: `BarnardBleClient.getPermissionStatus()` returns `platform=ios allGranted=true canScan=true canAdvertise=true`. Permission strip renders `Bluetooth: Allowed`; `Start Auto` enabled. Confirms the `#if targetEnvironment(simulator)` branch is correctly inert on device builds.
- [ ] Manual: Android Emulator → `canScan: false` / `canAdvertise: false` regardless of permission grants; example UI surfaces unsupported state.
- [ ] Manual: physical Android device with BLE → `canScan` / `canAdvertise` reflect real permission state.
- [ ] After merge, remove the Meissa app-side `isIosSimulator` workaround introduced in Meissa PR #44.

## Notes

- iOS Swift unit-test infrastructure does not currently exist in this repo (the Swift Package import-chains Flutter, and the RN package has no Swift Package), so the simulator branch is verified by the compile-time macro plus the Dart-side parser contract test plus the Flutter example end-to-end runs on iOS Simulator and on a physical iOS 26.5 device rather than by a native XCTest. Setting up Swift testing is out of scope for this fix.
- An RN-package Android Robolectric test was not added because `getPermissionStatus()` returns a `WritableMap` via `Arguments.createMap()`, which needs more React Native test scaffolding than currently exists. The Kotlin logic is a direct mirror of the Dart pkg implementation that IS covered by Robolectric.
- The iOS `canBle` computation collapses both flags onto a single value because iOS exposes Bluetooth as a single authorization gate — there is no separate scan/advertise grant. Android keeps the flags independent because the underlying permissions (`BLUETOOTH_SCAN` vs `BLUETOOTH_ADVERTISE` + `BLUETOOTH_CONNECT`) and hardware checks (`bluetoothLeAdvertiser` / `isMultipleAdvertisementSupported`) are independent.

Closes #57
Refs thegreeting/meissa#44