### PR TITLE
fix(ios): keep GATT watchdog active through exchange

### DIFF
--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -91,12 +91,12 @@ final class BarnardBleController: NSObject {
   private let resolutionFailureBackoffSeconds: TimeInterval = 30
   private let resolutionRejectedBackoffSeconds: TimeInterval = 5 * 60
   private let maxConnectQueue = 20
-  // CoreBluetooth's `connect()` has no built-in deadline. A hung connection
-  // (e.g. to a peripheral whose BLE address has since rotated) keeps
-  // `activePeripheral` pinned forever and starves the connect queue, so
-  // every subsequently-discovered peer shows up as "scan only, awaiting
-  // GATT". Arm a manual watchdog that cancels and releases the pin after
-  // this many seconds if no GATT progress has been made.
+  // CoreBluetooth's connection and GATT callbacks have no built-in deadline.
+  // A hung connection or service/characteristic discovery keeps
+  // `activePeripheral` pinned forever and starves the connect queue, so every
+  // subsequently-discovered peer shows up as "scan only, awaiting GATT".
+  // Arm a manual watchdog that cancels and releases the pin after this many
+  // seconds if the GATT exchange does not reach disconnection or failure.
   private let connectTimeoutSeconds: TimeInterval = 8
   private var connectWatchdog: DispatchWorkItem?
   private var connectCooldownWorkItem: DispatchWorkItem?
@@ -663,13 +663,13 @@ final class BarnardBleController: NSObject {
       guard let pinned = self.activePeripheral, pinned.identifier == id else {
         return
       }
-      self.emitDebug(level: "warn", name: "connect_timeout", data: [
+      self.emitDebug(level: "warn", name: "gatt_exchange_timeout", data: [
         "id": id.uuidString,
         "seconds": self.connectTimeoutSeconds,
       ])
       self.markGattResolutionFailed(
         id,
-        reason: "connect_timeout",
+        reason: "gatt_exchange_timeout",
         recoverable: true,
         extra: ["seconds": self.connectTimeoutSeconds]
       )
@@ -1101,7 +1101,6 @@ extension BarnardBleController: CBCentralManagerDelegate {
       ])
       return
     }
-    cancelConnectWatchdog()
     emitDebug(level: "trace", name: "connected", data: ["id": peripheral.identifier.uuidString])
     peripheral.discoverServices([discoveryServiceUUID])
   }

--- a/packages/dart/barnard/test/ios_gatt_watchdog_source_test.dart
+++ b/packages/dart/barnard/test/ios_gatt_watchdog_source_test.dart
@@ -1,0 +1,75 @@
+import "dart:io";
+
+import "package:test/test.dart";
+
+void main() {
+  group("iOS GATT watchdog source invariants", () {
+    for (final _SwiftSource source in <_SwiftSource>[
+      _SwiftSource(
+        name: "Flutter iOS",
+        path: "ios/barnard/Sources/barnard/BarnardBleController.swift",
+      ),
+      _SwiftSource(
+        name: "React Native iOS",
+        path: "../../react-native/barnard/ios/BarnardBleController.swift",
+      ),
+    ]) {
+      test("${source.name} keeps watchdog active until connection release", () {
+        final String text = File(source.path).readAsStringSync();
+
+        final String didConnect = _sliceBetween(
+          text,
+          "func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral)",
+          "func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral",
+        );
+        expect(didConnect, isNot(contains("cancelConnectWatchdog()")));
+
+        final String finishConnection = _sliceBetween(
+          text,
+          "private func finishConnection(_ peripheral: CBPeripheral)",
+          source.finishConnectionEndMarker,
+        );
+        expect(finishConnection, isNot(contains("cancelConnectWatchdog()")));
+
+        final String didFailToConnect = _sliceBetween(
+          text,
+          "func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral",
+          "func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral",
+        );
+        expect(didFailToConnect, contains("cancelConnectWatchdog()"));
+
+        final String didDisconnect = _sliceBetween(
+          text,
+          "func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral",
+          "// MARK: - CBPeripheralDelegate",
+        );
+        expect(didDisconnect, contains("cancelConnectWatchdog()"));
+      });
+    }
+  });
+}
+
+String _sliceBetween(String text, String start, String end) {
+  final int startIndex = text.indexOf(start);
+  expect(startIndex, isNonNegative, reason: "missing start marker: $start");
+  final int endIndex = text.indexOf(end, startIndex + start.length);
+  expect(endIndex, isNonNegative, reason: "missing end marker: $end");
+  return text.substring(startIndex, endIndex);
+}
+
+class _SwiftSource {
+  const _SwiftSource({
+    required this.name,
+    required this.path,
+  });
+
+  final String name;
+  final String path;
+
+  String get finishConnectionEndMarker {
+    if (name == "React Native iOS") {
+      return "private func characteristicName";
+    }
+    return "// MARK: - Event Emission";
+  }
+}

--- a/packages/react-native/barnard/__tests__/BarnardManager.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardManager.test.ts
@@ -92,6 +92,7 @@ const setup = () => {
       exportCurrentTek: () => Promise<string>;
       getPermissionStatus: () => Promise<unknown>;
       requestPermissions: () => Promise<unknown>;
+      openAppSettings: () => Promise<void>;
       joinEvent: (eventCode: string) => Promise<void>;
       onDetection: (callback: (event: unknown) => void) => () => void;
       onRssiUpdate: (callback: (event: unknown) => void) => () => void;

--- a/packages/react-native/barnard/ios/BarnardBleController.swift
+++ b/packages/react-native/barnard/ios/BarnardBleController.swift
@@ -75,8 +75,9 @@ final class BarnardBleController: NSObject {
   private let resolutionFailureBackoffSeconds: TimeInterval = 30
   private let resolutionRejectedBackoffSeconds: TimeInterval = 5 * 60
   private let maxConnectQueue = 20
-  // See Flutter variant: CoreBluetooth's `connect()` has no deadline, so a
-  // hung connection pins `activePeripheral` forever and starves the queue.
+  // See Flutter variant: CoreBluetooth's connection and GATT callbacks have no
+  // deadline, so a hung exchange pins `activePeripheral` forever and starves
+  // the queue.
   private let connectTimeoutSeconds: TimeInterval = 8
   private var connectWatchdog: DispatchWorkItem?
   private var connectCooldownWorkItem: DispatchWorkItem?
@@ -563,13 +564,13 @@ final class BarnardBleController: NSObject {
       guard let pinned = self.activePeripheral, pinned.identifier == id else {
         return
       }
-      self.emitDebug(level: "warn", name: "connect_timeout", data: [
+      self.emitDebug(level: "warn", name: "gatt_exchange_timeout", data: [
         "id": id.uuidString,
         "seconds": self.connectTimeoutSeconds,
       ])
       self.markGattResolutionFailed(
         id,
-        reason: "connect_timeout",
+        reason: "gatt_exchange_timeout",
         recoverable: true,
         extra: ["seconds": self.connectTimeoutSeconds]
       )
@@ -994,7 +995,6 @@ extension BarnardBleController: CBCentralManagerDelegate {
       ])
       return
     }
-    cancelConnectWatchdog()
     emitDebug(level: "trace", name: "connected", data: ["id": peripheral.identifier.uuidString])
     peripheral.discoverServices([discoveryServiceUUID])
   }

--- a/specs/004-resolvable-id/spec.md
+++ b/specs/004-resolvable-id/spec.md
@@ -99,6 +99,20 @@ A debug event with name `gatt_b003_read_failed` (error path) or `gatt_b003_missi
 
 If B004 fails or B002 itself fails, no detection is emitted.
 
+### 5.3 Central GATT self-recovery
+
+Central implementations MUST bound each active GATT exchange. If the platform
+does not provide a connection / service-discovery / characteristic-read
+deadline, the SDK must arm its own watchdog while `activePeripheral` is pinned.
+The watchdog stays active until the connection is released through GATT
+completion, failure, explicit reset, or disconnect. On timeout, the Central
+marks the resolution attempt as failed, cancels the peripheral connection,
+clears per-connection GATT state, releases the active slot, and resumes the
+connect queue.
+
+This prevents one stalled iOS CoreBluetooth exchange from permanently blocking
+all later Scan results from reaching GATT resolution.
+
 ## 6. `DetectionEvent` (v2)
 
 ```


### PR DESCRIPTION
## Summary
- Keep the iOS GATT watchdog armed after `didConnect` so it covers service discovery and characteristic reads, not only the initial CoreBluetooth connection callback.
- Apply the same behavior to the Flutter iOS and React Native iOS implementations.
- Rename timeout diagnostics from `connect_timeout` to `gatt_exchange_timeout` to match the broader failure surface.
- Document Central GATT self-recovery requirements in spec 004.
- Add a source invariant test that guards both iOS implementations against canceling the watchdog before the active connection is released.
- Fix the React Native Jest test mock type for `openAppSettings`, which was blocking the existing test suite on main.

## Compatibility / privacy
- No public event/schema shape changes.
- No on-wire payload changes.
- No device-unique persistent identifiers are added on-wire.
- The watchdog only affects Central-side recovery when a GATT exchange stalls.

## Validation
- `flutter test`
- `flutter analyze`
- `npm test -- --runInBand` in `packages/react-native/barnard`
- `npm run typescript` in `packages/react-native/barnard`

## Device-lab note
The current emi device-lab target is Android two-device BLE rendezvous only; iOS real-device lab support is not wired yet. I will run the available Android device-lab loop as a regression check for the PR head.

Closes #47