### PR TITLE
fix(react-native): align ENIN default with v2 spec

### DIFF
--- a/packages/react-native/barnard/CHANGELOG.md
+++ b/packages/react-native/barnard/CHANGELOG.md
@@ -75,7 +75,7 @@ manager.onDetection((e) => {
   // failed. The detection is still emitted on failure.
   const peer = e.detectedDisplayId ?? '(no B003)';
   // e.rpid is 34-char hex (17 B wire form).
-  // e.enin is a number (floor(unix_seconds / 600)).
+  // e.enin is a number (floor(unix_seconds / 120)).
   // e.reporterRpid is 34-char hex for this device's own RPID at the
   // observation timestamp.
   // e.resolvedTek is GONE — TEK never travels on the wire in v2.

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -92,6 +92,7 @@ const setup = () => {
       exportCurrentTek: () => Promise<string>;
       getPermissionStatus: () => Promise<unknown>;
       requestPermissions: () => Promise<unknown>;
+      openAppSettings: () => Promise<void>;
       joinEvent: (eventCode: string) => Promise<void>;
       onDetection: (callback: (event: unknown) => void) => () => void;
       onRssiUpdate: (callback: (event: unknown) => void) => () => void;

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
@@ -71,8 +71,9 @@ object BarnardCrypto {
         }
     }
 
-    fun calculateEnin(timestampMs: Long = System.currentTimeMillis()): UInt {
-        return ((timestampMs / 1000) / 600).toUInt()
+    fun calculateEnin(timestampMs: Long = System.currentTimeMillis(), eninSeconds: Long = 120L): UInt {
+        val effectiveSeconds = eninSeconds.coerceIn(12L, 3600L)
+        return ((timestampMs / 1000) / effectiveSeconds).toUInt()
     }
 
     fun computeEventCodeHash(eventCode: String): ByteArray {

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardCryptoTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardCryptoTest.kt
@@ -62,4 +62,16 @@ class BarnardCryptoTest {
             BarnardCrypto.displayIdString(tek1) == BarnardCrypto.displayIdString(tek2)
         )
     }
+
+    @Test
+    fun calculateEnin_defaultsTo120SecondWindow() {
+        assertEquals(1U, BarnardCrypto.calculateEnin(timestampMs = 120_000L))
+        assertEquals(2U, BarnardCrypto.calculateEnin(timestampMs = 240_000L))
+    }
+
+    @Test
+    fun calculateEnin_clampsFixedWindowSeconds() {
+        assertEquals(10U, BarnardCrypto.calculateEnin(timestampMs = 120_000L, eninSeconds = 1L))
+        assertEquals(1U, BarnardCrypto.calculateEnin(timestampMs = 3_600_000L, eninSeconds = 7_200L))
+    }
 }

--- a/packages/react-native/barnard/ios/BarnardCrypto.swift
+++ b/packages/react-native/barnard/ios/BarnardCrypto.swift
@@ -116,8 +116,9 @@ enum BarnardCrypto {
 
   // MARK: - ENIN Calculation
 
-  static func calculateEnin(for date: Date = Date()) -> UInt32 {
-    UInt32(Int(date.timeIntervalSince1970) / 600)
+  static func calculateEnin(for date: Date = Date(), eninSeconds: Int = 120) -> UInt32 {
+    let effectiveSeconds = min(max(eninSeconds, 12), 3600)
+    return UInt32(Int(date.timeIntervalSince1970) / effectiveSeconds)
   }
 
   // MARK: - EventCodeHash

--- a/packages/react-native/barnard/src/BarnardManager.ts
+++ b/packages/react-native/barnard/src/BarnardManager.ts
@@ -80,7 +80,7 @@ export class BarnardManager {
     return BarnardModule.getCurrentRpi();
   }
 
-  /** v2: current ENIN (floor(unix_seconds / 600)). */
+  /** v2: current ENIN (floor(unix_seconds / 120)). */
   async getCurrentEnin(): Promise<number> {
     return BarnardModule.getCurrentEnin();
   }


### PR DESCRIPTION
## Summary
- Align React Native Android/iOS ENIN default calculation with the v2 spec and Dart package default (`eninSeconds = 120`).
- Add Android native regression coverage for the 120-second default and clamp behavior.
- Update RN docs/comments and the Jest helper type for the existing `openAppSettings` API.

## Context
Follow-up to #51 after review found that React Native native crypto still used the old `floor(unix_seconds / 600)` ENIN window while #51 changed the v2 spec and Dart implementation to default to 120 seconds.

## Validation
- `npm test -- --runInBand`
- `npm run typescript`
- `JAVA_HOME=/Users/kenichi/Library/Java/JavaVirtualMachines/corretto-11.0.27/Contents/Home ./gradlew :barnard:testDebugUnitTest` from `examples/react-native/barnard_demo/android`

Refs #51