### PR TITLE
fix(ble): guard RSSI updates against stale RPIDs

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -1046,7 +1046,7 @@ internal class BarnardController(
         val knownPeer = knownPeers[address]
         if (knownPeer != null) {
             val currentEnin = BarnardCrypto.calculateEnin(nowMs).toLong()
-            if (BarnardV2Policy.KnownPeerWindow(knownPeer.enin).matches(currentEnin)) {
+            if (BarnardV2Policy.shouldEmitRssiUpdate(knownPeer.enin, currentEnin)) {
                 emitRssiUpdate(address, result.rssi, nowMs)
             } else {
                 knownPeers.remove(address)

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
@@ -8,4 +8,8 @@ internal object BarnardV2Policy {
     data class KnownPeerWindow(val enin: Long) {
         fun matches(currentEnin: Long): Boolean = enin == currentEnin
     }
+
+    fun shouldEmitRssiUpdate(cachedPeerEnin: Long, currentEnin: Long): Boolean {
+        return KnownPeerWindow(cachedPeerEnin).matches(currentEnin)
+    }
 }

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
@@ -19,4 +19,10 @@ internal class BarnardV2PolicyTest {
         assertTrue(peer.matches(1234))
         assertFalse(peer.matches(1235))
     }
+
+    @Test
+    fun shouldEmitRssiUpdate_rejectsCachedPeerAfterEninRotation() {
+        assertTrue(BarnardV2Policy.shouldEmitRssiUpdate(cachedPeerEnin = 1234, currentEnin = 1234))
+        assertFalse(BarnardV2Policy.shouldEmitRssiUpdate(cachedPeerEnin = 1234, currentEnin = 1235))
+    }
 }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -1073,7 +1073,7 @@ extension BarnardBleController: CBCentralManagerDelegate {
 
     if let knownPeer = knownPeers[peripheral.identifier] {
       let currentEnin = BarnardCrypto.calculateEnin(for: now)
-      if BarnardV2Policy.KnownPeerWindow(enin: knownPeer.enin).matches(currentEnin) {
+      if BarnardV2Policy.shouldEmitRssiUpdate(cachedPeerEnin: knownPeer.enin, currentEnin: currentEnin) {
         emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
       } else {
         knownPeers.removeValue(forKey: peripheral.identifier)

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardV2Policy.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardV2Policy.swift
@@ -19,4 +19,13 @@ enum BarnardV2Policy {
     let enin: UInt32
     func matches(_ currentEnin: UInt32) -> Bool { enin == currentEnin }
   }
+
+  /// RSSI updates may reuse a cached peer RPID only while the cache belongs to
+  /// the current ENIN. After rotation, Central must re-resolve B002/B003 first.
+  static func shouldEmitRssiUpdate(
+    cachedPeerEnin: UInt32,
+    currentEnin: UInt32
+  ) -> Bool {
+    KnownPeerWindow(enin: cachedPeerEnin).matches(currentEnin)
+  }
 }

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -92,6 +92,7 @@ const setup = () => {
       exportCurrentTek: () => Promise<string>;
       getPermissionStatus: () => Promise<unknown>;
       requestPermissions: () => Promise<unknown>;
+      openAppSettings: () => Promise<void>;
       joinEvent: (eventCode: string) => Promise<void>;
       onDetection: (callback: (event: unknown) => void) => () => void;
       onRssiUpdate: (callback: (event: unknown) => void) => () => void;

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -923,7 +923,7 @@ internal class BarnardController(
         val knownPeer = knownPeers[address]
         if (knownPeer != null) {
             val currentEnin = BarnardCrypto.calculateEnin(nowMs).toLong()
-            if (BarnardV2Policy.KnownPeerWindow(knownPeer.enin).matches(currentEnin)) {
+            if (BarnardV2Policy.shouldEmitRssiUpdate(knownPeer.enin, currentEnin)) {
                 emitRssiUpdate(address, result.rssi, nowMs)
             } else {
                 knownPeers.remove(address)

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardV2Policy.kt
@@ -8,4 +8,8 @@ internal object BarnardV2Policy {
     data class KnownPeerWindow(val enin: Long) {
         fun matches(currentEnin: Long): Boolean = enin == currentEnin
     }
+
+    fun shouldEmitRssiUpdate(cachedPeerEnin: Long, currentEnin: Long): Boolean {
+        return KnownPeerWindow(cachedPeerEnin).matches(currentEnin)
+    }
 }

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardV2PolicyTest.kt
@@ -19,4 +19,10 @@ internal class BarnardV2PolicyTest {
         assertTrue(peer.matches(1234))
         assertFalse(peer.matches(1235))
     }
+
+    @Test
+    fun shouldEmitRssiUpdate_rejectsCachedPeerAfterEninRotation() {
+        assertTrue(BarnardV2Policy.shouldEmitRssiUpdate(cachedPeerEnin = 1234, currentEnin = 1234))
+        assertFalse(BarnardV2Policy.shouldEmitRssiUpdate(cachedPeerEnin = 1234, currentEnin = 1235))
+    }
 }

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -966,7 +966,7 @@ extension BarnardBleController: CBCentralManagerDelegate {
 
     if let knownPeer = knownPeers[peripheral.identifier] {
       let currentEnin = BarnardCrypto.calculateEnin(for: now)
-      if BarnardV2Policy.KnownPeerWindow(enin: knownPeer.enin).matches(currentEnin) {
+      if BarnardV2Policy.shouldEmitRssiUpdate(cachedPeerEnin: knownPeer.enin, currentEnin: currentEnin) {
         emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
       } else {
         knownPeers.removeValue(forKey: peripheral.identifier)

--- a/packages/react-native/barnard/ios/BarnardV2Policy.swift
+++ b/packages/react-native/barnard/ios/BarnardV2Policy.swift
@@ -19,4 +19,13 @@ enum BarnardV2Policy {
     let enin: UInt32
     func matches(_ currentEnin: UInt32) -> Bool { enin == currentEnin }
   }
+
+  /// RSSI updates may reuse a cached peer RPID only while the cache belongs to
+  /// the current ENIN. After rotation, Central must re-resolve B002/B003 first.
+  static func shouldEmitRssiUpdate(
+    cachedPeerEnin: UInt32,
+    currentEnin: UInt32
+  ) -> Bool {
+    KnownPeerWindow(enin: cachedPeerEnin).matches(currentEnin)
+  }
 }

--- a/specs/004-resolvable-id/spec.md
+++ b/specs/004-resolvable-id/spec.md
@@ -124,7 +124,7 @@ If B004 fails or B002 itself fails, no detection is emitted.
 
 ### 6.1 `RssiUpdateEvent` (v2)
 
-Emitted on every BLE scan hit for a peer that has already completed v2 GATT exchange and been cached as `knownPeer`. No GATT round-trip is performed; the cached `rpid` and `detectedDisplayId` are reused.
+Emitted on every BLE scan hit for a peer that has already completed v2 GATT exchange and been cached as `knownPeer` in the current ENIN. No GATT round-trip is performed while the cached ENIN still matches; the cached `rpid` and `detectedDisplayId` are reused.
 
 ```
 {
@@ -139,6 +139,12 @@ Emitted on every BLE scan hit for a peer that has already completed v2 GATT exch
 ```
 
 `reporterRpid` and `enin` carry the same atomic-snapshot contract as `DetectionEvent` (both derived natively from the observation `timestamp`), so consumers can bucket Detection and RssiUpdate samples together by `(rpid, enin)` without recomputing `enin` client-side.
+
+Known-peer caches are ENIN-scoped. If a scan hit arrives after the cached
+peer's ENIN no longer matches the current ENIN, the Central MUST discard that
+cached peer, MUST NOT emit `rssi_update` with the stale cached RPID, and SHOULD
+perform a fresh GATT resolution before emitting further RSSI updates for that
+peer.
 
 ## 7. SDK public API
 


### PR DESCRIPTION
## Summary
- Add an explicit `shouldEmitRssiUpdate` v2 policy for cached known peers.
- Route Flutter/Dart native Android+iOS and React Native Android+iOS RSSI update paths through that policy.
- Clarify in spec 004 that known-peer caches are ENIN-scoped and Central must not emit `rssi_update` with a stale cached RPID after ENIN rotation.
- Fix the React Native Jest test mock type for `openAppSettings`, which was blocking the existing test suite.

## Compatibility / privacy
- No public event/schema shape changes.
- No on-wire payload changes.
- No device-unique persistent identifiers are added on-wire.
- Behavior is conservative: cached peer RPIDs are only reused while their cached ENIN still matches the current ENIN; after rotation the Central must re-resolve B002/B003 before further RSSI updates.

## Validation
- `dart test test/mock_barnard_test.dart test/crypto_test.dart`
- `flutter test`
- `flutter analyze`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew testDebugUnitTest --tests 'network.greeting.barnard.BarnardV2PolicyTest'` in `packages/dart/barnard/android`
- `npm test -- --runInBand` in `packages/react-native/barnard`
- `npm run typescript` in `packages/react-native/barnard`

Closes #40