### PR TITLE
feat(identity): per-event device signing key (barnard#65)

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
@@ -210,7 +210,7 @@ object BarnardCrypto {
     /**
      * HKDF-SHA256 key derivation (simplified: no salt, extract-then-expand).
      */
-    private fun hkdfSha256(ikm: ByteArray, info: ByteArray, outputLength: Int): ByteArray {
+    internal fun hkdfSha256(ikm: ByteArray, info: ByteArray, outputLength: Int): ByteArray {
         // Extract: PRK = HMAC-SHA256(salt=zeros, IKM)
         val salt = ByteArray(32) // All zeros
         val mac = Mac.getInstance("HmacSHA256")

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityController.kt
@@ -1,0 +1,103 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import network.greeting.barnard.BarnardCrypto.toHex
+
+/**
+ * Barnard per-event device signing identity (barnard#65).
+ *
+ * A **module separate from the sensing client** — its own `barnard/identity`
+ * method channel, not `barnard/methods` (owned by [BarnardController]). It
+ * shares the same on-device `DeviceSecret` storage (SharedPreferences key
+ * `rpidSeed` in the `barnard` prefs file) so the signing identity is rooted
+ * in the same secret as the sensing client's TEK, but the private signing
+ * key it derives never crosses the method channel — only the public key
+ * and signatures do.
+ */
+internal class BarnardIdentityController(
+    private val appContext: Context,
+    messenger: BinaryMessenger,
+) : MethodChannel.MethodCallHandler {
+    private val methods = MethodChannel(messenger, "barnard/identity")
+
+    private val prefs: SharedPreferences =
+        appContext.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+
+    init {
+        methods.setMethodCallHandler(this)
+    }
+
+    fun dispose() {
+        methods.setMethodCallHandler(null)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "signingPublicKey" -> {
+                val eventCode = (call.arguments as? Map<*, *>)?.get("eventCode") as? String
+                if (eventCode == null) {
+                    result.error("E_ARGS", "eventCode is required", null)
+                    return
+                }
+                val keyPair = BarnardSigning.deriveSigningKeyPair(getOrCreateDeviceSecret(), eventCode)
+                result.success(keyPair.publicKeyCompressed.toHex())
+            }
+
+            "sign" -> {
+                val args = call.arguments as? Map<*, *>
+                val eventCode = args?.get("eventCode") as? String
+                val bytesHex = args?.get("bytes") as? String
+                if (eventCode == null || bytesHex == null) {
+                    result.error("E_ARGS", "eventCode and bytes are required", null)
+                    return
+                }
+                val keyPair = BarnardSigning.deriveSigningKeyPair(getOrCreateDeviceSecret(), eventCode)
+                val messageHash = java.security.MessageDigest.getInstance("SHA-256").digest(hexToBytes(bytesHex))
+                val sig = BarnardSigning.signRecoverable(keyPair.privateKey, messageHash)
+                result.success(
+                    mapOf(
+                        "r" to sig.r.toHex(),
+                        "s" to sig.s.toHex(),
+                        "v" to sig.v,
+                    )
+                )
+            }
+
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        val clean = if (hex.length % 2 == 0) hex else "0$hex"
+        return ByteArray(clean.length / 2) { i ->
+            clean.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+        }
+    }
+
+    // MARK: - DeviceSecret Management
+    //
+    // Same storage key as BarnardController.getOrCreateDeviceSecret — the
+    // signing identity and the sensing client are rooted in the same
+    // DeviceSecret, but this module never exposes it (unlike
+    // BarnardClient.exportCurrentTek, which is the TEK, not the raw secret).
+
+    private fun getOrCreateDeviceSecret(): ByteArray {
+        val key = "rpidSeed"
+        val existing = prefs.getString(key, null)
+        if (existing != null) {
+            val bytes = Base64.decode(existing, Base64.DEFAULT)
+            if (bytes.size >= 32) return bytes
+        }
+        val bytes = BarnardCrypto.generateRandomBytes(32)
+        prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
+        return bytes
+    }
+}

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPlugin.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPlugin.kt
@@ -6,10 +6,12 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 
 class BarnardPlugin : FlutterPlugin, ActivityAware {
     private var controller: BarnardController? = null
+    private var identityController: BarnardIdentityController? = null
     private var activityBinding: ActivityPluginBinding? = null
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         controller = BarnardController(binding.applicationContext, binding.binaryMessenger)
+        identityController = BarnardIdentityController(binding.applicationContext, binding.binaryMessenger)
         activityBinding?.let { attachControllerToActivity(it) }
     }
 
@@ -17,6 +19,8 @@ class BarnardPlugin : FlutterPlugin, ActivityAware {
         activityBinding?.let { detachControllerFromActivity(it) }
         controller?.dispose()
         controller = null
+        identityController?.dispose()
+        identityController = null
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
@@ -1,0 +1,260 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.math.BigInteger
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Per-event device signing identity (barnard#65).
+ *
+ * Key derivation chain:
+ * ```
+ * DeviceSecret (32 bytes)
+ *      |
+ *      +-- signSeed = HKDF(DeviceSecret || EventCode, "barnard-sign", 32)
+ *                          |
+ *                          v
+ *                     secp256k1 keypair (signSeed reduced mod curve order)
+ * ```
+ *
+ * Mirrors the TEK event-mode derivation shape
+ * (`TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`) but uses a
+ * distinct HKDF `info` string ("barnard-sign" vs "barnard-tek" / "EN-RPIK")
+ * so the signing key and the TEK/RPIK chain are not cross-computable.
+ *
+ * Implements secp256k1 EC math directly on [BigInteger] (no third-party
+ * crypto dependency): field/point arithmetic, RFC 6979 deterministic
+ * ECDSA, and recovery-id computation for ecrecover-compatible signatures.
+ */
+internal object BarnardSigning {
+    const val signingKeyInfo = "barnard-sign"
+
+    // MARK: - secp256k1 curve parameters
+
+    private val P = BigInteger(
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+        16,
+    )
+    private val N = BigInteger(
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+        16,
+    )
+    private val GX = BigInteger(
+        "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+        16,
+    )
+    private val GY = BigInteger(
+        "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+        16,
+    )
+    private val G = ECPoint(GX, GY)
+
+    /** An affine point on secp256k1. `null` coordinates represent infinity. */
+    data class ECPoint(val x: BigInteger?, val y: BigInteger?) {
+        val isInfinity: Boolean get() = x == null || y == null
+    }
+
+    private val INFINITY = ECPoint(null, null)
+
+    private fun mod(a: BigInteger): BigInteger = a.mod(P)
+
+    private fun pointDouble(p: ECPoint): ECPoint {
+        if (p.isInfinity || p.y == BigInteger.ZERO) return INFINITY
+        val x = p.x!!
+        val y = p.y!!
+        // slope = (3x^2) / (2y) mod P  (a = 0 for secp256k1)
+        val num = mod(BigInteger.valueOf(3) * x * x)
+        val den = mod(BigInteger.valueOf(2) * y).modInverse(P)
+        val slope = mod(num * den)
+        val x3 = mod(slope * slope - x - x)
+        val y3 = mod(slope * (x - x3) - y)
+        return ECPoint(x3, y3)
+    }
+
+    private fun pointAdd(p1: ECPoint, p2: ECPoint): ECPoint {
+        if (p1.isInfinity) return p2
+        if (p2.isInfinity) return p1
+        if (p1.x == p2.x) {
+            return if (mod(p1.y!! + p2.y!!) == BigInteger.ZERO) INFINITY else pointDouble(p1)
+        }
+        val slope = mod((p2.y!! - p1.y!!) * (p2.x!! - p1.x!!).modInverse(P))
+        val x3 = mod(slope * slope - p1.x - p2.x)
+        val y3 = mod(slope * (p1.x - x3) - p1.y)
+        return ECPoint(x3, y3)
+    }
+
+    private fun scalarMult(k: BigInteger, point: ECPoint): ECPoint {
+        var result = INFINITY
+        var addend = point
+        var scalar = k
+        while (scalar.signum() > 0) {
+            if (scalar.testBit(0)) {
+                result = pointAdd(result, addend)
+            }
+            addend = pointDouble(addend)
+            scalar = scalar.shiftRight(1)
+        }
+        return result
+    }
+
+    /** SEC1-compressed encoding (33 bytes: 0x02/0x03 prefix + 32-byte X). */
+    private fun compress(point: ECPoint): ByteArray {
+        val x = point.x!!
+        val y = point.y!!
+        val prefix: Byte = if (y.testBit(0)) 0x03 else 0x02
+        return byteArrayOf(prefix) + toFixedBytes(x, 32)
+    }
+
+    /** Decompress a point from its X coordinate and Y parity bit. Returns null if X is not on the curve. */
+    private fun decompress(x: BigInteger, yIsOdd: Boolean): ECPoint? {
+        // y^2 = x^3 + 7 mod P
+        val rhs = mod(x.modPow(BigInteger.valueOf(3), P) + BigInteger.valueOf(7))
+        // secp256k1's P is congruent to 3 mod 4, so sqrt(a) = a^((P+1)/4) mod P.
+        val sqrtExp = (P + BigInteger.ONE).shiftRight(2)
+        var y = rhs.modPow(sqrtExp, P)
+        if (mod(y * y) != rhs) return null
+        if (y.testBit(0) != yIsOdd) {
+            y = P - y
+        }
+        return ECPoint(x, y)
+    }
+
+    private fun toFixedBytes(value: BigInteger, length: Int): ByteArray {
+        val raw = value.toByteArray()
+        val trimmed = if (raw.size > length && raw[0] == 0.toByte()) raw.copyOfRange(raw.size - length, raw.size) else raw
+        return when {
+            trimmed.size == length -> trimmed
+            trimmed.size < length -> ByteArray(length - trimmed.size) + trimmed
+            else -> trimmed.copyOfRange(trimmed.size - length, trimmed.size)
+        }
+    }
+
+    private fun bytesToBigInt(bytes: ByteArray): BigInteger = BigInteger(1, bytes)
+
+    // MARK: - Key derivation
+
+    data class SigningKeyPair(val privateKey: BigInteger, val publicKeyCompressed: ByteArray)
+
+    /**
+     * Derive the per-event signing keypair from [deviceSecret] and [eventCode].
+     */
+    fun deriveSigningKeyPair(deviceSecret: ByteArray, eventCode: String): SigningKeyPair {
+        val combined = deviceSecret + eventCode.toByteArray(Charsets.UTF_8)
+        var seed = BarnardCrypto.hkdfSha256(combined, signingKeyInfo.toByteArray(Charsets.UTF_8), 32)
+        var d = bytesToBigInt(seed).mod(N)
+        while (d.signum() == 0) {
+            seed = sha256(seed)
+            d = bytesToBigInt(seed).mod(N)
+        }
+        val q = scalarMult(d, G)
+        return SigningKeyPair(d, compress(q))
+    }
+
+    private fun sha256(bytes: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA-256").digest(bytes)
+
+    // MARK: - Recoverable ECDSA (RFC 6979 deterministic k)
+
+    data class RecoverableSignature(val r: ByteArray, val s: ByteArray, val v: Int)
+
+    private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    /** RFC 6979 deterministic `k` (HMAC-SHA256, qlen == hlen == 32 bytes for secp256k1/SHA-256). */
+    private fun deterministicK(privateKey: BigInteger, messageHash32: ByteArray): BigInteger {
+        val x = toFixedBytes(privateKey, 32)
+        val h1 = toFixedBytes(bytesToBigInt(messageHash32).mod(N), 32)
+
+        var v = ByteArray(32) { 0x01 }
+        var k = ByteArray(32) { 0x00 }
+
+        k = hmacSha256(k, v + byteArrayOf(0x00) + x + h1)
+        v = hmacSha256(k, v)
+        k = hmacSha256(k, v + byteArrayOf(0x01) + x + h1)
+        v = hmacSha256(k, v)
+
+        while (true) {
+            v = hmacSha256(k, v)
+            val kCandidate = bytesToBigInt(v)
+            if (kCandidate.signum() > 0 && kCandidate < N) {
+                return kCandidate
+            }
+            k = hmacSha256(k, v + byteArrayOf(0x00))
+            v = hmacSha256(k, v)
+        }
+    }
+
+    /**
+     * Sign a 32-byte message hash with [privateKey], returning a recoverable
+     * signature `(r, s, v)`. Normalizes `s` to the lower half of the curve
+     * order (canonical / "low-S" form) and searches for the recovery id
+     * (`0` or `1`) that recovers the caller's own public key — i.e. after
+     * low-S normalization, not before.
+     */
+    fun signRecoverable(privateKey: BigInteger, messageHash32: ByteArray): RecoverableSignature {
+        require(messageHash32.size == 32) { "messageHash must be 32 bytes" }
+
+        val e = bytesToBigInt(messageHash32).mod(N)
+        val expectedPub = compress(scalarMult(privateKey, G))
+
+        var r: BigInteger
+        var s: BigInteger
+        var k: BigInteger
+        while (true) {
+            k = deterministicK(privateKey, messageHash32)
+            val rPoint = scalarMult(k, G)
+            r = rPoint.x!!.mod(N)
+            if (r.signum() == 0) continue
+            s = (k.modInverse(N) * (e + privateKey * r)).mod(N)
+            if (s.signum() == 0) continue
+            break
+        }
+
+        val halfOrder = N.shiftRight(1)
+        if (s > halfOrder) {
+            s = N - s
+        }
+
+        var recoveryId = -1
+        for (id in 0..3) {
+            val candidate = recoverPublicKey(id, r, s, messageHash32)
+            if (candidate != null && candidate.contentEquals(expectedPub)) {
+                recoveryId = id
+                break
+            }
+        }
+        check(recoveryId != -1) { "signRecoverable: could not determine recovery id" }
+
+        return RecoverableSignature(toFixedBytes(r, 32), toFixedBytes(s, 32), recoveryId)
+    }
+
+    /** Recover the SEC1-compressed public key from `(recId, r, s)` and the signed message hash. */
+    fun recoverPublicKey(recId: Int, r: BigInteger, s: BigInteger, messageHash32: ByteArray): ByteArray? {
+        val i = BigInteger.valueOf((recId / 2).toLong())
+        val x = r + i * N
+        if (x >= P) return null
+
+        val rPoint = decompress(x, (recId and 1) == 1) ?: return null
+
+        val nTimesR = scalarMult(N, rPoint)
+        if (!nTimesR.isInfinity) return null
+
+        val e = bytesToBigInt(messageHash32).mod(N)
+        val eNeg = N - e.mod(N)
+        val rInv = r.modInverse(N)
+        val srInv = (rInv * s).mod(N)
+        val eInvrInv = (rInv * eNeg).mod(N)
+
+        val term1 = scalarMult(eInvrInv, G)
+        val term2 = scalarMult(srInv, rPoint)
+        val point = pointAdd(term1, term2)
+        if (point.isInfinity) return null
+        return compress(point)
+    }
+}

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardSigningTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardSigningTest.kt
@@ -1,0 +1,129 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.security.MessageDigest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun deviceSecret(seed: Int): ByteArray = ByteArray(32) { ((it * 7 + seed) and 0xff).toByte() }
+
+private fun sha256(bytes: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+
+class BarnardSigningTest {
+
+    @Test
+    fun sameDeviceSameEvent_producesIdenticalSigningKey() {
+        val secret = deviceSecret(1)
+        val a = BarnardSigning.deriveSigningKeyPair(secret, "event-A")
+        val b = BarnardSigning.deriveSigningKeyPair(secret, "event-A")
+
+        assertArrayEquals(a.publicKeyCompressed, b.publicKeyCompressed)
+        assertEquals(a.privateKey, b.privateKey)
+    }
+
+    @Test
+    fun sameDeviceDifferentEvent_producesDifferentSigningKey() {
+        val secret = deviceSecret(1)
+        val a = BarnardSigning.deriveSigningKeyPair(secret, "event-A")
+        val b = BarnardSigning.deriveSigningKeyPair(secret, "event-B")
+
+        assertFalse(a.publicKeyCompressed.contentEquals(b.publicKeyCompressed))
+    }
+
+    @Test
+    fun noCrossEventStableKey_manyEventsNeverCollide() {
+        val secret = deviceSecret(42)
+        val seen = HashSet<String>()
+        for (i in 0 until 50) {
+            val pub = BarnardSigning.deriveSigningKeyPair(secret, "event-$i").publicKeyCompressed
+            val hex = pub.joinToString("") { "%02x".format(it) }
+            assertTrue("event-$i collided with a prior event's key", seen.add(hex))
+        }
+    }
+
+    @Test
+    fun reDerivableOffline_reproducesSameKeyFromDeviceSecretAlone() {
+        val secret = deviceSecret(7)
+        val first = BarnardSigning.deriveSigningKeyPair(secret, "reunion-2026")
+        val second = BarnardSigning.deriveSigningKeyPair(secret.copyOf(), "reunion-2026")
+
+        assertArrayEquals(first.publicKeyCompressed, second.publicKeyCompressed)
+    }
+
+    @Test
+    fun differentDevices_produceDifferentKeysForSameEvent() {
+        val a = BarnardSigning.deriveSigningKeyPair(deviceSecret(1), "shared-event")
+        val b = BarnardSigning.deriveSigningKeyPair(deviceSecret(2), "shared-event")
+
+        assertFalse(a.publicKeyCompressed.contentEquals(b.publicKeyCompressed))
+    }
+
+    @Test
+    fun domainSeparatedFromTekRpik() {
+        val secret = deviceSecret(3)
+        val eventCode = "domain-sep-event"
+
+        val signingPub = BarnardSigning.deriveSigningKeyPair(secret, eventCode).publicKeyCompressed
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+
+        assertFalse(signingPub.contentEquals(tek))
+        assertFalse(signingPub.contentEquals(rpik))
+        assertFalse(tek.contentEquals(rpik))
+    }
+
+    @Test
+    fun signatureRecoversExactSigningPublicKey() {
+        val secret = deviceSecret(5)
+        val eventCode = "ecrecover-event"
+        val keyPair = BarnardSigning.deriveSigningKeyPair(secret, eventCode)
+        val message = "hello barnard".toByteArray(Charsets.UTF_8)
+        val messageHash = sha256(message)
+
+        val sig = BarnardSigning.signRecoverable(keyPair.privateKey, messageHash)
+        val recovered = BarnardSigning.recoverPublicKey(
+            sig.v,
+            java.math.BigInteger(1, sig.r),
+            java.math.BigInteger(1, sig.s),
+            messageHash,
+        )
+
+        assertNotNull(recovered)
+        assertArrayEquals(keyPair.publicKeyCompressed, recovered)
+    }
+
+    @Test
+    fun recoveryFailsAgainstTamperedMessage() {
+        val secret = deviceSecret(6)
+        val eventCode = "tamper-event"
+        val keyPair = BarnardSigning.deriveSigningKeyPair(secret, eventCode)
+        val original = "original".toByteArray(Charsets.UTF_8)
+        val tampered = "tampered!".toByteArray(Charsets.UTF_8)
+
+        val sig = BarnardSigning.signRecoverable(keyPair.privateKey, sha256(original))
+        val recovered = BarnardSigning.recoverPublicKey(
+            sig.v,
+            java.math.BigInteger(1, sig.r),
+            java.math.BigInteger(1, sig.s),
+            sha256(tampered),
+        )
+
+        assertFalse(keyPair.publicKeyCompressed.contentEquals(recovered ?: ByteArray(0)))
+    }
+
+    @Test
+    fun signatureShape_is32ByteRs_withRecoveryIdInRange() {
+        val keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret(8), "shape-event")
+        val sig = BarnardSigning.signRecoverable(keyPair.privateKey, sha256(byteArrayOf(1, 2, 3)))
+
+        assertEquals(32, sig.r.size)
+        assertEquals(32, sig.s.size)
+        assertTrue(sig.v == 0 || sig.v == 1)
+    }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardIdentityController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardIdentityController.swift
@@ -1,0 +1,87 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import Flutter
+import Foundation
+
+/// Barnard per-event device signing identity (barnard#65).
+///
+/// A **module separate from the sensing client** — its own
+/// `barnard/identity` method channel, not `barnard/methods` (owned by
+/// `BarnardBleController`). It shares the same on-device `DeviceSecret`
+/// storage (`UserDefaults` key `barnard.rpidSeed`) as `BarnardRpidGenerator`
+/// so the signing identity is rooted in the same secret as the sensing
+/// client's TEK, but the private signing key it derives never crosses the
+/// method channel — only the public key and signatures do.
+final class BarnardIdentityController: NSObject, FlutterPlugin {
+  private let deviceSecretKey = "barnard.rpidSeed"
+
+  static func register(with _: FlutterPluginRegistrar) {
+    // Registered directly by BarnardPlugin.register(with:); this
+    // conformance only exists to satisfy `addMethodCallDelegate`'s
+    // `FlutterPlugin` requirement.
+  }
+
+  func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "signingPublicKey":
+      guard let args = call.arguments as? [String: Any], let eventCode = args["eventCode"] as? String else {
+        result(FlutterError(code: "E_ARGS", message: "eventCode is required", details: nil))
+        return
+      }
+      let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
+      result(keyPair.publicKeyCompressed.hexString)
+
+    case "sign":
+      guard let args = call.arguments as? [String: Any],
+        let eventCode = args["eventCode"] as? String,
+        let bytesHex = args["bytes"] as? String
+      else {
+        result(FlutterError(code: "E_ARGS", message: "eventCode and bytes are required", details: nil))
+        return
+      }
+      let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
+      let messageHash = Data(SHA256.hash(data: hexToBytes(bytesHex)))
+      let sig = BarnardSigning.signRecoverable(privateKey: keyPair.privateKey, messageHash32: messageHash)
+      result([
+        "r": sig.r.hexString,
+        "s": sig.s.hexString,
+        "v": sig.v,
+      ])
+
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func hexToBytes(_ hex: String) -> Data {
+    var clean = hex
+    if clean.count % 2 != 0 { clean = "0" + clean }
+    var bytes = [UInt8]()
+    var idx = clean.startIndex
+    while idx < clean.endIndex {
+      let next = clean.index(idx, offsetBy: 2)
+      bytes.append(UInt8(clean[idx..<next], radix: 16) ?? 0)
+      idx = next
+    }
+    return Data(bytes)
+  }
+
+  // MARK: - DeviceSecret Management
+  //
+  // Same storage key as BarnardRpidGenerator.getOrCreateDeviceSecret — the
+  // signing identity and the sensing client are rooted in the same
+  // DeviceSecret, but this module never exposes it (unlike
+  // BarnardClient.exportCurrentTek, which is the TEK, not the raw secret).
+
+  private func getOrCreateDeviceSecret() -> Data {
+    let defaults = UserDefaults.standard
+    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
+      return existing
+    }
+    let newSecret = BarnardCrypto.generateRandomBytes(32)
+    defaults.set(newSecret, forKey: deviceSecretKey)
+    return newSecret
+  }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardPlugin.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardPlugin.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public final class BarnardPlugin: NSObject, FlutterPlugin {
   private let controller = BarnardBleController()
+  private let identityController = BarnardIdentityController()
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let instance = BarnardPlugin()
@@ -15,6 +16,9 @@ public final class BarnardPlugin: NSObject, FlutterPlugin {
 
     let debugEvents = FlutterEventChannel(name: "barnard/debugEvents", binaryMessenger: registrar.messenger())
     debugEvents.setStreamHandler(instance.controller.debugEventsStreamHandler)
+
+    let identity = FlutterMethodChannel(name: "barnard/identity", binaryMessenger: registrar.messenger())
+    registrar.addMethodCallDelegate(instance.identityController, channel: identity)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardSigning.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardSigning.swift
@@ -1,0 +1,167 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import Foundation
+
+/// Per-event device signing identity (barnard#65).
+///
+/// Key derivation chain:
+/// ```
+/// DeviceSecret (32 bytes)
+///      |
+///      +-- signSeed = HKDF(DeviceSecret || EventCode, "barnard-sign", 32)
+///                          |
+///                          v
+///                     secp256k1 keypair (signSeed reduced mod curve order)
+/// ```
+///
+/// Mirrors the TEK event-mode derivation shape
+/// (`TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`, see
+/// `BarnardCrypto.deriveTekForEvent`) but uses a distinct HKDF `info`
+/// string ("barnard-sign" vs "barnard-tek" / "EN-RPIK") so the signing key
+/// and the TEK/RPIK chain are not cross-computable.
+///
+/// iOS has no system-provided secp256k1 (CryptoKit only covers P-256/384/521
+/// and Curve25519), so this implements the minimal field/point arithmetic
+/// and RFC 6979 deterministic ECDSA directly on a fixed-width 256-bit
+/// integer. It has been cross-verified byte-for-byte against the Dart
+/// (`package:pointycastle`) and Kotlin (`java.math.BigInteger`)
+/// implementations of the same algorithm for the same test vectors.
+enum BarnardSigning {
+  static let signingKeyInfo = "barnard-sign"
+
+  struct SigningKeyPair {
+    let privateKey: Secp256k1.UInt256
+    let publicKeyCompressed: Data
+  }
+
+  struct RecoverableSignature {
+    let r: Data
+    let s: Data
+    let v: Int
+  }
+
+  /// Derive the per-event signing keypair from `deviceSecret` and `eventCode`.
+  static func deriveSigningKeyPair(deviceSecret: Data, eventCode: String) -> SigningKeyPair {
+    let eventCodeData = eventCode.data(using: .utf8) ?? Data()
+    var combined = deviceSecret
+    combined.append(eventCodeData)
+
+    let key = SymmetricKey(data: combined)
+    var seed = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: signingKeyInfo.data(using: .utf8)!,
+      outputByteCount: 32
+    ).withUnsafeBytes { Data($0) }
+
+    var d = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: seed), Secp256k1.N)
+    while d.isZero {
+      seed = Data(SHA256.hash(data: seed))
+      d = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: seed), Secp256k1.N)
+    }
+
+    let q = Secp256k1.scalarMult(d, Secp256k1.G)
+    return SigningKeyPair(privateKey: d, publicKeyCompressed: Secp256k1.compress(q))
+  }
+
+  /// Sign a 32-byte message hash with `privateKey`, returning a recoverable
+  /// signature `(r, s, v)`. Deterministic (RFC 6979 / HMAC-SHA256 `k`),
+  /// normalizes `s` to the lower half of the curve order (canonical /
+  /// "low-S" form), and searches for the recovery id (`0` or `1`) against
+  /// the caller's own public key.
+  static func signRecoverable(privateKey: Secp256k1.UInt256, messageHash32: Data) -> RecoverableSignature {
+    precondition(messageHash32.count == 32, "messageHash must be 32 bytes")
+
+    let e = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N)
+    let expectedPub = Secp256k1.compress(Secp256k1.scalarMult(privateKey, Secp256k1.G))
+
+    var r = Secp256k1.UInt256.zero
+    var s = Secp256k1.UInt256.zero
+    while true {
+      let k = deterministicK(privateKey: privateKey, messageHash32: messageHash32)
+      let rPoint = Secp256k1.scalarMult(k, Secp256k1.G)
+      guard let rx = rPoint.x else { continue }
+      r = Secp256k1.Field.reduceOnce(rx, Secp256k1.N)
+      if r.isZero { continue }
+      let kInv = Secp256k1.Field.invMod(k, Secp256k1.N)
+      s = Secp256k1.Field.mulMod(
+        kInv,
+        Secp256k1.Field.addMod(e, Secp256k1.Field.mulMod(privateKey, r, Secp256k1.N), Secp256k1.N),
+        Secp256k1.N
+      )
+      if s.isZero { continue }
+      break
+    }
+
+    let halfOrder = Secp256k1.N.shiftedRight1()
+    if s > halfOrder {
+      s = Secp256k1.N.subtracting(s)
+    }
+
+    var recoveryId = -1
+    for id in 0..<4 {
+      if let candidate = recoverPublicKey(recId: id, r: r, s: s, messageHash32: messageHash32),
+        candidate == expectedPub
+      {
+        recoveryId = id
+        break
+      }
+    }
+    precondition(recoveryId != -1, "signRecoverable: could not determine recovery id")
+
+    return RecoverableSignature(r: r.data, s: s.data, v: recoveryId)
+  }
+
+  /// Recover the SEC1-compressed public key from `(recId, r, s)` and the
+  /// signed message hash. Returns nil if the signature/recovery id is
+  /// invalid.
+  static func recoverPublicKey(recId: Int, r: Secp256k1.UInt256, s: Secp256k1.UInt256, messageHash32: Data) -> Data? {
+    guard recId / 2 == 0 else { return nil }
+    if r >= Secp256k1.P { return nil }
+    guard let rPoint = Secp256k1.decompress(x: r, yIsOdd: (recId & 1) == 1) else { return nil }
+    // secp256k1 has cofactor 1: every point satisfying the curve equation
+    // already has order N, so the "N*R == infinity" order check other
+    // implementations run here is mathematically redundant and skipped.
+
+    let e = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N)
+    let eNeg = Secp256k1.N.subtracting(e)
+    let rInv = Secp256k1.Field.invMod(r, Secp256k1.N)
+    let srInv = Secp256k1.Field.mulMod(rInv, s, Secp256k1.N)
+    let eInvrInv = Secp256k1.Field.mulMod(rInv, eNeg, Secp256k1.N)
+
+    let term1 = Secp256k1.scalarMult(eInvrInv, Secp256k1.G)
+    let term2 = Secp256k1.scalarMult(srInv, rPoint)
+    let point = Secp256k1.pointAdd(term1, term2)
+    if point.isInfinity { return nil }
+    return Secp256k1.compress(point)
+  }
+
+  /// RFC 6979 deterministic `k` (HMAC-SHA256; qlen == hlen == 32 bytes for secp256k1/SHA-256).
+  private static func deterministicK(privateKey: Secp256k1.UInt256, messageHash32: Data) -> Secp256k1.UInt256 {
+    let x = privateKey.data
+    let h1 = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N).data
+
+    func hmac(_ key: Data, _ data: Data) -> Data {
+      Data(HMAC<SHA256>.authenticationCode(for: data, using: SymmetricKey(data: key)))
+    }
+
+    var v = Data(repeating: 0x01, count: 32)
+    var k = Data(repeating: 0x00, count: 32)
+
+    k = hmac(k, v + Data([0x00]) + x + h1)
+    v = hmac(k, v)
+    k = hmac(k, v + Data([0x01]) + x + h1)
+    v = hmac(k, v)
+
+    while true {
+      v = hmac(k, v)
+      let candidate = Secp256k1.UInt256(data: v)
+      if !candidate.isZero && candidate < Secp256k1.N {
+        return candidate
+      }
+      k = hmac(k, v + Data([0x00]))
+      v = hmac(k, v)
+    }
+  }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/Secp256k1.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/Secp256k1.swift
@@ -1,0 +1,274 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+
+/// Minimal secp256k1 field/point arithmetic and a fixed-width 256-bit
+/// integer, used by `BarnardSigning` (barnard#65) for recoverable
+/// ("ecrecover"-able) ECDSA. iOS has no system-provided secp256k1 curve
+/// (CryptoKit covers P-256/384/521 and Curve25519 only).
+enum Secp256k1 {
+  /// Fixed-width 256-bit unsigned integer for secp256k1 field/scalar
+  /// arithmetic. Stored as 4 big-endian `UInt64` limbs (`limbs.0` most
+  /// significant).
+  struct UInt256: Comparable {
+    var limbs: (UInt64, UInt64, UInt64, UInt64)
+
+    static func == (lhs: UInt256, rhs: UInt256) -> Bool {
+      lhs.limbs == rhs.limbs
+    }
+
+    static let zero = UInt256(limbs: (0, 0, 0, 0))
+    static let one = UInt256(limbs: (0, 0, 0, 1))
+
+    init(limbs: (UInt64, UInt64, UInt64, UInt64)) {
+      self.limbs = limbs
+    }
+
+    init?(hex: String) {
+      var h = hex
+      if h.count > 64 { return nil }
+      while h.count < 64 { h = "0" + h }
+      var parts: [UInt64] = []
+      var idx = h.startIndex
+      for _ in 0..<4 {
+        let next = h.index(idx, offsetBy: 16)
+        guard let v = UInt64(h[idx..<next], radix: 16) else { return nil }
+        parts.append(v)
+        idx = next
+      }
+      self.limbs = (parts[0], parts[1], parts[2], parts[3])
+    }
+
+    /// Interprets `data` as a big-endian integer, truncating/left-padding
+    /// to 32 bytes if the input isn't exactly 32 bytes.
+    init(data: Data) {
+      var bytes = [UInt8](data)
+      if bytes.count > 32 {
+        bytes = Array(bytes.suffix(32))
+      } else if bytes.count < 32 {
+        bytes = [UInt8](repeating: 0, count: 32 - bytes.count) + bytes
+      }
+      func limb(_ range: Range<Int>) -> UInt64 {
+        var v: UInt64 = 0
+        for i in range { v = (v << 8) | UInt64(bytes[i]) }
+        return v
+      }
+      self.limbs = (limb(0..<8), limb(8..<16), limb(16..<24), limb(24..<32))
+    }
+
+    /// Big-endian 32-byte encoding.
+    var data: Data {
+      var out = [UInt8](repeating: 0, count: 32)
+      let parts = [limbs.0, limbs.1, limbs.2, limbs.3]
+      for (i, part) in parts.enumerated() {
+        for j in 0..<8 {
+          out[i * 8 + j] = UInt8((part >> (56 - 8 * j)) & 0xff)
+        }
+      }
+      return Data(out)
+    }
+
+    static func < (lhs: UInt256, rhs: UInt256) -> Bool {
+      if lhs.limbs.0 != rhs.limbs.0 { return lhs.limbs.0 < rhs.limbs.0 }
+      if lhs.limbs.1 != rhs.limbs.1 { return lhs.limbs.1 < rhs.limbs.1 }
+      if lhs.limbs.2 != rhs.limbs.2 { return lhs.limbs.2 < rhs.limbs.2 }
+      return lhs.limbs.3 < rhs.limbs.3
+    }
+
+    var isZero: Bool { self == .zero }
+
+    @inline(__always)
+    func testBit(_ n: Int) -> Bool {
+      let bitIndex = n % 64
+      switch n / 64 {
+      case 0: return (limbs.3 >> bitIndex) & 1 == 1
+      case 1: return (limbs.2 >> bitIndex) & 1 == 1
+      case 2: return (limbs.1 >> bitIndex) & 1 == 1
+      default: return (limbs.0 >> bitIndex) & 1 == 1
+      }
+    }
+
+    /// Adds `x + y + carryIn`, returning `(result, carryOut)`.
+    @inline(__always)
+    private static func addLimb(_ x: UInt64, _ y: UInt64, _ carryIn: UInt64) -> (UInt64, UInt64) {
+      let (s1, o1) = x.addingReportingOverflow(y)
+      let (s2, o2) = s1.addingReportingOverflow(carryIn)
+      return (s2, (o1 ? 1 : 0) &+ (o2 ? 1 : 0))
+    }
+
+    /// Unsigned add with carry-out (across all 4 limbs), ripple-carry from
+    /// the least-significant limb (`limbs.3`). Operates directly on the
+    /// tuple fields (no array allocation) since this is the innermost loop
+    /// of `Field.mulMod`/`powMod`, called millions of times per signature.
+    @inline(__always)
+    func addingWithCarry(_ other: UInt256) -> (UInt256, Bool) {
+      let (r3, c3) = UInt256.addLimb(limbs.3, other.limbs.3, 0)
+      let (r2, c2) = UInt256.addLimb(limbs.2, other.limbs.2, c3)
+      let (r1, c1) = UInt256.addLimb(limbs.1, other.limbs.1, c2)
+      let (r0, c0) = UInt256.addLimb(limbs.0, other.limbs.0, c1)
+      return (UInt256(limbs: (r0, r1, r2, r3)), c0 != 0)
+    }
+
+    /// Subtracts `x - y - borrowIn`, returning `(result, borrowOut)`.
+    @inline(__always)
+    private static func subLimb(_ x: UInt64, _ y: UInt64, _ borrowIn: UInt64) -> (UInt64, UInt64) {
+      let (d1, b1) = x.subtractingReportingOverflow(y)
+      let (d2, b2) = d1.subtractingReportingOverflow(borrowIn)
+      return (d2, (b1 ? 1 : 0) &+ (b2 ? 1 : 0))
+    }
+
+    /// Unsigned subtract assuming `self >= other` (across all 4 limbs).
+    @inline(__always)
+    func subtracting(_ other: UInt256) -> UInt256 {
+      let (d3, b3) = UInt256.subLimb(limbs.3, other.limbs.3, 0)
+      let (d2, b2) = UInt256.subLimb(limbs.2, other.limbs.2, b3)
+      let (d1, b1) = UInt256.subLimb(limbs.1, other.limbs.1, b2)
+      let (d0, _) = UInt256.subLimb(limbs.0, other.limbs.0, b1)
+      return UInt256(limbs: (d0, d1, d2, d3))
+    }
+
+    @inline(__always)
+    func shiftedRight1() -> UInt256 {
+      let c1 = limbs.0 & 1
+      let c2 = limbs.1 & 1
+      let c3 = limbs.2 & 1
+      return UInt256(
+        limbs: (
+          limbs.0 >> 1,
+          (limbs.1 >> 1) | (c1 << 63),
+          (limbs.2 >> 1) | (c2 << 63),
+          (limbs.3 >> 1) | (c3 << 63)
+        )
+      )
+    }
+  }
+
+  /// Field/scalar arithmetic mod an arbitrary 256-bit modulus `m` (either
+  /// the field prime `P` or the curve order `N`). Reduced with modular
+  /// addition/doubling only (no full-width multiply+reduce): every
+  /// 256-bit input here is already `< 2 * m` (`m` is within ~2^129 of
+  /// 2^256 for both `P` and `N`), so a single conditional subtraction
+  /// reduces it.
+  enum Field {
+    static func reduceOnce(_ a: UInt256, _ m: UInt256) -> UInt256 {
+      a >= m ? a.subtracting(m) : a
+    }
+
+    static func addMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      let (sum, carry) = a.addingWithCarry(b)
+      if carry || sum >= m { return sum.subtracting(m) }
+      return sum
+    }
+
+    static func subMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      if a >= b { return a.subtracting(b) }
+      return m.subtracting(b.subtracting(a))
+    }
+
+    /// Modular multiplication via double-and-add (avoids a full 512-bit
+    /// multiply + reduction step).
+    static func mulMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      var result = UInt256.zero
+      let addend = reduceOnce(a, m)
+      for i in stride(from: 255, through: 0, by: -1) {
+        result = addMod(result, result, m)
+        if b.testBit(i) {
+          result = addMod(result, addend, m)
+        }
+      }
+      return result
+    }
+
+    static func powMod(_ base: UInt256, _ exponent: UInt256, _ m: UInt256) -> UInt256 {
+      var result = UInt256.one
+      let b = reduceOnce(base, m)
+      for i in stride(from: 255, through: 0, by: -1) {
+        result = mulMod(result, result, m)
+        if exponent.testBit(i) {
+          result = mulMod(result, b, m)
+        }
+      }
+      return result
+    }
+
+    /// Modular inverse via Fermat's little theorem (`m` must be prime):
+    /// `a^-1 = a^(m-2) mod m`.
+    static func invMod(_ a: UInt256, _ m: UInt256) -> UInt256 {
+      let mMinus2 = m.subtracting(UInt256(limbs: (0, 0, 0, 2)))
+      return powMod(a, mMinus2, m)
+    }
+  }
+
+  static let P = UInt256(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")!
+  static let N = UInt256(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")!
+  static let Gx = UInt256(hex: "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798")!
+  static let Gy = UInt256(hex: "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8")!
+
+  struct Point: Equatable {
+    var x: UInt256?
+    var y: UInt256?
+    static let infinity = Point(x: nil, y: nil)
+    var isInfinity: Bool { x == nil || y == nil }
+  }
+
+  static let G = Point(x: Gx, y: Gy)
+
+  static func pointDouble(_ p: Point) -> Point {
+    guard let x = p.x, let y = p.y, !y.isZero else { return .infinity }
+    let num = Field.mulMod(UInt256(limbs: (0, 0, 0, 3)), Field.mulMod(x, x, P), P)
+    let den = Field.invMod(Field.mulMod(UInt256(limbs: (0, 0, 0, 2)), y, P), P)
+    let slope = Field.mulMod(num, den, P)
+    let x3 = Field.subMod(Field.subMod(Field.mulMod(slope, slope, P), x, P), x, P)
+    let y3 = Field.subMod(Field.mulMod(slope, Field.subMod(x, x3, P), P), y, P)
+    return Point(x: x3, y: y3)
+  }
+
+  static func pointAdd(_ p1: Point, _ p2: Point) -> Point {
+    if p1.isInfinity { return p2 }
+    if p2.isInfinity { return p1 }
+    guard let x1 = p1.x, let y1 = p1.y, let x2 = p2.x, let y2 = p2.y else { return .infinity }
+    if x1 == x2 {
+      if Field.addMod(y1, y2, P).isZero { return .infinity }
+      return pointDouble(p1)
+    }
+    let slope = Field.mulMod(Field.subMod(y2, y1, P), Field.invMod(Field.subMod(x2, x1, P), P), P)
+    let x3 = Field.subMod(Field.subMod(Field.mulMod(slope, slope, P), x1, P), x2, P)
+    let y3 = Field.subMod(Field.mulMod(slope, Field.subMod(x1, x3, P), P), y1, P)
+    return Point(x: x3, y: y3)
+  }
+
+  static func scalarMult(_ k: UInt256, _ point: Point) -> Point {
+    var result = Point.infinity
+    let addend = point
+    for i in stride(from: 255, through: 0, by: -1) {
+      result = pointDouble(result)
+      if k.testBit(i) {
+        result = pointAdd(result, addend)
+      }
+    }
+    return result
+  }
+
+  /// SEC1-compressed encoding (33 bytes: 0x02/0x03 prefix + 32-byte X).
+  static func compress(_ point: Point) -> Data {
+    guard let x = point.x, let y = point.y else { return Data() }
+    let prefix: UInt8 = y.testBit(0) ? 0x03 : 0x02
+    return Data([prefix]) + x.data
+  }
+
+  /// Decompress a point from its X coordinate and Y parity bit. Returns
+  /// nil if X is not on the curve.
+  static func decompress(x: UInt256, yIsOdd: Bool) -> Point? {
+    let x3 = Field.mulMod(Field.mulMod(x, x, P), x, P)
+    let rhs = Field.addMod(x3, UInt256(limbs: (0, 0, 0, 7)), P)
+    // secp256k1's P is congruent to 3 mod 4, so sqrt(a) = a^((P+1)/4) mod P.
+    let sqrtExponent = P.addingWithCarry(UInt256.one).0.shiftedRight1().shiftedRight1()
+    var y = Field.powMod(rhs, sqrtExponent, P)
+    if Field.mulMod(y, y, P) != rhs { return nil }
+    if y.testBit(0) != yIsOdd {
+      y = P.subtracting(y)
+    }
+    return Point(x: x, y: y)
+  }
+}

--- a/packages/dart/barnard/lib/barnard.dart
+++ b/packages/dart/barnard/lib/barnard.dart
@@ -6,8 +6,11 @@ export "src/domain/events.dart";
 export "src/domain/hex.dart";
 export "src/domain/permissions.dart";
 export "src/domain/rssi.dart";
+export "src/domain/secp256k1.dart";
+export "src/domain/signing.dart";
 export "src/domain/state.dart";
 export "src/domain/transport.dart";
 
 // usecase (public interface)
 export "src/usecase/barnard_client.dart";
+export "src/usecase/barnard_identity.dart";

--- a/packages/dart/barnard/lib/barnard_ble.dart
+++ b/packages/dart/barnard/lib/barnard_ble.dart
@@ -1,1 +1,2 @@
 export "src/interface_adapter/ble/barnard_ble_client.dart";
+export "src/interface_adapter/ble/barnard_ble_identity.dart";

--- a/packages/dart/barnard/lib/mock_barnard.dart
+++ b/packages/dart/barnard/lib/mock_barnard.dart
@@ -1,1 +1,2 @@
 export "src/interface_adapter/mock/mock_barnard.dart";
+export "src/interface_adapter/mock/mock_barnard_identity.dart";

--- a/packages/dart/barnard/lib/src/domain/secp256k1.dart
+++ b/packages/dart/barnard/lib/src/domain/secp256k1.dart
@@ -1,0 +1,202 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+/// Minimal secp256k1 ECDSA support with recoverable ("ecrecover"-able)
+/// signatures, built on the secp256k1 curve parameters already shipped by
+/// `package:pointycastle`.
+///
+/// This does not implement a generic secp256k1/ECDSA library — only the
+/// operations barnard#65 needs: derive a keypair from 32 bytes of key
+/// material, produce a recoverable signature (r, s, v), and recover the
+/// public key from a signature (used by tests to prove the signature is
+/// genuinely ecrecover-compatible).
+library;
+
+import "dart:typed_data";
+
+import "package:pointycastle/export.dart";
+
+import "crypto.dart";
+
+final ECDomainParameters _params = ECCurve_secp256k1();
+
+BigInt get _curveOrder => _params.n;
+
+BigInt _bytesToBigInt(Uint8List bytes) {
+  BigInt result = BigInt.zero;
+  for (final byte in bytes) {
+    result = (result << 8) | BigInt.from(byte);
+  }
+  return result;
+}
+
+Uint8List _bigIntToBytes(BigInt value, int length) {
+  final result = Uint8List(length);
+  BigInt v = value;
+  for (int i = length - 1; i >= 0; i--) {
+    result[i] = (v & BigInt.from(0xff)).toInt();
+    v = v >> 8;
+  }
+  return result;
+}
+
+/// A secp256k1 keypair: the raw scalar private key and its SEC1-compressed
+/// (33-byte) public key.
+class Secp256k1KeyPair {
+  const Secp256k1KeyPair({required this.privateKey, required this.publicKeyCompressed});
+
+  /// The private scalar, in `[1, n-1]`. Callers must never let this leave
+  /// the boundary that derived it.
+  final BigInt privateKey;
+
+  /// SEC1-compressed public key point (33 bytes: 0x02/0x03 prefix + 32-byte X).
+  final Uint8List publicKeyCompressed;
+}
+
+/// A recoverable ECDSA signature: `(r, s, v)` where `v` is the recovery id
+/// (`0` or `1`) needed to recover the public key from `(r, s)` alone
+/// (i.e. "ecrecover"-compatible).
+class RecoverableSignature {
+  const RecoverableSignature({required this.r, required this.s, required this.v});
+
+  /// 32-byte big-endian `r`.
+  final Uint8List r;
+
+  /// 32-byte big-endian `s`, normalized to the lower half of the curve
+  /// order (canonical / "low-S" form).
+  final Uint8List s;
+
+  /// Recovery id: `0` or `1`.
+  final int v;
+}
+
+/// Derive a secp256k1 keypair from 32 bytes of key material (e.g. HKDF
+/// output). The scalar is reduced mod the curve order; on the
+/// astronomically unlikely event it reduces to zero, it is re-hashed with
+/// SHA-256 and retried so derivation always succeeds deterministically.
+Secp256k1KeyPair secp256k1KeyPairFromSeed(Uint8List seed32) {
+  if (seed32.length != 32) {
+    throw ArgumentError("seed must be 32 bytes, got ${seed32.length}");
+  }
+
+  Uint8List candidate = seed32;
+  BigInt d = _bytesToBigInt(candidate) % _curveOrder;
+  while (d == BigInt.zero) {
+    candidate = sha256(candidate);
+    d = _bytesToBigInt(candidate) % _curveOrder;
+  }
+
+  final ECPoint? q = (_params.G * d);
+  if (q == null) {
+    throw StateError("secp256k1KeyPairFromSeed: failed to derive public key point");
+  }
+
+  return Secp256k1KeyPair(
+    privateKey: d,
+    publicKeyCompressed: Uint8List.fromList(q.getEncoded(true)),
+  );
+}
+
+/// Sign a 32-byte message hash with [privateKey], returning a recoverable
+/// signature. Uses RFC 6979 deterministic `k` (HMAC-SHA256) so signing is
+/// deterministic and never depends on a system RNG, and normalizes `s` to
+/// the lower half of the curve order (canonical form) with the matching
+/// recovery id flip.
+RecoverableSignature signRecoverable(BigInt privateKey, Uint8List messageHash32) {
+  if (messageHash32.length != 32) {
+    throw ArgumentError("messageHash must be 32 bytes, got ${messageHash32.length}");
+  }
+
+  final key = ECPrivateKey(privateKey, _params);
+  final signer = ECDSASigner(null, HMac(SHA256Digest(), 64))
+    ..init(true, PrivateKeyParameter<ECPrivateKey>(key));
+
+  ECSignature sig = signer.generateSignature(messageHash32) as ECSignature;
+
+  final halfOrder = _curveOrder >> 1;
+  BigInt s = sig.s;
+  if (s > halfOrder) {
+    s = _curveOrder - s;
+  }
+
+  final ECPoint? q = (_params.G * privateKey);
+  if (q == null) {
+    throw StateError("signRecoverable: failed to derive public key point");
+  }
+  final expectedPub = Uint8List.fromList(q.getEncoded(true));
+
+  int? recoveryId;
+  for (int id = 0; id < 4; id++) {
+    final candidate = _recoverPublicKey(id, sig.r, s, messageHash32);
+    if (candidate != null && _bytesEqual(candidate, expectedPub)) {
+      recoveryId = id;
+      break;
+    }
+  }
+  if (recoveryId == null) {
+    throw StateError("signRecoverable: could not determine recovery id");
+  }
+
+  return RecoverableSignature(
+    r: _bigIntToBytes(sig.r, 32),
+    s: _bigIntToBytes(s, 32),
+    v: recoveryId,
+  );
+}
+
+/// Recover the SEC1-compressed public key from a [RecoverableSignature]
+/// and the 32-byte message hash that was signed. Returns null if the
+/// signature/recovery id is invalid.
+Uint8List? recoverPublicKey(RecoverableSignature signature, Uint8List messageHash32) {
+  final r = _bytesToBigInt(signature.r);
+  final s = _bytesToBigInt(signature.s);
+  return _recoverPublicKey(signature.v, r, s, messageHash32);
+}
+
+Uint8List? _recoverPublicKey(int recId, BigInt r, BigInt s, Uint8List messageHash32) {
+  final curve = _params.curve;
+  final n = _curveOrder;
+  final prime = _fieldPrime;
+  final i = BigInt.from(recId ~/ 2);
+  final x = r + (i * n);
+  if (x >= prime) return null;
+
+  ECPoint rPoint;
+  try {
+    rPoint = curve.decompressPoint(recId & 1, x);
+  } catch (_) {
+    return null;
+  }
+
+  final nTimesR = rPoint * n;
+  if (nTimesR == null || !nTimesR.isInfinity) return null;
+
+  final e = _bytesToBigInt(messageHash32);
+  final eNeg = (-e) % n;
+  final rInv = r.modInverse(n);
+  final srInv = (rInv * s) % n;
+  final eInvrInv = (rInv * eNeg) % n;
+
+  final ECPoint? term1 = _params.G * eInvrInv;
+  final ECPoint? term2 = rPoint * srInv;
+  if (term1 == null || term2 == null) return null;
+  final point = term1 + term2;
+  if (point == null || point.isInfinity) return null;
+  return Uint8List.fromList(point.getEncoded(true));
+}
+
+/// secp256k1's field prime `p`. pointycastle's `ECCurve` does not expose
+/// `p` directly, so this module (hard-coded to secp256k1) uses the
+/// well-known curve constant.
+final BigInt _fieldPrime = BigInt.parse(
+  "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+  radix: 16,
+);
+
+bool _bytesEqual(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (int i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/dart/barnard/lib/src/domain/signing.dart
+++ b/packages/dart/barnard/lib/src/domain/signing.dart
@@ -1,0 +1,69 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+/// Per-event device signing identity (barnard#65).
+///
+/// Key derivation chain:
+/// ```
+/// DeviceSecret (32 bytes)
+///      |
+///      +-- signSeed = HKDF(DeviceSecret || EventCode, "barnard-sign", 32)
+///                          |
+///                          v
+///                     secp256k1 keypair (signSeed reduced mod curve order)
+/// ```
+///
+/// This mirrors the TEK event-mode derivation shape
+/// (`TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`, see
+/// [deriveTek]) so the signing key is diversified by `eventCode` the same
+/// way the TEK is, but uses a distinct HKDF `info` string ("barnard-sign"
+/// vs "barnard-tek") so the two derivation chains are not cross-computable
+/// from one another.
+library;
+
+import "dart:convert";
+import "dart:typed_data";
+
+import "crypto.dart";
+import "secp256k1.dart";
+
+/// HKDF `info` tag for the per-event signing key. Distinct from
+/// `"barnard-tek"` / `"barnard-tek-anonymous"` / `"EN-RPIK"` so the signing
+/// key and the TEK/RPIK chain are domain-separated.
+const String signingKeyInfo = "barnard-sign";
+
+/// Derive the per-event signing keypair from [deviceSecret] and
+/// [eventCode].
+///
+/// - Deterministic and re-derivable offline from `DeviceSecret` alone.
+/// - Stable within one `eventCode`, different across `eventCode`s.
+/// - Domain-separated from the TEK/RPIK chain (distinct HKDF `info`).
+Secp256k1KeyPair deriveSigningKeyPair(Uint8List deviceSecret, String eventCode) {
+  final eventCodeBytes = utf8.encode(eventCode);
+  final combined = Uint8List(deviceSecret.length + eventCodeBytes.length);
+  combined.setRange(0, deviceSecret.length, deviceSecret);
+  combined.setRange(deviceSecret.length, combined.length, eventCodeBytes);
+
+  final seed = hkdfSha256(
+    ikm: combined,
+    info: Uint8List.fromList(utf8.encode(signingKeyInfo)),
+    length: 32,
+  );
+
+  return secp256k1KeyPairFromSeed(seed);
+}
+
+/// Sign [message] with the per-event signing key derived from
+/// [deviceSecret] and [eventCode].
+///
+/// [message] is SHA-256 hashed before ECDSA signing (a message hash, not
+/// raw bytes, is required for ecrecover-style recovery).
+RecoverableSignature signWithDeviceSecret({
+  required Uint8List deviceSecret,
+  required String eventCode,
+  required Uint8List message,
+}) {
+  final keyPair = deriveSigningKeyPair(deviceSecret, eventCode);
+  final messageHash = sha256(message);
+  return signRecoverable(keyPair.privateKey, messageHash);
+}

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_identity.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_identity.dart
@@ -1,0 +1,58 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import "package:flutter/services.dart";
+
+import "../../domain/hex.dart";
+import "../../usecase/barnard_identity.dart";
+
+/// Real-device implementation of [BarnardIdentity]. Delegates key
+/// derivation and signing to native code (Kotlin/Swift) over a dedicated
+/// `barnard/identity` method channel, separate from `barnard/methods`
+/// (used by [BarnardBleClient]) — the private key is derived and used
+/// natively and never crosses into Dart.
+class BarnardBleIdentity implements BarnardIdentity {
+  BarnardBleIdentity._();
+
+  static const MethodChannel _methods = MethodChannel("barnard/identity");
+
+  /// Create a [BarnardBleIdentity] bound to the same native `DeviceSecret`
+  /// as the platform's `BarnardBleClient`.
+  static Future<BarnardBleIdentity> create() async {
+    return BarnardBleIdentity._();
+  }
+
+  @override
+  Future<Uint8List> signingPublicKey(String eventCode) async {
+    final String hex =
+        (await _methods.invokeMethod<String>("signingPublicKey", {
+          "eventCode": eventCode,
+        })) ??
+        "";
+    final Uint8List bytes = hexToBytes(hex);
+    if (bytes.length != 33) {
+      throw StateError(
+        "signingPublicKey: expected 33 bytes from native, got ${bytes.length}",
+      );
+    }
+    return bytes;
+  }
+
+  @override
+  Future<BarnardSignature> sign(String eventCode, Uint8List bytes) async {
+    final Map<Object?, Object?> result =
+        (await _methods.invokeMethod<Map<Object?, Object?>>("sign", {
+          "eventCode": eventCode,
+          "bytes": bytesToHex(bytes),
+        })) ??
+        const {};
+
+    final Uint8List r = hexToBytes(result["r"] as String? ?? "");
+    final Uint8List s = hexToBytes(result["s"] as String? ?? "");
+    final int? v = result["v"] as int?;
+    if (r.length != 32 || s.length != 32 || v == null) {
+      throw StateError("sign: malformed signature from native ($result)");
+    }
+    return BarnardSignature(r: r, s: s, v: v);
+  }
+}

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard.dart
@@ -274,6 +274,11 @@ class MockBarnard implements BarnardClient {
     return Uint8List.fromList(_currentTek);
   }
 
+  /// This mock's `DeviceSecret`, for pairing a [MockBarnardIdentity] with
+  /// the same root secret (test/demo convenience only — a real
+  /// `DeviceSecret` never leaves the SDK this way).
+  Uint8List get deviceSecretForTesting => Uint8List.fromList(_deviceSecret);
+
   @override
   List<BarnardDebugEvent> getDebugBuffer({int? limit}) =>
       _debugBuffer.toList(limit: limit);

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard_identity.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard_identity.dart
@@ -1,0 +1,47 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import "dart:math";
+import "dart:typed_data";
+
+import "../../domain/secp256k1.dart";
+import "../../domain/signing.dart";
+import "../../usecase/barnard_identity.dart";
+import "mock_barnard.dart";
+
+/// Mock/local implementation of [BarnardIdentity]. Computes the per-event
+/// signing key entirely in Dart from a locally held `DeviceSecret` — no
+/// platform channel involved.
+class MockBarnardIdentity implements BarnardIdentity {
+  MockBarnardIdentity({Uint8List? deviceSecret})
+    : _deviceSecret = deviceSecret ?? _generateRandomBytes(32);
+
+  /// Pair a [MockBarnardIdentity] with the same `DeviceSecret` as [client],
+  /// so the signing identity and the sensing client are rooted in the same
+  /// device secret (as they would be for a real device).
+  factory MockBarnardIdentity.pairedWith(MockBarnard client) {
+    return MockBarnardIdentity(deviceSecret: client.deviceSecretForTesting);
+  }
+
+  final Uint8List _deviceSecret;
+
+  @override
+  Future<Uint8List> signingPublicKey(String eventCode) async {
+    return deriveSigningKeyPair(_deviceSecret, eventCode).publicKeyCompressed;
+  }
+
+  @override
+  Future<BarnardSignature> sign(String eventCode, Uint8List bytes) async {
+    final RecoverableSignature sig = signWithDeviceSecret(
+      deviceSecret: _deviceSecret,
+      eventCode: eventCode,
+      message: bytes,
+    );
+    return BarnardSignature(r: sig.r, s: sig.s, v: sig.v);
+  }
+}
+
+Uint8List _generateRandomBytes(int length) {
+  final random = Random.secure();
+  return Uint8List.fromList(List<int>.generate(length, (_) => random.nextInt(256)));
+}

--- a/packages/dart/barnard/lib/src/usecase/barnard_identity.dart
+++ b/packages/dart/barnard/lib/src/usecase/barnard_identity.dart
@@ -1,0 +1,50 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import "dart:typed_data";
+
+/// A recoverable ECDSA (secp256k1) signature: `(r, s, v)`.
+///
+/// `v` is the recovery id (`0` or `1`) that lets a verifier recover the
+/// signing public key from `(r, s)` and the message hash alone
+/// ("ecrecover"-compatible).
+class BarnardSignature {
+  const BarnardSignature({required this.r, required this.s, required this.v});
+
+  /// 32-byte big-endian `r`.
+  final Uint8List r;
+
+  /// 32-byte big-endian `s` (canonical / low-S form).
+  final Uint8List s;
+
+  /// Recovery id: `0` or `1`.
+  final int v;
+}
+
+/// Barnard's per-event device signing identity (barnard#65).
+///
+/// This is a **sibling module to [BarnardClient]**, not part of it — the
+/// sensing SDK is transport-only by charter
+/// (`specs/001-barnard-core-sdk/spec.md`). `BarnardIdentity` owns the
+/// device's signing capability instead: a per-event, `DeviceSecret`-rooted
+/// secp256k1 keypair whose private key never leaves the SDK (the opposite
+/// of `BarnardClient.exportCurrentTek`).
+///
+/// The signing public key is **not** a cross-event-stable identifier: it
+/// is stable only within one `eventCode` and differs across `eventCode`s,
+/// so it cannot be used to correlate a participant's activity across
+/// events (see barnard#65 for the threat this avoids).
+abstract class BarnardIdentity {
+  /// The per-event signing public key, SEC1-compressed (33 bytes).
+  ///
+  /// Same value for every call with the same [eventCode]; a different
+  /// value for every other [eventCode]. Re-derivable offline at any time
+  /// from `DeviceSecret` — it never "expires".
+  Future<Uint8List> signingPublicKey(String eventCode);
+
+  /// Sign [bytes] with the per-event signing key for [eventCode].
+  ///
+  /// The private key never leaves the SDK; only the resulting signature is
+  /// returned. [bytes] is hashed (SHA-256) before ECDSA signing.
+  Future<BarnardSignature> sign(String eventCode, Uint8List bytes);
+}

--- a/packages/dart/barnard/test/signing_test.dart
+++ b/packages/dart/barnard/test/signing_test.dart
@@ -1,0 +1,174 @@
+import "dart:typed_data";
+
+import "package:barnard/barnard.dart";
+import "package:barnard/mock_barnard.dart";
+import "package:test/test.dart";
+
+Uint8List _deviceSecret(int seed) =>
+    Uint8List.fromList(List<int>.generate(32, (i) => (i * 7 + seed) & 0xff));
+
+void main() {
+  group("per-event signing key derivation (barnard#65)", () {
+    test("same device + same event => identical signing public key", () {
+      final secret = _deviceSecret(1);
+      final a = deriveSigningKeyPair(secret, "event-A");
+      final b = deriveSigningKeyPair(secret, "event-A");
+
+      expect(a.publicKeyCompressed, equals(b.publicKeyCompressed));
+      expect(a.privateKey, equals(b.privateKey));
+    });
+
+    test("same device + different event => different signing public key", () {
+      final secret = _deviceSecret(1);
+      final a = deriveSigningKeyPair(secret, "event-A");
+      final b = deriveSigningKeyPair(secret, "event-B");
+
+      expect(a.publicKeyCompressed, isNot(equals(b.publicKeyCompressed)));
+    });
+
+    test("no cross-event-stable public key: distinct events across many "
+        "derivations never collide and never repeat a prior event's key", () {
+      final secret = _deviceSecret(42);
+      final seen = <String>{};
+      for (int i = 0; i < 50; i++) {
+        final pub = deriveSigningKeyPair(secret, "event-$i").publicKeyCompressed;
+        final hex = bytesToHex(pub);
+        expect(seen.contains(hex), isFalse, reason: "event-$i collided with a prior event's key");
+        seen.add(hex);
+      }
+    });
+
+    test("re-derivable offline: recomputing from DeviceSecret alone reproduces the same key", () {
+      final secret = _deviceSecret(7);
+      final first = deriveSigningKeyPair(secret, "reunion-2026");
+      // Simulate "later, offline" by deriving again from scratch.
+      final second = deriveSigningKeyPair(Uint8List.fromList(secret), "reunion-2026");
+
+      expect(first.publicKeyCompressed, equals(second.publicKeyCompressed));
+    });
+
+    test("different devices => different signing keys for the same event", () {
+      final a = deriveSigningKeyPair(_deviceSecret(1), "shared-event");
+      final b = deriveSigningKeyPair(_deviceSecret(2), "shared-event");
+
+      expect(a.publicKeyCompressed, isNot(equals(b.publicKeyCompressed)));
+    });
+
+    test("domain separation from TEK/RPIK: signing key differs from the TEK-derived key material", () {
+      final secret = _deviceSecret(3);
+      const eventCode = "domain-sep-event";
+
+      final signingPub = deriveSigningKeyPair(secret, eventCode).publicKeyCompressed;
+      final tek = BarnardCrypto.deriveTekForEvent(secret, eventCode);
+      final rpik = BarnardCrypto.deriveRpikFromTek(tek);
+
+      // The signing key material must not equal (nor be trivially
+      // derivable as a prefix/suffix of) the TEK or RPIK: different HKDF
+      // `info` strings feed into independent HKDF outputs.
+      expect(bytesToHex(signingPub), isNot(contains(bytesToHex(tek))));
+      expect(bytesToHex(signingPub), isNot(contains(bytesToHex(rpik))));
+      expect(tek, isNot(equals(rpik)));
+    });
+
+    test("signing key is not cross-computable from TEK: same IKM, different info, different HKDF output", () {
+      final secret = _deviceSecret(9);
+      const eventCode = "cross-compute-event";
+
+      // TEK uses info="barnard-tek"; signing key uses info="barnard-sign".
+      // Prove they diverge even though both are HKDF(DeviceSecret||EventCode, ...).
+      final tekSeed = hkdfSha256(
+        ikm: _concat(secret, eventCode),
+        info: Uint8List.fromList("barnard-tek".codeUnits),
+        length: 32,
+      );
+      final signSeed = hkdfSha256(
+        ikm: _concat(secret, eventCode),
+        info: Uint8List.fromList(signingKeyInfo.codeUnits),
+        length: 32,
+      );
+
+      expect(tekSeed, isNot(equals(signSeed)));
+    });
+  });
+
+  group("recoverable (ecrecover-able) secp256k1 signatures", () {
+    test("signature recovers the exact signing public key from (r, s, v)", () {
+      final secret = _deviceSecret(5);
+      const eventCode = "ecrecover-event";
+      final keyPair = deriveSigningKeyPair(secret, eventCode);
+      final message = Uint8List.fromList("hello barnard".codeUnits);
+      final messageHash = sha256(message);
+
+      final sig = signRecoverable(keyPair.privateKey, messageHash);
+      final recovered = recoverPublicKey(sig, messageHash);
+
+      expect(recovered, isNotNull);
+      expect(recovered, equals(keyPair.publicKeyCompressed));
+    });
+
+    test("recovery fails (does not silently match) against a tampered message", () {
+      final secret = _deviceSecret(6);
+      const eventCode = "tamper-event";
+      final keyPair = deriveSigningKeyPair(secret, eventCode);
+      final message = Uint8List.fromList("original".codeUnits);
+      final tampered = Uint8List.fromList("tampered!".codeUnits);
+
+      final sig = signRecoverable(keyPair.privateKey, sha256(message));
+      final recovered = recoverPublicKey(sig, sha256(tampered));
+
+      expect(recovered, isNot(equals(keyPair.publicKeyCompressed)));
+    });
+
+    test("signature is 32/32-byte r/s with recovery id in {0, 1}", () {
+      final secret = _deviceSecret(8);
+      final keyPair = deriveSigningKeyPair(secret, "shape-event");
+      final sig = signRecoverable(keyPair.privateKey, sha256(Uint8List.fromList([1, 2, 3])));
+
+      expect(sig.r.length, equals(32));
+      expect(sig.s.length, equals(32));
+      expect(sig.v, anyOf(equals(0), equals(1)));
+    });
+  });
+
+  group("BarnardIdentity (sibling module to BarnardClient)", () {
+    test("MockBarnardIdentity.sign produces an ecrecover-able signature bound to eventCode", () async {
+      final identity = MockBarnardIdentity();
+      const eventCode = "identity-module-event";
+      final pubKey = await identity.signingPublicKey(eventCode);
+      final message = Uint8List.fromList("observation-tuple".codeUnits);
+
+      final sig = await identity.sign(eventCode, message);
+      final recovered = recoverPublicKey(
+        RecoverableSignature(r: sig.r, s: sig.s, v: sig.v),
+        sha256(message),
+      );
+
+      expect(recovered, equals(pubKey));
+    });
+
+    test("MockBarnardIdentity never exposes a private key — only public key + signatures", () {
+      // Compile-time API check: BarnardIdentity has no private-key-shaped
+      // accessor (the opposite of exportCurrentTek on BarnardClient).
+      final identity = MockBarnardIdentity();
+      expect(identity, isA<BarnardIdentity>());
+    });
+
+    test("MockBarnardIdentity.pairedWith(MockBarnard) shares the sensing client's DeviceSecret", () async {
+      final client = MockBarnard();
+      final identity = MockBarnardIdentity.pairedWith(client);
+      final direct = MockBarnardIdentity(deviceSecret: client.deviceSecretForTesting);
+
+      final a = await identity.signingPublicKey("paired-event");
+      final b = await direct.signingPublicKey("paired-event");
+      expect(a, equals(b));
+    });
+  });
+}
+
+Uint8List _concat(Uint8List a, String eventCode) {
+  final codeBytes = Uint8List.fromList(eventCode.codeUnits);
+  final out = Uint8List(a.length + codeBytes.length);
+  out.setRange(0, a.length, a);
+  out.setRange(a.length, out.length, codeBytes);
+  return out;
+}

--- a/packages/react-native/barnard/__tests__/BarnardIdentity.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardIdentity.test.ts
@@ -1,0 +1,93 @@
+export {};
+
+jest.mock('react-native', () => {
+  const BarnardIdentity = {
+    signingPublicKey: jest.fn().mockImplementation((eventCode: string) => {
+      // Deterministic per-eventCode stub good enough to test module wiring
+      // (real per-event uniqueness/domain-separation is proven in
+      // packages/dart/barnard/test/signing_test.dart and the Kotlin/Swift
+      // native unit tests, which exercise the real secp256k1 derivation).
+      const hash = Array.from(eventCode).reduce((acc, c) => (acc * 31 + c.charCodeAt(0)) >>> 0, 7);
+      return Promise.resolve('02' + hash.toString(16).padStart(64, '0'));
+    }),
+    sign: jest.fn().mockResolvedValue({
+      r: 'aa'.repeat(32),
+      s: 'bb'.repeat(32),
+      v: 1,
+    }),
+  };
+
+  return {
+    NativeModules: { BarnardIdentity },
+  };
+});
+
+const setup = () => {
+  jest.resetModules();
+  const reactNative = require('react-native') as {
+    NativeModules: { BarnardIdentity: Record<string, jest.Mock> };
+  };
+  const { BarnardIdentity } = require('../src/BarnardIdentity') as {
+    BarnardIdentity: new () => {
+      signingPublicKey: (eventCode: string) => Promise<string>;
+      sign: (eventCode: string, bytesHex: string) => Promise<{ r: string; s: string; v: number }>;
+    };
+  };
+
+  return {
+    BarnardIdentity,
+    nativeModule: reactNative.NativeModules.BarnardIdentity,
+  };
+};
+
+describe('BarnardIdentity (sibling module to BarnardManager)', () => {
+  it('delegates signingPublicKey to the native module, keyed by eventCode', async () => {
+    const { BarnardIdentity, nativeModule } = setup();
+    const identity = new BarnardIdentity();
+
+    await identity.signingPublicKey('event-A');
+
+    expect(nativeModule.signingPublicKey).toHaveBeenCalledWith('event-A');
+    expect(nativeModule.signingPublicKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a different signing public key for a different eventCode', async () => {
+    const { BarnardIdentity } = setup();
+    const identity = new BarnardIdentity();
+
+    const a = await identity.signingPublicKey('event-A');
+    const b = await identity.signingPublicKey('event-B');
+
+    expect(a).not.toBe(b);
+  });
+
+  it('returns the same signing public key for the same eventCode', async () => {
+    const { BarnardIdentity } = setup();
+    const identity = new BarnardIdentity();
+
+    const first = await identity.signingPublicKey('event-A');
+    const second = await identity.signingPublicKey('event-A');
+
+    expect(first).toBe(second);
+  });
+
+  it('delegates sign to the native module and returns a (r, s, v) signature', async () => {
+    const { BarnardIdentity, nativeModule } = setup();
+    const identity = new BarnardIdentity();
+
+    const sig = await identity.sign('event-A', 'deadbeef');
+
+    expect(nativeModule.sign).toHaveBeenCalledWith('event-A', 'deadbeef');
+    expect(sig.r).toMatch(/^[0-9a-f]{64}$/);
+    expect(sig.s).toMatch(/^[0-9a-f]{64}$/);
+    expect([0, 1]).toContain(sig.v);
+  });
+
+  it('exposes no private-key-shaped accessor (opposite of exportCurrentTek)', () => {
+    const { BarnardIdentity } = setup();
+    const identity = new BarnardIdentity();
+
+    expect((identity as unknown as Record<string, unknown>).exportPrivateKey).toBeUndefined();
+    expect((identity as unknown as Record<string, unknown>).privateKey).toBeUndefined();
+  });
+});

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardCrypto.kt
@@ -140,7 +140,7 @@ object BarnardCrypto {
     /** Lowercase-hex encoder for the RN bridge boundary. */
     fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
 
-    private fun hkdfSha256(ikm: ByteArray, info: ByteArray, outputLength: Int): ByteArray {
+    internal fun hkdfSha256(ikm: ByteArray, info: ByteArray, outputLength: Int): ByteArray {
         val salt = ByteArray(32)
         val mac = Mac.getInstance("HmacSHA256")
         mac.init(SecretKeySpec(salt, "HmacSHA256"))

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityModule.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityModule.kt
@@ -1,0 +1,80 @@
+package network.greeting.barnard
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Base64
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import network.greeting.barnard.BarnardCrypto.toHex
+import java.security.MessageDigest
+
+/**
+ * Barnard per-event device signing identity (barnard#65).
+ *
+ * A **module separate from the sensing client** (`BarnardModule`) — its own
+ * RN native module, not part of `BarnardModule`. It shares the same
+ * on-device `DeviceSecret` storage (SharedPreferences key `rpidSeed` in the
+ * `barnard` prefs file) as `BarnardController`, so the signing identity is
+ * rooted in the same secret as the sensing client's TEK, but the private
+ * signing key it derives never crosses the RN bridge — only the public key
+ * and signatures do.
+ */
+class BarnardIdentityModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    private val prefs: SharedPreferences =
+        reactContext.applicationContext.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+
+    override fun getName(): String = "BarnardIdentity"
+
+    @ReactMethod
+    fun signingPublicKey(eventCode: String, promise: Promise) {
+        try {
+            val keyPair = BarnardSigning.deriveSigningKeyPair(getOrCreateDeviceSecret(), eventCode)
+            promise.resolve(keyPair.publicKeyCompressed.toHex())
+        } catch (e: Exception) {
+            promise.reject("E_SIGNING_PUBLIC_KEY", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun sign(eventCode: String, bytesHex: String, promise: Promise) {
+        try {
+            val keyPair = BarnardSigning.deriveSigningKeyPair(getOrCreateDeviceSecret(), eventCode)
+            val messageHash = MessageDigest.getInstance("SHA-256").digest(hexToBytes(bytesHex))
+            val sig = BarnardSigning.signRecoverable(keyPair.privateKey, messageHash)
+
+            val map: WritableMap = com.facebook.react.bridge.Arguments.createMap()
+            map.putString("r", sig.r.toHex())
+            map.putString("s", sig.s.toHex())
+            map.putInt("v", sig.v)
+            promise.resolve(map)
+        } catch (e: Exception) {
+            promise.reject("E_SIGN", e.message, e)
+        }
+    }
+
+    private fun hexToBytes(hex: String): ByteArray {
+        val clean = if (hex.length % 2 == 0) hex else "0$hex"
+        return ByteArray(clean.length / 2) { i ->
+            clean.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+        }
+    }
+
+    // Same storage key as BarnardController.getOrCreateDeviceSecret — see
+    // that class for the rationale (shared DeviceSecret, never exposed).
+    private fun getOrCreateDeviceSecret(): ByteArray {
+        val key = "rpidSeed"
+        val existing = prefs.getString(key, null)
+        if (existing != null) {
+            val bytes = Base64.decode(existing, Base64.DEFAULT)
+            if (bytes.size >= 32) return bytes
+        }
+        val bytes = BarnardCrypto.generateRandomBytes(32)
+        prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
+        return bytes
+    }
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPackage.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardPackage.kt
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.ViewManager
 
 class BarnardPackage : ReactPackage {
     override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
-        return listOf(BarnardModule(reactContext))
+        return listOf(BarnardModule(reactContext), BarnardIdentityModule(reactContext))
     }
 
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
@@ -1,0 +1,260 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.math.BigInteger
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Per-event device signing identity (barnard#65).
+ *
+ * Key derivation chain:
+ * ```
+ * DeviceSecret (32 bytes)
+ *      |
+ *      +-- signSeed = HKDF(DeviceSecret || EventCode, "barnard-sign", 32)
+ *                          |
+ *                          v
+ *                     secp256k1 keypair (signSeed reduced mod curve order)
+ * ```
+ *
+ * Mirrors the TEK event-mode derivation shape
+ * (`TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`) but uses a
+ * distinct HKDF `info` string ("barnard-sign" vs "barnard-tek" / "EN-RPIK")
+ * so the signing key and the TEK/RPIK chain are not cross-computable.
+ *
+ * Implements secp256k1 EC math directly on [BigInteger] (no third-party
+ * crypto dependency): field/point arithmetic, RFC 6979 deterministic
+ * ECDSA, and recovery-id computation for ecrecover-compatible signatures.
+ */
+internal object BarnardSigning {
+    const val signingKeyInfo = "barnard-sign"
+
+    // MARK: - secp256k1 curve parameters
+
+    private val P = BigInteger(
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
+        16,
+    )
+    private val N = BigInteger(
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
+        16,
+    )
+    private val GX = BigInteger(
+        "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
+        16,
+    )
+    private val GY = BigInteger(
+        "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
+        16,
+    )
+    private val G = ECPoint(GX, GY)
+
+    /** An affine point on secp256k1. `null` coordinates represent infinity. */
+    data class ECPoint(val x: BigInteger?, val y: BigInteger?) {
+        val isInfinity: Boolean get() = x == null || y == null
+    }
+
+    private val INFINITY = ECPoint(null, null)
+
+    private fun mod(a: BigInteger): BigInteger = a.mod(P)
+
+    private fun pointDouble(p: ECPoint): ECPoint {
+        if (p.isInfinity || p.y == BigInteger.ZERO) return INFINITY
+        val x = p.x!!
+        val y = p.y!!
+        // slope = (3x^2) / (2y) mod P  (a = 0 for secp256k1)
+        val num = mod(BigInteger.valueOf(3) * x * x)
+        val den = mod(BigInteger.valueOf(2) * y).modInverse(P)
+        val slope = mod(num * den)
+        val x3 = mod(slope * slope - x - x)
+        val y3 = mod(slope * (x - x3) - y)
+        return ECPoint(x3, y3)
+    }
+
+    private fun pointAdd(p1: ECPoint, p2: ECPoint): ECPoint {
+        if (p1.isInfinity) return p2
+        if (p2.isInfinity) return p1
+        if (p1.x == p2.x) {
+            return if (mod(p1.y!! + p2.y!!) == BigInteger.ZERO) INFINITY else pointDouble(p1)
+        }
+        val slope = mod((p2.y!! - p1.y!!) * (p2.x!! - p1.x!!).modInverse(P))
+        val x3 = mod(slope * slope - p1.x - p2.x)
+        val y3 = mod(slope * (p1.x - x3) - p1.y)
+        return ECPoint(x3, y3)
+    }
+
+    private fun scalarMult(k: BigInteger, point: ECPoint): ECPoint {
+        var result = INFINITY
+        var addend = point
+        var scalar = k
+        while (scalar.signum() > 0) {
+            if (scalar.testBit(0)) {
+                result = pointAdd(result, addend)
+            }
+            addend = pointDouble(addend)
+            scalar = scalar.shiftRight(1)
+        }
+        return result
+    }
+
+    /** SEC1-compressed encoding (33 bytes: 0x02/0x03 prefix + 32-byte X). */
+    private fun compress(point: ECPoint): ByteArray {
+        val x = point.x!!
+        val y = point.y!!
+        val prefix: Byte = if (y.testBit(0)) 0x03 else 0x02
+        return byteArrayOf(prefix) + toFixedBytes(x, 32)
+    }
+
+    /** Decompress a point from its X coordinate and Y parity bit. Returns null if X is not on the curve. */
+    private fun decompress(x: BigInteger, yIsOdd: Boolean): ECPoint? {
+        // y^2 = x^3 + 7 mod P
+        val rhs = mod(x.modPow(BigInteger.valueOf(3), P) + BigInteger.valueOf(7))
+        // secp256k1's P is congruent to 3 mod 4, so sqrt(a) = a^((P+1)/4) mod P.
+        val sqrtExp = (P + BigInteger.ONE).shiftRight(2)
+        var y = rhs.modPow(sqrtExp, P)
+        if (mod(y * y) != rhs) return null
+        if (y.testBit(0) != yIsOdd) {
+            y = P - y
+        }
+        return ECPoint(x, y)
+    }
+
+    private fun toFixedBytes(value: BigInteger, length: Int): ByteArray {
+        val raw = value.toByteArray()
+        val trimmed = if (raw.size > length && raw[0] == 0.toByte()) raw.copyOfRange(raw.size - length, raw.size) else raw
+        return when {
+            trimmed.size == length -> trimmed
+            trimmed.size < length -> ByteArray(length - trimmed.size) + trimmed
+            else -> trimmed.copyOfRange(trimmed.size - length, trimmed.size)
+        }
+    }
+
+    private fun bytesToBigInt(bytes: ByteArray): BigInteger = BigInteger(1, bytes)
+
+    // MARK: - Key derivation
+
+    data class SigningKeyPair(val privateKey: BigInteger, val publicKeyCompressed: ByteArray)
+
+    /**
+     * Derive the per-event signing keypair from [deviceSecret] and [eventCode].
+     */
+    fun deriveSigningKeyPair(deviceSecret: ByteArray, eventCode: String): SigningKeyPair {
+        val combined = deviceSecret + eventCode.toByteArray(Charsets.UTF_8)
+        var seed = BarnardCrypto.hkdfSha256(combined, signingKeyInfo.toByteArray(Charsets.UTF_8), 32)
+        var d = bytesToBigInt(seed).mod(N)
+        while (d.signum() == 0) {
+            seed = sha256(seed)
+            d = bytesToBigInt(seed).mod(N)
+        }
+        val q = scalarMult(d, G)
+        return SigningKeyPair(d, compress(q))
+    }
+
+    private fun sha256(bytes: ByteArray): ByteArray =
+        java.security.MessageDigest.getInstance("SHA-256").digest(bytes)
+
+    // MARK: - Recoverable ECDSA (RFC 6979 deterministic k)
+
+    data class RecoverableSignature(val r: ByteArray, val s: ByteArray, val v: Int)
+
+    private fun hmacSha256(key: ByteArray, data: ByteArray): ByteArray {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key, "HmacSHA256"))
+        return mac.doFinal(data)
+    }
+
+    /** RFC 6979 deterministic `k` (HMAC-SHA256, qlen == hlen == 32 bytes for secp256k1/SHA-256). */
+    private fun deterministicK(privateKey: BigInteger, messageHash32: ByteArray): BigInteger {
+        val x = toFixedBytes(privateKey, 32)
+        val h1 = toFixedBytes(bytesToBigInt(messageHash32).mod(N), 32)
+
+        var v = ByteArray(32) { 0x01 }
+        var k = ByteArray(32) { 0x00 }
+
+        k = hmacSha256(k, v + byteArrayOf(0x00) + x + h1)
+        v = hmacSha256(k, v)
+        k = hmacSha256(k, v + byteArrayOf(0x01) + x + h1)
+        v = hmacSha256(k, v)
+
+        while (true) {
+            v = hmacSha256(k, v)
+            val kCandidate = bytesToBigInt(v)
+            if (kCandidate.signum() > 0 && kCandidate < N) {
+                return kCandidate
+            }
+            k = hmacSha256(k, v + byteArrayOf(0x00))
+            v = hmacSha256(k, v)
+        }
+    }
+
+    /**
+     * Sign a 32-byte message hash with [privateKey], returning a recoverable
+     * signature `(r, s, v)`. Normalizes `s` to the lower half of the curve
+     * order (canonical / "low-S" form) and searches for the recovery id
+     * (`0` or `1`) that recovers the caller's own public key — i.e. after
+     * low-S normalization, not before.
+     */
+    fun signRecoverable(privateKey: BigInteger, messageHash32: ByteArray): RecoverableSignature {
+        require(messageHash32.size == 32) { "messageHash must be 32 bytes" }
+
+        val e = bytesToBigInt(messageHash32).mod(N)
+        val expectedPub = compress(scalarMult(privateKey, G))
+
+        var r: BigInteger
+        var s: BigInteger
+        var k: BigInteger
+        while (true) {
+            k = deterministicK(privateKey, messageHash32)
+            val rPoint = scalarMult(k, G)
+            r = rPoint.x!!.mod(N)
+            if (r.signum() == 0) continue
+            s = (k.modInverse(N) * (e + privateKey * r)).mod(N)
+            if (s.signum() == 0) continue
+            break
+        }
+
+        val halfOrder = N.shiftRight(1)
+        if (s > halfOrder) {
+            s = N - s
+        }
+
+        var recoveryId = -1
+        for (id in 0..3) {
+            val candidate = recoverPublicKey(id, r, s, messageHash32)
+            if (candidate != null && candidate.contentEquals(expectedPub)) {
+                recoveryId = id
+                break
+            }
+        }
+        check(recoveryId != -1) { "signRecoverable: could not determine recovery id" }
+
+        return RecoverableSignature(toFixedBytes(r, 32), toFixedBytes(s, 32), recoveryId)
+    }
+
+    /** Recover the SEC1-compressed public key from `(recId, r, s)` and the signed message hash. */
+    fun recoverPublicKey(recId: Int, r: BigInteger, s: BigInteger, messageHash32: ByteArray): ByteArray? {
+        val i = BigInteger.valueOf((recId / 2).toLong())
+        val x = r + i * N
+        if (x >= P) return null
+
+        val rPoint = decompress(x, (recId and 1) == 1) ?: return null
+
+        val nTimesR = scalarMult(N, rPoint)
+        if (!nTimesR.isInfinity) return null
+
+        val e = bytesToBigInt(messageHash32).mod(N)
+        val eNeg = N - e.mod(N)
+        val rInv = r.modInverse(N)
+        val srInv = (rInv * s).mod(N)
+        val eInvrInv = (rInv * eNeg).mod(N)
+
+        val term1 = scalarMult(eInvrInv, G)
+        val term2 = scalarMult(srInv, rPoint)
+        val point = pointAdd(term1, term2)
+        if (point.isInfinity) return null
+        return compress(point)
+    }
+}

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardSigningTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardSigningTest.kt
@@ -1,0 +1,129 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.security.MessageDigest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private fun deviceSecret(seed: Int): ByteArray = ByteArray(32) { ((it * 7 + seed) and 0xff).toByte() }
+
+private fun sha256(bytes: ByteArray): ByteArray = MessageDigest.getInstance("SHA-256").digest(bytes)
+
+class BarnardSigningTest {
+
+    @Test
+    fun sameDeviceSameEvent_producesIdenticalSigningKey() {
+        val secret = deviceSecret(1)
+        val a = BarnardSigning.deriveSigningKeyPair(secret, "event-A")
+        val b = BarnardSigning.deriveSigningKeyPair(secret, "event-A")
+
+        assertArrayEquals(a.publicKeyCompressed, b.publicKeyCompressed)
+        assertEquals(a.privateKey, b.privateKey)
+    }
+
+    @Test
+    fun sameDeviceDifferentEvent_producesDifferentSigningKey() {
+        val secret = deviceSecret(1)
+        val a = BarnardSigning.deriveSigningKeyPair(secret, "event-A")
+        val b = BarnardSigning.deriveSigningKeyPair(secret, "event-B")
+
+        assertFalse(a.publicKeyCompressed.contentEquals(b.publicKeyCompressed))
+    }
+
+    @Test
+    fun noCrossEventStableKey_manyEventsNeverCollide() {
+        val secret = deviceSecret(42)
+        val seen = HashSet<String>()
+        for (i in 0 until 50) {
+            val pub = BarnardSigning.deriveSigningKeyPair(secret, "event-$i").publicKeyCompressed
+            val hex = pub.joinToString("") { "%02x".format(it) }
+            assertTrue("event-$i collided with a prior event's key", seen.add(hex))
+        }
+    }
+
+    @Test
+    fun reDerivableOffline_reproducesSameKeyFromDeviceSecretAlone() {
+        val secret = deviceSecret(7)
+        val first = BarnardSigning.deriveSigningKeyPair(secret, "reunion-2026")
+        val second = BarnardSigning.deriveSigningKeyPair(secret.copyOf(), "reunion-2026")
+
+        assertArrayEquals(first.publicKeyCompressed, second.publicKeyCompressed)
+    }
+
+    @Test
+    fun differentDevices_produceDifferentKeysForSameEvent() {
+        val a = BarnardSigning.deriveSigningKeyPair(deviceSecret(1), "shared-event")
+        val b = BarnardSigning.deriveSigningKeyPair(deviceSecret(2), "shared-event")
+
+        assertFalse(a.publicKeyCompressed.contentEquals(b.publicKeyCompressed))
+    }
+
+    @Test
+    fun domainSeparatedFromTekRpik() {
+        val secret = deviceSecret(3)
+        val eventCode = "domain-sep-event"
+
+        val signingPub = BarnardSigning.deriveSigningKeyPair(secret, eventCode).publicKeyCompressed
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+
+        assertFalse(signingPub.contentEquals(tek))
+        assertFalse(signingPub.contentEquals(rpik))
+        assertFalse(tek.contentEquals(rpik))
+    }
+
+    @Test
+    fun signatureRecoversExactSigningPublicKey() {
+        val secret = deviceSecret(5)
+        val eventCode = "ecrecover-event"
+        val keyPair = BarnardSigning.deriveSigningKeyPair(secret, eventCode)
+        val message = "hello barnard".toByteArray(Charsets.UTF_8)
+        val messageHash = sha256(message)
+
+        val sig = BarnardSigning.signRecoverable(keyPair.privateKey, messageHash)
+        val recovered = BarnardSigning.recoverPublicKey(
+            sig.v,
+            java.math.BigInteger(1, sig.r),
+            java.math.BigInteger(1, sig.s),
+            messageHash,
+        )
+
+        assertNotNull(recovered)
+        assertArrayEquals(keyPair.publicKeyCompressed, recovered)
+    }
+
+    @Test
+    fun recoveryFailsAgainstTamperedMessage() {
+        val secret = deviceSecret(6)
+        val eventCode = "tamper-event"
+        val keyPair = BarnardSigning.deriveSigningKeyPair(secret, eventCode)
+        val original = "original".toByteArray(Charsets.UTF_8)
+        val tampered = "tampered!".toByteArray(Charsets.UTF_8)
+
+        val sig = BarnardSigning.signRecoverable(keyPair.privateKey, sha256(original))
+        val recovered = BarnardSigning.recoverPublicKey(
+            sig.v,
+            java.math.BigInteger(1, sig.r),
+            java.math.BigInteger(1, sig.s),
+            sha256(tampered),
+        )
+
+        assertFalse(keyPair.publicKeyCompressed.contentEquals(recovered ?: ByteArray(0)))
+    }
+
+    @Test
+    fun signatureShape_is32ByteRs_withRecoveryIdInRange() {
+        val keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret(8), "shape-event")
+        val sig = BarnardSigning.signRecoverable(keyPair.privateKey, sha256(byteArrayOf(1, 2, 3)))
+
+        assertEquals(32, sig.r.size)
+        assertEquals(32, sig.s.size)
+        assertTrue(sig.v == 0 || sig.v == 1)
+    }
+}

--- a/packages/react-native/barnard/ios/BarnardIdentity.m
+++ b/packages/react-native/barnard/ios/BarnardIdentity.m
@@ -1,0 +1,19 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(BarnardIdentity, NSObject)
+
+RCT_EXTERN_METHOD(signingPublicKey:(NSString *)eventCode
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(sign:(NSString *)eventCode
+                  bytesHex:(NSString *)bytesHex
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+@end

--- a/packages/react-native/barnard/ios/BarnardIdentity.swift
+++ b/packages/react-native/barnard/ios/BarnardIdentity.swift
@@ -1,0 +1,67 @@
+import CryptoKit
+import Foundation
+import React
+
+/// Barnard per-event device signing identity (barnard#65).
+///
+/// A **module separate from the sensing client** (`Barnard`) — its own RN
+/// native module, not part of `Barnard`. It shares the same on-device
+/// `DeviceSecret` storage (`UserDefaults` key `barnard.rpidSeed`) as
+/// `BarnardRpidGenerator`, so the signing identity is rooted in the same
+/// secret as the sensing client's TEK, but the private signing key it
+/// derives never crosses the RN bridge — only the public key and
+/// signatures do.
+@objc(BarnardIdentity)
+class BarnardIdentity: NSObject {
+  private let deviceSecretKey = "barnard.rpidSeed"
+
+  @objc static func requiresMainQueueSetup() -> Bool { false }
+
+  @objc(signingPublicKey:resolve:reject:)
+  func signingPublicKey(_ eventCode: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
+    resolve(keyPair.publicKeyCompressed.hexString)
+  }
+
+  @objc(sign:bytesHex:resolve:reject:)
+  func sign(
+    _ eventCode: String,
+    bytesHex: String,
+    resolve: RCTPromiseResolveBlock,
+    reject: RCTPromiseRejectBlock
+  ) {
+    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
+    let messageHash = Data(SHA256.hash(data: hexToBytes(bytesHex)))
+    let sig = BarnardSigning.signRecoverable(privateKey: keyPair.privateKey, messageHash32: messageHash)
+    resolve([
+      "r": sig.r.hexString,
+      "s": sig.s.hexString,
+      "v": sig.v,
+    ])
+  }
+
+  private func hexToBytes(_ hex: String) -> Data {
+    var clean = hex
+    if clean.count % 2 != 0 { clean = "0" + clean }
+    var bytes = [UInt8]()
+    var idx = clean.startIndex
+    while idx < clean.endIndex {
+      let next = clean.index(idx, offsetBy: 2)
+      bytes.append(UInt8(clean[idx..<next], radix: 16) ?? 0)
+      idx = next
+    }
+    return Data(bytes)
+  }
+
+  // Same storage key as BarnardRpidGenerator.getOrCreateDeviceSecret — see
+  // that class for the rationale (shared DeviceSecret, never exposed).
+  private func getOrCreateDeviceSecret() -> Data {
+    let defaults = UserDefaults.standard
+    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
+      return existing
+    }
+    let newSecret = BarnardCrypto.generateRandomBytes(32)
+    defaults.set(newSecret, forKey: deviceSecretKey)
+    return newSecret
+  }
+}

--- a/packages/react-native/barnard/ios/BarnardSigning.swift
+++ b/packages/react-native/barnard/ios/BarnardSigning.swift
@@ -1,0 +1,167 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import Foundation
+
+/// Per-event device signing identity (barnard#65).
+///
+/// Key derivation chain:
+/// ```
+/// DeviceSecret (32 bytes)
+///      |
+///      +-- signSeed = HKDF(DeviceSecret || EventCode, "barnard-sign", 32)
+///                          |
+///                          v
+///                     secp256k1 keypair (signSeed reduced mod curve order)
+/// ```
+///
+/// Mirrors the TEK event-mode derivation shape
+/// (`TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`, see
+/// `BarnardCrypto.deriveTekForEvent`) but uses a distinct HKDF `info`
+/// string ("barnard-sign" vs "barnard-tek" / "EN-RPIK") so the signing key
+/// and the TEK/RPIK chain are not cross-computable.
+///
+/// iOS has no system-provided secp256k1 (CryptoKit only covers P-256/384/521
+/// and Curve25519), so this implements the minimal field/point arithmetic
+/// and RFC 6979 deterministic ECDSA directly on a fixed-width 256-bit
+/// integer. It has been cross-verified byte-for-byte against the Dart
+/// (`package:pointycastle`) and Kotlin (`java.math.BigInteger`)
+/// implementations of the same algorithm for the same test vectors.
+enum BarnardSigning {
+  static let signingKeyInfo = "barnard-sign"
+
+  struct SigningKeyPair {
+    let privateKey: Secp256k1.UInt256
+    let publicKeyCompressed: Data
+  }
+
+  struct RecoverableSignature {
+    let r: Data
+    let s: Data
+    let v: Int
+  }
+
+  /// Derive the per-event signing keypair from `deviceSecret` and `eventCode`.
+  static func deriveSigningKeyPair(deviceSecret: Data, eventCode: String) -> SigningKeyPair {
+    let eventCodeData = eventCode.data(using: .utf8) ?? Data()
+    var combined = deviceSecret
+    combined.append(eventCodeData)
+
+    let key = SymmetricKey(data: combined)
+    var seed = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: signingKeyInfo.data(using: .utf8)!,
+      outputByteCount: 32
+    ).withUnsafeBytes { Data($0) }
+
+    var d = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: seed), Secp256k1.N)
+    while d.isZero {
+      seed = Data(SHA256.hash(data: seed))
+      d = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: seed), Secp256k1.N)
+    }
+
+    let q = Secp256k1.scalarMult(d, Secp256k1.G)
+    return SigningKeyPair(privateKey: d, publicKeyCompressed: Secp256k1.compress(q))
+  }
+
+  /// Sign a 32-byte message hash with `privateKey`, returning a recoverable
+  /// signature `(r, s, v)`. Deterministic (RFC 6979 / HMAC-SHA256 `k`),
+  /// normalizes `s` to the lower half of the curve order (canonical /
+  /// "low-S" form), and searches for the recovery id (`0` or `1`) against
+  /// the caller's own public key.
+  static func signRecoverable(privateKey: Secp256k1.UInt256, messageHash32: Data) -> RecoverableSignature {
+    precondition(messageHash32.count == 32, "messageHash must be 32 bytes")
+
+    let e = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N)
+    let expectedPub = Secp256k1.compress(Secp256k1.scalarMult(privateKey, Secp256k1.G))
+
+    var r = Secp256k1.UInt256.zero
+    var s = Secp256k1.UInt256.zero
+    while true {
+      let k = deterministicK(privateKey: privateKey, messageHash32: messageHash32)
+      let rPoint = Secp256k1.scalarMult(k, Secp256k1.G)
+      guard let rx = rPoint.x else { continue }
+      r = Secp256k1.Field.reduceOnce(rx, Secp256k1.N)
+      if r.isZero { continue }
+      let kInv = Secp256k1.Field.invMod(k, Secp256k1.N)
+      s = Secp256k1.Field.mulMod(
+        kInv,
+        Secp256k1.Field.addMod(e, Secp256k1.Field.mulMod(privateKey, r, Secp256k1.N), Secp256k1.N),
+        Secp256k1.N
+      )
+      if s.isZero { continue }
+      break
+    }
+
+    let halfOrder = Secp256k1.N.shiftedRight1()
+    if s > halfOrder {
+      s = Secp256k1.N.subtracting(s)
+    }
+
+    var recoveryId = -1
+    for id in 0..<4 {
+      if let candidate = recoverPublicKey(recId: id, r: r, s: s, messageHash32: messageHash32),
+        candidate == expectedPub
+      {
+        recoveryId = id
+        break
+      }
+    }
+    precondition(recoveryId != -1, "signRecoverable: could not determine recovery id")
+
+    return RecoverableSignature(r: r.data, s: s.data, v: recoveryId)
+  }
+
+  /// Recover the SEC1-compressed public key from `(recId, r, s)` and the
+  /// signed message hash. Returns nil if the signature/recovery id is
+  /// invalid.
+  static func recoverPublicKey(recId: Int, r: Secp256k1.UInt256, s: Secp256k1.UInt256, messageHash32: Data) -> Data? {
+    guard recId / 2 == 0 else { return nil }
+    if r >= Secp256k1.P { return nil }
+    guard let rPoint = Secp256k1.decompress(x: r, yIsOdd: (recId & 1) == 1) else { return nil }
+    // secp256k1 has cofactor 1: every point satisfying the curve equation
+    // already has order N, so the "N*R == infinity" order check other
+    // implementations run here is mathematically redundant and skipped.
+
+    let e = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N)
+    let eNeg = Secp256k1.N.subtracting(e)
+    let rInv = Secp256k1.Field.invMod(r, Secp256k1.N)
+    let srInv = Secp256k1.Field.mulMod(rInv, s, Secp256k1.N)
+    let eInvrInv = Secp256k1.Field.mulMod(rInv, eNeg, Secp256k1.N)
+
+    let term1 = Secp256k1.scalarMult(eInvrInv, Secp256k1.G)
+    let term2 = Secp256k1.scalarMult(srInv, rPoint)
+    let point = Secp256k1.pointAdd(term1, term2)
+    if point.isInfinity { return nil }
+    return Secp256k1.compress(point)
+  }
+
+  /// RFC 6979 deterministic `k` (HMAC-SHA256; qlen == hlen == 32 bytes for secp256k1/SHA-256).
+  private static func deterministicK(privateKey: Secp256k1.UInt256, messageHash32: Data) -> Secp256k1.UInt256 {
+    let x = privateKey.data
+    let h1 = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N).data
+
+    func hmac(_ key: Data, _ data: Data) -> Data {
+      Data(HMAC<SHA256>.authenticationCode(for: data, using: SymmetricKey(data: key)))
+    }
+
+    var v = Data(repeating: 0x01, count: 32)
+    var k = Data(repeating: 0x00, count: 32)
+
+    k = hmac(k, v + Data([0x00]) + x + h1)
+    v = hmac(k, v)
+    k = hmac(k, v + Data([0x01]) + x + h1)
+    v = hmac(k, v)
+
+    while true {
+      v = hmac(k, v)
+      let candidate = Secp256k1.UInt256(data: v)
+      if !candidate.isZero && candidate < Secp256k1.N {
+        return candidate
+      }
+      k = hmac(k, v + Data([0x00]))
+      v = hmac(k, v)
+    }
+  }
+}

--- a/packages/react-native/barnard/ios/Secp256k1.swift
+++ b/packages/react-native/barnard/ios/Secp256k1.swift
@@ -1,0 +1,274 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+
+/// Minimal secp256k1 field/point arithmetic and a fixed-width 256-bit
+/// integer, used by `BarnardSigning` (barnard#65) for recoverable
+/// ("ecrecover"-able) ECDSA. iOS has no system-provided secp256k1 curve
+/// (CryptoKit covers P-256/384/521 and Curve25519 only).
+enum Secp256k1 {
+  /// Fixed-width 256-bit unsigned integer for secp256k1 field/scalar
+  /// arithmetic. Stored as 4 big-endian `UInt64` limbs (`limbs.0` most
+  /// significant).
+  struct UInt256: Comparable {
+    var limbs: (UInt64, UInt64, UInt64, UInt64)
+
+    static func == (lhs: UInt256, rhs: UInt256) -> Bool {
+      lhs.limbs == rhs.limbs
+    }
+
+    static let zero = UInt256(limbs: (0, 0, 0, 0))
+    static let one = UInt256(limbs: (0, 0, 0, 1))
+
+    init(limbs: (UInt64, UInt64, UInt64, UInt64)) {
+      self.limbs = limbs
+    }
+
+    init?(hex: String) {
+      var h = hex
+      if h.count > 64 { return nil }
+      while h.count < 64 { h = "0" + h }
+      var parts: [UInt64] = []
+      var idx = h.startIndex
+      for _ in 0..<4 {
+        let next = h.index(idx, offsetBy: 16)
+        guard let v = UInt64(h[idx..<next], radix: 16) else { return nil }
+        parts.append(v)
+        idx = next
+      }
+      self.limbs = (parts[0], parts[1], parts[2], parts[3])
+    }
+
+    /// Interprets `data` as a big-endian integer, truncating/left-padding
+    /// to 32 bytes if the input isn't exactly 32 bytes.
+    init(data: Data) {
+      var bytes = [UInt8](data)
+      if bytes.count > 32 {
+        bytes = Array(bytes.suffix(32))
+      } else if bytes.count < 32 {
+        bytes = [UInt8](repeating: 0, count: 32 - bytes.count) + bytes
+      }
+      func limb(_ range: Range<Int>) -> UInt64 {
+        var v: UInt64 = 0
+        for i in range { v = (v << 8) | UInt64(bytes[i]) }
+        return v
+      }
+      self.limbs = (limb(0..<8), limb(8..<16), limb(16..<24), limb(24..<32))
+    }
+
+    /// Big-endian 32-byte encoding.
+    var data: Data {
+      var out = [UInt8](repeating: 0, count: 32)
+      let parts = [limbs.0, limbs.1, limbs.2, limbs.3]
+      for (i, part) in parts.enumerated() {
+        for j in 0..<8 {
+          out[i * 8 + j] = UInt8((part >> (56 - 8 * j)) & 0xff)
+        }
+      }
+      return Data(out)
+    }
+
+    static func < (lhs: UInt256, rhs: UInt256) -> Bool {
+      if lhs.limbs.0 != rhs.limbs.0 { return lhs.limbs.0 < rhs.limbs.0 }
+      if lhs.limbs.1 != rhs.limbs.1 { return lhs.limbs.1 < rhs.limbs.1 }
+      if lhs.limbs.2 != rhs.limbs.2 { return lhs.limbs.2 < rhs.limbs.2 }
+      return lhs.limbs.3 < rhs.limbs.3
+    }
+
+    var isZero: Bool { self == .zero }
+
+    @inline(__always)
+    func testBit(_ n: Int) -> Bool {
+      let bitIndex = n % 64
+      switch n / 64 {
+      case 0: return (limbs.3 >> bitIndex) & 1 == 1
+      case 1: return (limbs.2 >> bitIndex) & 1 == 1
+      case 2: return (limbs.1 >> bitIndex) & 1 == 1
+      default: return (limbs.0 >> bitIndex) & 1 == 1
+      }
+    }
+
+    /// Adds `x + y + carryIn`, returning `(result, carryOut)`.
+    @inline(__always)
+    private static func addLimb(_ x: UInt64, _ y: UInt64, _ carryIn: UInt64) -> (UInt64, UInt64) {
+      let (s1, o1) = x.addingReportingOverflow(y)
+      let (s2, o2) = s1.addingReportingOverflow(carryIn)
+      return (s2, (o1 ? 1 : 0) &+ (o2 ? 1 : 0))
+    }
+
+    /// Unsigned add with carry-out (across all 4 limbs), ripple-carry from
+    /// the least-significant limb (`limbs.3`). Operates directly on the
+    /// tuple fields (no array allocation) since this is the innermost loop
+    /// of `Field.mulMod`/`powMod`, called millions of times per signature.
+    @inline(__always)
+    func addingWithCarry(_ other: UInt256) -> (UInt256, Bool) {
+      let (r3, c3) = UInt256.addLimb(limbs.3, other.limbs.3, 0)
+      let (r2, c2) = UInt256.addLimb(limbs.2, other.limbs.2, c3)
+      let (r1, c1) = UInt256.addLimb(limbs.1, other.limbs.1, c2)
+      let (r0, c0) = UInt256.addLimb(limbs.0, other.limbs.0, c1)
+      return (UInt256(limbs: (r0, r1, r2, r3)), c0 != 0)
+    }
+
+    /// Subtracts `x - y - borrowIn`, returning `(result, borrowOut)`.
+    @inline(__always)
+    private static func subLimb(_ x: UInt64, _ y: UInt64, _ borrowIn: UInt64) -> (UInt64, UInt64) {
+      let (d1, b1) = x.subtractingReportingOverflow(y)
+      let (d2, b2) = d1.subtractingReportingOverflow(borrowIn)
+      return (d2, (b1 ? 1 : 0) &+ (b2 ? 1 : 0))
+    }
+
+    /// Unsigned subtract assuming `self >= other` (across all 4 limbs).
+    @inline(__always)
+    func subtracting(_ other: UInt256) -> UInt256 {
+      let (d3, b3) = UInt256.subLimb(limbs.3, other.limbs.3, 0)
+      let (d2, b2) = UInt256.subLimb(limbs.2, other.limbs.2, b3)
+      let (d1, b1) = UInt256.subLimb(limbs.1, other.limbs.1, b2)
+      let (d0, _) = UInt256.subLimb(limbs.0, other.limbs.0, b1)
+      return UInt256(limbs: (d0, d1, d2, d3))
+    }
+
+    @inline(__always)
+    func shiftedRight1() -> UInt256 {
+      let c1 = limbs.0 & 1
+      let c2 = limbs.1 & 1
+      let c3 = limbs.2 & 1
+      return UInt256(
+        limbs: (
+          limbs.0 >> 1,
+          (limbs.1 >> 1) | (c1 << 63),
+          (limbs.2 >> 1) | (c2 << 63),
+          (limbs.3 >> 1) | (c3 << 63)
+        )
+      )
+    }
+  }
+
+  /// Field/scalar arithmetic mod an arbitrary 256-bit modulus `m` (either
+  /// the field prime `P` or the curve order `N`). Reduced with modular
+  /// addition/doubling only (no full-width multiply+reduce): every
+  /// 256-bit input here is already `< 2 * m` (`m` is within ~2^129 of
+  /// 2^256 for both `P` and `N`), so a single conditional subtraction
+  /// reduces it.
+  enum Field {
+    static func reduceOnce(_ a: UInt256, _ m: UInt256) -> UInt256 {
+      a >= m ? a.subtracting(m) : a
+    }
+
+    static func addMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      let (sum, carry) = a.addingWithCarry(b)
+      if carry || sum >= m { return sum.subtracting(m) }
+      return sum
+    }
+
+    static func subMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      if a >= b { return a.subtracting(b) }
+      return m.subtracting(b.subtracting(a))
+    }
+
+    /// Modular multiplication via double-and-add (avoids a full 512-bit
+    /// multiply + reduction step).
+    static func mulMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      var result = UInt256.zero
+      let addend = reduceOnce(a, m)
+      for i in stride(from: 255, through: 0, by: -1) {
+        result = addMod(result, result, m)
+        if b.testBit(i) {
+          result = addMod(result, addend, m)
+        }
+      }
+      return result
+    }
+
+    static func powMod(_ base: UInt256, _ exponent: UInt256, _ m: UInt256) -> UInt256 {
+      var result = UInt256.one
+      let b = reduceOnce(base, m)
+      for i in stride(from: 255, through: 0, by: -1) {
+        result = mulMod(result, result, m)
+        if exponent.testBit(i) {
+          result = mulMod(result, b, m)
+        }
+      }
+      return result
+    }
+
+    /// Modular inverse via Fermat's little theorem (`m` must be prime):
+    /// `a^-1 = a^(m-2) mod m`.
+    static func invMod(_ a: UInt256, _ m: UInt256) -> UInt256 {
+      let mMinus2 = m.subtracting(UInt256(limbs: (0, 0, 0, 2)))
+      return powMod(a, mMinus2, m)
+    }
+  }
+
+  static let P = UInt256(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")!
+  static let N = UInt256(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")!
+  static let Gx = UInt256(hex: "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798")!
+  static let Gy = UInt256(hex: "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8")!
+
+  struct Point: Equatable {
+    var x: UInt256?
+    var y: UInt256?
+    static let infinity = Point(x: nil, y: nil)
+    var isInfinity: Bool { x == nil || y == nil }
+  }
+
+  static let G = Point(x: Gx, y: Gy)
+
+  static func pointDouble(_ p: Point) -> Point {
+    guard let x = p.x, let y = p.y, !y.isZero else { return .infinity }
+    let num = Field.mulMod(UInt256(limbs: (0, 0, 0, 3)), Field.mulMod(x, x, P), P)
+    let den = Field.invMod(Field.mulMod(UInt256(limbs: (0, 0, 0, 2)), y, P), P)
+    let slope = Field.mulMod(num, den, P)
+    let x3 = Field.subMod(Field.subMod(Field.mulMod(slope, slope, P), x, P), x, P)
+    let y3 = Field.subMod(Field.mulMod(slope, Field.subMod(x, x3, P), P), y, P)
+    return Point(x: x3, y: y3)
+  }
+
+  static func pointAdd(_ p1: Point, _ p2: Point) -> Point {
+    if p1.isInfinity { return p2 }
+    if p2.isInfinity { return p1 }
+    guard let x1 = p1.x, let y1 = p1.y, let x2 = p2.x, let y2 = p2.y else { return .infinity }
+    if x1 == x2 {
+      if Field.addMod(y1, y2, P).isZero { return .infinity }
+      return pointDouble(p1)
+    }
+    let slope = Field.mulMod(Field.subMod(y2, y1, P), Field.invMod(Field.subMod(x2, x1, P), P), P)
+    let x3 = Field.subMod(Field.subMod(Field.mulMod(slope, slope, P), x1, P), x2, P)
+    let y3 = Field.subMod(Field.mulMod(slope, Field.subMod(x1, x3, P), P), y1, P)
+    return Point(x: x3, y: y3)
+  }
+
+  static func scalarMult(_ k: UInt256, _ point: Point) -> Point {
+    var result = Point.infinity
+    let addend = point
+    for i in stride(from: 255, through: 0, by: -1) {
+      result = pointDouble(result)
+      if k.testBit(i) {
+        result = pointAdd(result, addend)
+      }
+    }
+    return result
+  }
+
+  /// SEC1-compressed encoding (33 bytes: 0x02/0x03 prefix + 32-byte X).
+  static func compress(_ point: Point) -> Data {
+    guard let x = point.x, let y = point.y else { return Data() }
+    let prefix: UInt8 = y.testBit(0) ? 0x03 : 0x02
+    return Data([prefix]) + x.data
+  }
+
+  /// Decompress a point from its X coordinate and Y parity bit. Returns
+  /// nil if X is not on the curve.
+  static func decompress(x: UInt256, yIsOdd: Bool) -> Point? {
+    let x3 = Field.mulMod(Field.mulMod(x, x, P), x, P)
+    let rhs = Field.addMod(x3, UInt256(limbs: (0, 0, 0, 7)), P)
+    // secp256k1's P is congruent to 3 mod 4, so sqrt(a) = a^((P+1)/4) mod P.
+    let sqrtExponent = P.addingWithCarry(UInt256.one).0.shiftedRight1().shiftedRight1()
+    var y = Field.powMod(rhs, sqrtExponent, P)
+    if Field.mulMod(y, y, P) != rhs { return nil }
+    if y.testBit(0) != yIsOdd {
+      y = P.subtracting(y)
+    }
+    return Point(x: x, y: y)
+  }
+}

--- a/packages/react-native/barnard/src/BarnardIdentity.ts
+++ b/packages/react-native/barnard/src/BarnardIdentity.ts
@@ -1,0 +1,48 @@
+import { BarnardIdentityModule } from './NativeBarnardIdentity';
+import type { BarnardSignature } from './types';
+
+/**
+ * Barnard's per-event device signing identity (barnard#65).
+ *
+ * This is a **sibling module to `BarnardManager`**, not part of it — the
+ * sensing SDK is transport-only by charter
+ * (`specs/001-barnard-core-sdk/spec.md`). `BarnardIdentity` owns the
+ * device's signing capability instead: a per-event, `DeviceSecret`-rooted
+ * secp256k1 keypair whose private key never leaves the SDK (the opposite
+ * of `BarnardManager.exportCurrentTek`).
+ *
+ * The signing public key is **not** a cross-event-stable identifier: it
+ * is stable only within one `eventCode` and differs across `eventCode`s,
+ * so it cannot be used to correlate a participant's activity across
+ * events (see barnard#65 for the threat this avoids).
+ *
+ * @example
+ * ```typescript
+ * const identity = new BarnardIdentity();
+ * const pubKey = await identity.signingPublicKey('my-event');
+ * const sig = await identity.sign('my-event', observationTupleHex);
+ * ```
+ */
+export class BarnardIdentity {
+  /**
+   * The per-event signing public key, SEC1-compressed, as 66 lowercase
+   * hex chars (33 bytes).
+   *
+   * Same value for every call with the same `eventCode`; a different
+   * value for every other `eventCode`. Re-derivable offline at any time
+   * from `DeviceSecret` — it never "expires".
+   */
+  async signingPublicKey(eventCode: string): Promise<string> {
+    return BarnardIdentityModule.signingPublicKey(eventCode);
+  }
+
+  /**
+   * Sign `bytesHex` (lowercase hex) with the per-event signing key for
+   * `eventCode`. The private key never leaves the SDK; only the resulting
+   * signature is returned. The bytes are hashed (SHA-256) natively before
+   * ECDSA signing.
+   */
+  async sign(eventCode: string, bytesHex: string): Promise<BarnardSignature> {
+    return BarnardIdentityModule.sign(eventCode, bytesHex);
+  }
+}

--- a/packages/react-native/barnard/src/NativeBarnardIdentity.ts
+++ b/packages/react-native/barnard/src/NativeBarnardIdentity.ts
@@ -1,0 +1,33 @@
+import { NativeModules } from 'react-native';
+import type { BarnardSignature } from './types';
+
+const LINKING_ERROR =
+  "The package 'barnard' doesn't seem to be linked. Make sure: \n\n" +
+  '- You rebuilt the app after installing the package\n' +
+  '- You are not using Expo Go\n' +
+  '- If you are using Expo, install it in a custom dev client or bare workflow\n';
+
+/**
+ * Native module interface for the per-event device signing identity
+ * (barnard#65). A separate native module from `Barnard` (the sensing
+ * client) — its own bridge surface, own method channel/native module.
+ */
+interface BarnardIdentityNativeModule {
+  /** SEC1-compressed signing public key (33 bytes) as 66 hex chars. */
+  signingPublicKey(eventCode: string): Promise<string>;
+  /** `bytesHex` is signed after being SHA-256 hashed natively. */
+  sign(eventCode: string, bytesHex: string): Promise<BarnardSignature>;
+}
+
+const BarnardIdentityModule = NativeModules.BarnardIdentity
+  ? (NativeModules.BarnardIdentity as BarnardIdentityNativeModule)
+  : (new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    ) as BarnardIdentityNativeModule);
+
+export { BarnardIdentityModule };

--- a/packages/react-native/barnard/src/index.ts
+++ b/packages/react-native/barnard/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export { BarnardManager } from './BarnardManager';
+export { BarnardIdentity } from './BarnardIdentity';
 
 export type {
   TransportKind,
@@ -32,4 +33,5 @@ export type {
   DebugLevel,
   DebugEvent,
   BarnardEvent,
+  BarnardSignature,
 } from './types';

--- a/packages/react-native/barnard/src/types.ts
+++ b/packages/react-native/barnard/src/types.ts
@@ -218,3 +218,17 @@ export type BarnardEvent =
   | ConstraintEvent
   | ErrorEvent
   | DebugEvent;
+
+/**
+ * A recoverable ECDSA (secp256k1) signature: `(r, s, v)`.
+ *
+ * `v` is the recovery id (`0` or `1`) that lets a verifier recover the
+ * signing public key from `(r, s)` and the message hash alone
+ * ("ecrecover"-compatible). `r` and `s` are 64-char lowercase hex (32
+ * bytes each).
+ */
+export interface BarnardSignature {
+  r: string;
+  s: string;
+  v: number;
+}


### PR DESCRIPTION
## Summary

Implements barnard#65: a per-event, DeviceSecret-rooted secp256k1 signing keypair exposed via a **new identity/attestation module** (`BarnardIdentity`), separate from `BarnardClient`/`BarnardManager` (the sensing SDK stays transport-only per `specs/001-barnard-core-sdk/spec.md:6`). The private key never leaves the SDK — the opposite of `exportCurrentTek()`.

`signKey_event = HKDF(DeviceSecret || EventCode, "barnard-sign", 32)`, reduced mod the secp256k1 curve order.

## Interpretation of the issue spec

The issue's shorthand `HKDF(DeviceSecret, "barnard-sign", eventCode)` doesn't match HKDF's 3-arg signature `(ikm, info, length)`. Per the issue's own "same shape as TEK" guidance, I mirrored `deriveTek`'s event-mode pattern exactly: `ikm = DeviceSecret || EventCode`, `info = "barnard-sign"`, `length = 32` (32 bytes, enough for a secp256k1 scalar — TEK uses 16 because AES-128 needs exactly 16). This satisfies all four acceptance bullets (verified in tests below).

**Curve**: secp256k1 (issue: "ecrecover-able" → secp256k1, not P-256). Signatures are recoverable `(r, s, v)` ECDSA.

**Hash before signing**: `sign(eventCode, bytes)` SHA-256-hashes `bytes` before ECDSA signing (ECDSA signs a fixed-size hash, not arbitrary-length data) — not specified by the issue, called out here per the "state your choice" instruction.

## Changed files (by platform)

**Dart** (`packages/dart/barnard`):
- `lib/src/domain/secp256k1.dart` (new) — secp256k1 keygen/sign/recover on `pointycastle`'s existing curve params
- `lib/src/domain/signing.dart` (new) — `deriveSigningKeyPair`/`signWithDeviceSecret`, HKDF info=`"barnard-sign"`
- `lib/src/usecase/barnard_identity.dart` (new) — `BarnardIdentity` abstract class (sibling to `BarnardClient`), `BarnardSignature`
- `lib/src/interface_adapter/mock/mock_barnard_identity.dart`, `.../ble/barnard_ble_identity.dart` (new) — mock and real (platform-channel `barnard/identity`) implementations
- `lib/src/interface_adapter/mock/mock_barnard.dart` — added `deviceSecretForTesting` getter so `MockBarnardIdentity.pairedWith(MockBarnard)` shares the same root secret
- `lib/{barnard,barnard_ble,mock_barnard}.dart` — exports
- `test/signing_test.dart` (new) — 13 tests covering all 4 acceptance bullets + ecrecover roundtrip

**Android/Kotlin** (both `packages/dart/barnard/android` and `packages/react-native/barnard/android`, byte-identical files):
- `BarnardSigning.kt` (new) — secp256k1 on `java.math.BigInteger` (no new dependency), RFC 6979 deterministic ECDSA
- `BarnardCrypto.kt` — `hkdfSha256` visibility `private` → `internal` so `BarnardSigning` can reuse it
- `BarnardIdentityController.kt` (Dart plugin, new) — own `barnard/identity` `MethodChannel`, registered in `BarnardPlugin.kt`
- `BarnardIdentityModule.kt` (RN, new) — own RN native module `BarnardIdentity`, registered in `BarnardPackage.kt`
- `BarnardSigningTest.kt` (new, both) — 9 JVM unit tests, same coverage as Dart

**iOS/Swift** (both `packages/dart/barnard/ios` and `packages/react-native/barnard/ios`, byte-identical files):
- `Secp256k1.swift` (new) — from-scratch `UInt256` + secp256k1 field/point arithmetic (iOS has no system secp256k1; CryptoKit only covers P-256/384/521 and Curve25519)
- `BarnardSigning.swift` (new) — keygen/sign/recover using CryptoKit's built-in `HKDF<SHA256>`/`HMAC<SHA256>` (matches the existing `BarnardCrypto.swift` convention)
- `BarnardIdentityController.swift` (Dart plugin, new) / `BarnardIdentity.swift` + `.m` (RN, new) — own channel/module, wired in `BarnardPlugin.swift` / RN's Obj-C bridge

**React Native TS** (`packages/react-native/barnard`):
- `src/BarnardIdentity.ts`, `src/NativeBarnardIdentity.ts` (new) — sibling class to `BarnardManager`
- `src/types.ts` — `BarnardSignature` type
- `src/index.ts` — exports
- `__tests__/BarnardIdentity.test.ts` (new) — 5 tests (module wiring; the real secp256k1 math is proven in the Dart/Kotlin/Swift suites, not re-derived here)

## Security invariant (explicitly tested)

No cross-event-stable public key is ever exposed:
- Same key within one `eventCode` (identical across repeated calls)
- Different key across `eventCode`s (checked pairwise + 12-50 events with no collisions, depending on platform)
- Re-derivable offline from `DeviceSecret` alone (deterministic HKDF, no stored state)
- Domain-separated from TEK/RPIK (`info="barnard-sign"` vs `"barnard-tek"`/`"EN-RPIK"` — different HKDF outputs proven directly in the Dart suite)

## Validation run + output

**Dart**: `flutter test` → `100/100 passed`. `flutter analyze` → `No issues found!`.

**Kotlin (Dart-plugin `android/`)**: `JAVA_HOME=<jdk17> ./gradlew testDebugUnitTest` → all green (incl. 9/9 new `BarnardSigningTest`). Repo's local JDK 25 breaks Gradle (`Unsupported class file major version 69`) — this is the pre-existing toolchain issue the task brief warned about, not a code failure; I installed a JDK 17 (`brew install openjdk@17`) locally to actually run the suite rather than skip it.

**Kotlin (RN `android/`)**: no standalone Gradle wrapper/example app in this repo to build it in isolation (toolchain gap, not a code issue). `BarnardSigning.kt`/`BarnardSigningTest.kt` there are byte-identical to the Gradle-and-JVM-verified Dart-plugin copy (`diff` confirms), so the same 9/9 pass applies.

**Swift (both copies)**: no XCTest target exists in this repo for either iOS module (no code test infra to hook into — toolchain gap, not a code issue). I validated the actual production `Secp256k1.swift`/`BarnardSigning.swift` files by compiling them (`swiftc -O`) with a small standalone driver exercising the same test matrix as the Dart suite — all 9 checks pass, **including an exact byte-for-byte match of the compressed public key against the Dart/Kotlin reference for the same `(deviceSecret, eventCode)` input**, which cross-verifies all three from-scratch implementations agree.

**React Native**: `npm test -- --runInBand` → `20/20 passed` (5 new + 15 existing). `npx tsc --noEmit` → clean. `npm run lint` fails with a pre-existing toolchain error (`prettier.resolveConfig.sync is not a function`, ESLint/Prettier version mismatch in `node_modules`) unrelated to this change — not caused by these edits.

## Acceptance criteria

1. **Per-event, DeviceSecret-rooted keypair, `sign`/`signingPublicKey`, private key never leaves SDK** — ✅ `BarnardIdentity` on every platform exposes only the public key and signatures; the private scalar is derived and used natively/in-process and never serialized across a channel boundary.
2. **Same within event, different across events, re-derivable offline** — ✅ tested explicitly on all platforms (see above).
3. **Domain-separated from TEK/RPIK, not cross-computable** — ✅ distinct HKDF `info` string; Dart test proves the derivations diverge from the shared `DeviceSecret||EventCode` input.
4. **Lives in a module separate from the sensing client** — ✅ new `BarnardIdentity` class/object/module on every platform, its own channel (`barnard/identity` on Dart; a separate RN native module `BarnardIdentity`), never touching `BarnardClient`/`BarnardManager`/`Barnard`.

## Notes for the checker

- Swift's `Secp256k1`/`BarnardSigning` implement field/point arithmetic from scratch (no vetted C library available without adding a new SPM/CocoaPods dependency I couldn't verify end-to-end in this sandbox). I cross-verified it byte-for-byte against Dart (`pointycastle`) and Kotlin (`java.math.BigInteger`) for the same test vectors, but it hasn't been reviewed against a reference implementation like libsecp256k1's test vectors — worth a close look.
- Signing/derivation on iOS takes roughly a few seconds on this Mac's compiled (`-O`) build (not measured on-device); the field arithmetic is double-and-add rather than a fast reduction (e.g. Montgomery/Barrett for the secp256k1 field prime's special form). Flagging as a possible follow-up if signing latency turns out to be user-visible — not blocking for this PR's correctness bar.
- Per the task brief: base for barnard#63 (Task 2) will be this branch's tip, since #63 depends on the `BarnardIdentity` module added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMPEzZ2FFCDWx1GHNpSPw1