### PR TITLE
feat(identity): RPID-ownership proof primitive (barnard#63)

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -277,6 +277,11 @@ internal class BarnardController(
 
             "exportCurrentTek" -> {
                 // Explicit privacy egress. SDK never transmits TEK over BLE.
+                //
+                // Deprecated (barnard#63): exposing the raw TEK lets anyone
+                // derive every RPID and the displayId for it. Use
+                // BarnardIdentityController's "proveRpidOwnership" instead.
+                // Kept (not removed) for backward compatibility.
                 result.success(currentTek.toHex())
             }
 

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityController.kt
@@ -71,6 +71,58 @@ internal class BarnardIdentityController(
                 )
             }
 
+            "proveRpidOwnership" -> {
+                val args = call.arguments as? Map<*, *>
+                val eventCode = args?.get("eventCode") as? String
+                val enin = (args?.get("enin") as? Number)?.toLong()
+                val eventIdHashHex = args?.get("eventIdHash") as? String
+                val challengeHex = args?.get("challenge") as? String
+                if (eventCode == null || enin == null || eventIdHashHex == null) {
+                    result.error("E_ARGS", "eventCode, enin and eventIdHash are required", null)
+                    return
+                }
+                val proof = BarnardSigning.proveRpidOwnership(
+                    getOrCreateDeviceSecret(),
+                    eventCode,
+                    hexToBytes(eventIdHashHex),
+                    enin,
+                    challengeHex?.let { hexToBytes(it) },
+                )
+                result.success(
+                    mapOf(
+                        "rpi" to proof.rpi.toHex(),
+                        "signingPublicKey" to proof.signingPublicKey.toHex(),
+                        "r" to proof.sig.r.toHex(),
+                        "s" to proof.sig.s.toHex(),
+                        "v" to proof.sig.v,
+                    )
+                )
+            }
+
+            "proveKeyBinding" -> {
+                val args = call.arguments as? Map<*, *>
+                val eventCode = args?.get("eventCode") as? String
+                val displayIdHex = args?.get("displayId") as? String
+                if (eventCode == null || displayIdHex == null) {
+                    result.error("E_ARGS", "eventCode and displayId are required", null)
+                    return
+                }
+                val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+                val sig = BarnardSigning.signKeyBinding(
+                    getOrCreateDeviceSecret(),
+                    eventCode,
+                    eventCodeHash,
+                    hexToBytes(displayIdHex),
+                )
+                result.success(
+                    mapOf(
+                        "r" to sig.r.toHex(),
+                        "s" to sig.s.toHex(),
+                        "v" to sig.v,
+                    )
+                )
+            }
+
             else -> result.notImplemented()
         }
     }

--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
@@ -32,6 +32,12 @@ import javax.crypto.spec.SecretKeySpec
 internal object BarnardSigning {
     const val signingKeyInfo = "barnard-sign"
 
+    /** Domain-separation tag for [buildRpidProofMessage] (barnard#63). */
+    const val rpidProofDomainTag = "barnard-rpid-proof:v1"
+
+    /** Domain-separation tag for [buildKeyBindingMessage] (barnard#63). */
+    const val keyBindingDomainTag = "barnard-key-binding:v1"
+
     // MARK: - secp256k1 curve parameters
 
     private val P = BigInteger(
@@ -155,6 +161,70 @@ internal object BarnardSigning {
 
     private fun sha256(bytes: ByteArray): ByteArray =
         java.security.MessageDigest.getInstance("SHA-256").digest(bytes)
+
+    // MARK: - RPID ownership proof / key binding (barnard#63)
+
+    /**
+     * Canonical, fixed-order/length-prefixed encoding of an RPID ownership
+     * proof claim:
+     * `"barnard-rpid-proof:v1" ‖ eventIdHash(32) ‖ enin(8, BE) ‖ rpi(16) ‖ len(challenge) as u16 BE ‖ challenge`.
+     */
+    fun buildRpidProofMessage(eventIdHash: ByteArray, enin: Long, rpi: ByteArray, challenge: ByteArray?): ByteArray {
+        require(eventIdHash.size == 32) { "eventIdHash must be 32 bytes" }
+        require(rpi.size == 16) { "rpi must be 16 bytes" }
+        val challengeBytes = challenge ?: ByteArray(0)
+        require(challengeBytes.size <= 0xffff) { "challenge too long" }
+
+        val eninBytes = java.nio.ByteBuffer.allocate(8).order(java.nio.ByteOrder.BIG_ENDIAN).putLong(enin).array()
+        val lenBytes = java.nio.ByteBuffer.allocate(2).order(java.nio.ByteOrder.BIG_ENDIAN)
+            .putShort(challengeBytes.size.toShort()).array()
+
+        return rpidProofDomainTag.toByteArray(Charsets.UTF_8) + eventIdHash + eninBytes + rpi + lenBytes + challengeBytes
+    }
+
+    /** Canonical encoding of a signing-key-to-device-identity binding claim. */
+    fun buildKeyBindingMessage(eventCodeHash: ByteArray, displayId: ByteArray): ByteArray {
+        return keyBindingDomainTag.toByteArray(Charsets.UTF_8) + eventCodeHash + displayId
+    }
+
+    data class RpidOwnershipProof(
+        val rpi: ByteArray,
+        val enin: Long,
+        val eventIdHash: ByteArray,
+        val signingPublicKey: ByteArray,
+        val sig: RecoverableSignature,
+    )
+
+    /**
+     * Compute the RPID ownership proof for [enin] within [eventCode], per
+     * barnard#63. Derives the TEK/RPIK/RPI internally from [deviceSecret]
+     * (via [BarnardCrypto]) — only the resulting `rpi` (not the TEK/RPIK)
+     * appears in the output.
+     */
+    fun proveRpidOwnership(
+        deviceSecret: ByteArray,
+        eventCode: String,
+        eventIdHash: ByteArray,
+        enin: Long,
+        challenge: ByteArray?,
+    ): RpidOwnershipProof {
+        val tek = BarnardCrypto.deriveTekForEvent(deviceSecret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+        val rpi = BarnardCrypto.generateRpi(rpik, enin.toUInt())
+
+        val message = buildRpidProofMessage(eventIdHash, enin, rpi, challenge)
+        val keyPair = deriveSigningKeyPair(deviceSecret, eventCode)
+        val sig = signRecoverable(keyPair.privateKey, sha256(message))
+
+        return RpidOwnershipProof(rpi, enin, eventIdHash, keyPair.publicKeyCompressed, sig)
+    }
+
+    /** Sign the key-binding claim per barnard#63 acceptance criterion 3. */
+    fun signKeyBinding(deviceSecret: ByteArray, eventCode: String, eventCodeHash: ByteArray, displayId: ByteArray): RecoverableSignature {
+        val message = buildKeyBindingMessage(eventCodeHash, displayId)
+        val keyPair = deriveSigningKeyPair(deviceSecret, eventCode)
+        return signRecoverable(keyPair.privateKey, sha256(message))
+    }
 
     // MARK: - Recoverable ECDSA (RFC 6979 deterministic k)
 

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardRpidProofTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardRpidProofTest.kt
@@ -1,0 +1,130 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.math.BigInteger
+import java.security.MessageDigest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+private fun deviceSecret(seed: Int): ByteArray = ByteArray(32) { ((it * 7 + seed) and 0xff).toByte() }
+
+private fun eventIdHash(seed: Int): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest(ByteArray(40) { ((it + seed) and 0xff).toByte() })
+
+class BarnardRpidProofTest {
+
+    @Test
+    fun proofMatchesIndependentlyComputedRpi_andRecoversToSigningPublicKey() {
+        val secret = deviceSecret(11)
+        val eventCode = "rpid-proof-event"
+        val idHash = eventIdHash(1)
+
+        val proof = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 2948599L, null)
+
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+        val expectedRpi = BarnardCrypto.generateRpi(rpik, 2948599u)
+        assertArrayEquals(expectedRpi, proof.rpi)
+
+        val message = BarnardSigning.buildRpidProofMessage(idHash, proof.enin, proof.rpi, null)
+        val recovered = BarnardSigning.recoverPublicKey(
+            proof.sig.v,
+            java.math.BigInteger(1, proof.sig.r),
+            java.math.BigInteger(1, proof.sig.s),
+            MessageDigest.getInstance("SHA-256").digest(message),
+        )
+        assertNotNull(recovered)
+        assertArrayEquals(proof.signingPublicKey, recovered)
+    }
+
+    @Test
+    fun discloseNoTekOrRpik() {
+        val secret = deviceSecret(12)
+        val eventCode = "no-tek-leak-event"
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+
+        val proof = BarnardSigning.proveRpidOwnership(secret, eventCode, eventIdHash(2), 100L, null)
+
+        assertFalse(proof.rpi.contentEquals(tek))
+        assertFalse(proof.rpi.contentEquals(rpik))
+    }
+
+    @Test
+    fun notReplayableToAnotherEvent() {
+        val secret = deviceSecret(14)
+        val eventCode = "replay-event"
+
+        val proofA = BarnardSigning.proveRpidOwnership(secret, eventCode, eventIdHash(4), 5L, null)
+        val proofB = BarnardSigning.proveRpidOwnership(secret, eventCode, eventIdHash(5), 5L, null)
+
+        assertArrayEquals(proofA.rpi, proofB.rpi)
+        assertFalse(proofA.sig.r.contentEquals(proofB.sig.r))
+
+        val messageForB = BarnardSigning.buildRpidProofMessage(proofB.eventIdHash, proofA.enin, proofA.rpi, null)
+        val recoveredWrong = BarnardSigning.recoverPublicKey(
+            proofA.sig.v,
+            BigInteger(1, proofA.sig.r),
+            BigInteger(1, proofA.sig.s),
+            MessageDigest.getInstance("SHA-256").digest(messageForB),
+        )
+        assertFalse(proofA.signingPublicKey.contentEquals(recoveredWrong ?: ByteArray(0)))
+    }
+
+    @Test
+    fun notReplayableToAnotherEnin() {
+        val secret = deviceSecret(15)
+        val eventCode = "replay-enin-event"
+        val idHash = eventIdHash(6)
+
+        val proofEnin5 = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 5L, null)
+
+        val messageForEnin6 = BarnardSigning.buildRpidProofMessage(idHash, 6L, proofEnin5.rpi, null)
+        val recoveredWrong = BarnardSigning.recoverPublicKey(
+            proofEnin5.sig.v,
+            BigInteger(1, proofEnin5.sig.r),
+            BigInteger(1, proofEnin5.sig.s),
+            MessageDigest.getInstance("SHA-256").digest(messageForEnin6),
+        )
+        assertFalse(proofEnin5.signingPublicKey.contentEquals(recoveredWrong ?: ByteArray(0)))
+    }
+
+    @Test
+    fun challengeChangesSignedMessage() {
+        val secret = deviceSecret(16)
+        val eventCode = "challenge-event"
+        val idHash = eventIdHash(7)
+
+        val proofNoChallenge = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 9L, null)
+        val proofWithChallenge = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 9L, byteArrayOf(1, 2, 3, 4))
+
+        assertFalse(proofNoChallenge.sig.r.contentEquals(proofWithChallenge.sig.r))
+    }
+
+    @Test
+    fun keyBindingRecoversToSigningPublicKey() {
+        val secret = deviceSecret(20)
+        val eventCode = "binding-event"
+
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val displayId = BarnardCrypto.displayId4(tek)
+        val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+
+        val sig = BarnardSigning.signKeyBinding(secret, eventCode, eventCodeHash, displayId)
+
+        val message = BarnardSigning.buildKeyBindingMessage(eventCodeHash, displayId)
+        val recovered = BarnardSigning.recoverPublicKey(
+            sig.v,
+            BigInteger(1, sig.r),
+            BigInteger(1, sig.s),
+            MessageDigest.getInstance("SHA-256").digest(message),
+        )
+
+        val keyPair = BarnardSigning.deriveSigningKeyPair(secret, eventCode)
+        assertArrayEquals(keyPair.publicKeyCompressed, recovered)
+    }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift
@@ -413,6 +413,11 @@ final class BarnardBleController: NSObject {
     case "exportCurrentTek":
       // Explicit privacy egress. SDK never transmits TEK over BLE; caller
       // decides whether/how to transmit it via another channel.
+      //
+      // Deprecated (barnard#63): exposing the raw TEK lets anyone derive
+      // every RPID and the displayId for it. Use
+      // BarnardIdentityController's "proveRpidOwnership" instead. Kept
+      // (not removed) for backward compatibility.
       result(rpid.getCurrentTek().hexString)
 
     case "getPermissionStatus":

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardIdentityController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardIdentityController.swift
@@ -50,6 +50,52 @@ final class BarnardIdentityController: NSObject, FlutterPlugin {
         "v": sig.v,
       ])
 
+    case "proveRpidOwnership":
+      guard let args = call.arguments as? [String: Any],
+        let eventCode = args["eventCode"] as? String,
+        let eninNumber = args["enin"] as? NSNumber,
+        let eventIdHashHex = args["eventIdHash"] as? String
+      else {
+        result(FlutterError(code: "E_ARGS", message: "eventCode, enin and eventIdHash are required", details: nil))
+        return
+      }
+      let challengeHex = args["challenge"] as? String
+      let proof = BarnardSigning.proveRpidOwnership(
+        deviceSecret: getOrCreateDeviceSecret(),
+        eventCode: eventCode,
+        eventIdHash: hexToBytes(eventIdHashHex),
+        enin: eninNumber.uint64Value,
+        challenge: challengeHex.map { hexToBytes($0) }
+      )
+      result([
+        "rpi": proof.rpi.hexString,
+        "signingPublicKey": proof.signingPublicKey.hexString,
+        "r": proof.sig.r.hexString,
+        "s": proof.sig.s.hexString,
+        "v": proof.sig.v,
+      ])
+
+    case "proveKeyBinding":
+      guard let args = call.arguments as? [String: Any],
+        let eventCode = args["eventCode"] as? String,
+        let displayIdHex = args["displayId"] as? String
+      else {
+        result(FlutterError(code: "E_ARGS", message: "eventCode and displayId are required", details: nil))
+        return
+      }
+      let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+      let sig = BarnardSigning.signKeyBinding(
+        deviceSecret: getOrCreateDeviceSecret(),
+        eventCode: eventCode,
+        eventCodeHash: eventCodeHash,
+        displayId: hexToBytes(displayIdHex)
+      )
+      result([
+        "r": sig.r.hexString,
+        "s": sig.s.hexString,
+        "v": sig.v,
+      ])
+
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardSigning.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardSigning.swift
@@ -31,6 +31,12 @@ import Foundation
 enum BarnardSigning {
   static let signingKeyInfo = "barnard-sign"
 
+  /// Domain-separation tag for `buildRpidProofMessage` (barnard#63).
+  static let rpidProofDomainTag = "barnard-rpid-proof:v1"
+
+  /// Domain-separation tag for `buildKeyBindingMessage` (barnard#63).
+  static let keyBindingDomainTag = "barnard-key-binding:v1"
+
   struct SigningKeyPair {
     let privateKey: Secp256k1.UInt256
     let publicKeyCompressed: Data
@@ -135,6 +141,82 @@ enum BarnardSigning {
     let point = Secp256k1.pointAdd(term1, term2)
     if point.isInfinity { return nil }
     return Secp256k1.compress(point)
+  }
+
+  // MARK: - RPID ownership proof / key binding (barnard#63)
+
+  struct RpidOwnershipProof {
+    let rpi: Data
+    let enin: UInt64
+    let eventIdHash: Data
+    let signingPublicKey: Data
+    let sig: RecoverableSignature
+  }
+
+  /// Canonical, fixed-order/length-prefixed encoding of an RPID ownership
+  /// proof claim:
+  /// `"barnard-rpid-proof:v1" ‖ eventIdHash(32) ‖ enin(8, BE) ‖ rpi(16) ‖ len(challenge) as u16 BE ‖ challenge`.
+  static func buildRpidProofMessage(eventIdHash: Data, enin: UInt64, rpi: Data, challenge: Data?) -> Data {
+    precondition(eventIdHash.count == 32, "eventIdHash must be 32 bytes")
+    precondition(rpi.count == 16, "rpi must be 16 bytes")
+    let challengeBytes = challenge ?? Data()
+    precondition(challengeBytes.count <= 0xffff, "challenge too long")
+
+    var message = Data(rpidProofDomainTag.utf8)
+    message.append(eventIdHash)
+    message.append(contentsOf: withUnsafeBytes(of: enin.bigEndian) { Data($0) })
+    message.append(rpi)
+    message.append(contentsOf: withUnsafeBytes(of: UInt16(challengeBytes.count).bigEndian) { Data($0) })
+    message.append(challengeBytes)
+    return message
+  }
+
+  /// Canonical encoding of a signing-key-to-device-identity binding claim.
+  static func buildKeyBindingMessage(eventCodeHash: Data, displayId: Data) -> Data {
+    var message = Data(keyBindingDomainTag.utf8)
+    message.append(eventCodeHash)
+    message.append(displayId)
+    return message
+  }
+
+  /// Compute the RPID ownership proof for `enin` within `eventCode`, per
+  /// barnard#63. Derives the TEK/RPIK/RPI internally from `deviceSecret`
+  /// (via `BarnardCrypto`) — only the resulting `rpi` (not the TEK/RPIK)
+  /// appears in the output.
+  static func proveRpidOwnership(
+    deviceSecret: Data,
+    eventCode: String,
+    eventIdHash: Data,
+    enin: UInt64,
+    challenge: Data?
+  ) -> RpidOwnershipProof {
+    let tek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: eventCode)
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
+    let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: UInt32(truncatingIfNeeded: enin))
+
+    let message = buildRpidProofMessage(eventIdHash: eventIdHash, enin: enin, rpi: rpi, challenge: challenge)
+    let keyPair = deriveSigningKeyPair(deviceSecret: deviceSecret, eventCode: eventCode)
+    let sig = signRecoverable(privateKey: keyPair.privateKey, messageHash32: Data(SHA256.hash(data: message)))
+
+    return RpidOwnershipProof(
+      rpi: rpi,
+      enin: enin,
+      eventIdHash: eventIdHash,
+      signingPublicKey: keyPair.publicKeyCompressed,
+      sig: sig
+    )
+  }
+
+  /// Sign the key-binding claim per barnard#63 acceptance criterion 3.
+  static func signKeyBinding(
+    deviceSecret: Data,
+    eventCode: String,
+    eventCodeHash: Data,
+    displayId: Data
+  ) -> RecoverableSignature {
+    let message = buildKeyBindingMessage(eventCodeHash: eventCodeHash, displayId: displayId)
+    let keyPair = deriveSigningKeyPair(deviceSecret: deviceSecret, eventCode: eventCode)
+    return signRecoverable(privateKey: keyPair.privateKey, messageHash32: Data(SHA256.hash(data: message)))
   }
 
   /// RFC 6979 deterministic `k` (HMAC-SHA256; qlen == hlen == 32 bytes for secp256k1/SHA-256).

--- a/packages/dart/barnard/lib/src/domain/signing.dart
+++ b/packages/dart/barnard/lib/src/domain/signing.dart
@@ -67,3 +67,93 @@ RecoverableSignature signWithDeviceSecret({
   final messageHash = sha256(message);
   return signRecoverable(keyPair.privateKey, messageHash);
 }
+
+/// Domain-separation tag for [buildRpidProofMessage] (barnard#63).
+const String rpidProofDomainTag = "barnard-rpid-proof:v1";
+
+/// Domain-separation tag for [buildKeyBindingMessage] (barnard#63).
+const String keyBindingDomainTag = "barnard-key-binding:v1";
+
+/// Canonical, fixed-order/length-prefixed encoding of an RPID ownership
+/// proof claim:
+/// ```
+/// "barnard-rpid-proof:v1" (ASCII, fixed) ‖ eventIdHash(32) ‖ enin(8, BE)
+///   ‖ rpi(16) ‖ len(challenge) as u16 BE ‖ challenge
+/// ```
+Uint8List buildRpidProofMessage({
+  required Uint8List eventIdHash,
+  required int enin,
+  required Uint8List rpi,
+  Uint8List? challenge,
+}) {
+  if (eventIdHash.length != 32) {
+    throw ArgumentError("eventIdHash must be 32 bytes, got ${eventIdHash.length}");
+  }
+  if (rpi.length != 16) {
+    throw ArgumentError("rpi must be 16 bytes, got ${rpi.length}");
+  }
+  final challengeBytes = challenge ?? Uint8List(0);
+  if (challengeBytes.length > 0xffff) {
+    throw ArgumentError("challenge too long: ${challengeBytes.length} bytes");
+  }
+
+  final tagBytes = utf8.encode(rpidProofDomainTag);
+  final builder = BytesBuilder();
+  builder.add(tagBytes);
+  builder.add(eventIdHash);
+  builder.add((ByteData(8)..setUint64(0, enin, Endian.big)).buffer.asUint8List());
+  builder.add(rpi);
+  builder.add((ByteData(2)..setUint16(0, challengeBytes.length, Endian.big)).buffer.asUint8List());
+  builder.add(challengeBytes);
+  return builder.toBytes();
+}
+
+/// Canonical encoding of a signing-key-to-device-identity binding claim:
+/// ```
+/// "barnard-key-binding:v1" (ASCII, fixed) ‖ EventCodeHash(8) ‖ displayId
+/// ```
+Uint8List buildKeyBindingMessage({
+  required Uint8List eventCodeHash,
+  required Uint8List displayId,
+}) {
+  final builder = BytesBuilder();
+  builder.add(utf8.encode(keyBindingDomainTag));
+  builder.add(eventCodeHash);
+  builder.add(displayId);
+  return builder.toBytes();
+}
+
+/// Compute the RPID ownership proof for [enin] within [eventCode], per
+/// barnard#63. Derives the TEK/RPIK/RPI internally from [deviceSecret] —
+/// only the resulting `rpi` (not the TEK/RPIK) appears in the output.
+RecoverableSignature signRpidOwnershipProof({
+  required Uint8List deviceSecret,
+  required String eventCode,
+  required Uint8List eventIdHash,
+  required int enin,
+  required Uint8List rpi,
+  Uint8List? challenge,
+}) {
+  final message = buildRpidProofMessage(
+    eventIdHash: eventIdHash,
+    enin: enin,
+    rpi: rpi,
+    challenge: challenge,
+  );
+  final keyPair = deriveSigningKeyPair(deviceSecret, eventCode);
+  final messageHash = sha256(message);
+  return signRecoverable(keyPair.privateKey, messageHash);
+}
+
+/// Sign the key-binding claim per barnard#63 acceptance criterion 3.
+RecoverableSignature signKeyBinding({
+  required Uint8List deviceSecret,
+  required String eventCode,
+  required Uint8List eventCodeHash,
+  required Uint8List displayId,
+}) {
+  final message = buildKeyBindingMessage(eventCodeHash: eventCodeHash, displayId: displayId);
+  final keyPair = deriveSigningKeyPair(deviceSecret, eventCode);
+  final messageHash = sha256(message);
+  return signRecoverable(keyPair.privateKey, messageHash);
+}

--- a/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_identity.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/ble/barnard_ble_identity.dart
@@ -55,4 +55,59 @@ class BarnardBleIdentity implements BarnardIdentity {
     }
     return BarnardSignature(r: r, s: s, v: v);
   }
+
+  @override
+  Future<RpidOwnershipProof> proveRpidOwnership({
+    required String eventCode,
+    required int enin,
+    required Uint8List eventIdHash,
+    Uint8List? challenge,
+  }) async {
+    final Map<Object?, Object?> result =
+        (await _methods.invokeMethod<Map<Object?, Object?>>("proveRpidOwnership", {
+          "eventCode": eventCode,
+          "enin": enin,
+          "eventIdHash": bytesToHex(eventIdHash),
+          "challenge": challenge != null ? bytesToHex(challenge) : null,
+        })) ??
+        const {};
+
+    final Uint8List rpi = hexToBytes(result["rpi"] as String? ?? "");
+    final Uint8List signingPublicKey = hexToBytes(result["signingPublicKey"] as String? ?? "");
+    final Uint8List r = hexToBytes(result["r"] as String? ?? "");
+    final Uint8List s = hexToBytes(result["s"] as String? ?? "");
+    final int? v = result["v"] as int?;
+    if (rpi.length != 16 || signingPublicKey.length != 33 || r.length != 32 || s.length != 32 || v == null) {
+      throw StateError("proveRpidOwnership: malformed proof from native ($result)");
+    }
+
+    return RpidOwnershipProof(
+      rpi: rpi,
+      enin: enin,
+      eventIdHash: eventIdHash,
+      signingPublicKey: signingPublicKey,
+      sig: BarnardSignature(r: r, s: s, v: v),
+    );
+  }
+
+  @override
+  Future<BarnardSignature> proveKeyBinding({
+    required String eventCode,
+    required Uint8List displayId,
+  }) async {
+    final Map<Object?, Object?> result =
+        (await _methods.invokeMethod<Map<Object?, Object?>>("proveKeyBinding", {
+          "eventCode": eventCode,
+          "displayId": bytesToHex(displayId),
+        })) ??
+        const {};
+
+    final Uint8List r = hexToBytes(result["r"] as String? ?? "");
+    final Uint8List s = hexToBytes(result["s"] as String? ?? "");
+    final int? v = result["v"] as int?;
+    if (r.length != 32 || s.length != 32 || v == null) {
+      throw StateError("proveKeyBinding: malformed signature from native ($result)");
+    }
+    return BarnardSignature(r: r, s: s, v: v);
+  }
 }

--- a/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard_identity.dart
+++ b/packages/dart/barnard/lib/src/interface_adapter/mock/mock_barnard_identity.dart
@@ -4,6 +4,7 @@
 import "dart:math";
 import "dart:typed_data";
 
+import "../../domain/crypto.dart";
 import "../../domain/secp256k1.dart";
 import "../../domain/signing.dart";
 import "../../usecase/barnard_identity.dart";
@@ -36,6 +37,50 @@ class MockBarnardIdentity implements BarnardIdentity {
       deviceSecret: _deviceSecret,
       eventCode: eventCode,
       message: bytes,
+    );
+    return BarnardSignature(r: sig.r, s: sig.s, v: sig.v);
+  }
+
+  @override
+  Future<RpidOwnershipProof> proveRpidOwnership({
+    required String eventCode,
+    required int enin,
+    required Uint8List eventIdHash,
+    Uint8List? challenge,
+  }) async {
+    final tek = BarnardCrypto.deriveTekForEvent(_deviceSecret, eventCode);
+    final rpik = BarnardCrypto.deriveRpikFromTek(tek);
+    final rpi = BarnardCrypto.generateRpiFromRpik(rpik, enin);
+
+    final sig = signRpidOwnershipProof(
+      deviceSecret: _deviceSecret,
+      eventCode: eventCode,
+      eventIdHash: eventIdHash,
+      enin: enin,
+      rpi: rpi,
+      challenge: challenge,
+    );
+
+    return RpidOwnershipProof(
+      rpi: rpi,
+      enin: enin,
+      eventIdHash: eventIdHash,
+      signingPublicKey: deriveSigningKeyPair(_deviceSecret, eventCode).publicKeyCompressed,
+      sig: BarnardSignature(r: sig.r, s: sig.s, v: sig.v),
+    );
+  }
+
+  @override
+  Future<BarnardSignature> proveKeyBinding({
+    required String eventCode,
+    required Uint8List displayId,
+  }) async {
+    final eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode);
+    final sig = signKeyBinding(
+      deviceSecret: _deviceSecret,
+      eventCode: eventCode,
+      eventCodeHash: eventCodeHash,
+      displayId: displayId,
     );
     return BarnardSignature(r: sig.r, s: sig.s, v: sig.v);
   }

--- a/packages/dart/barnard/lib/src/usecase/barnard_client.dart
+++ b/packages/dart/barnard/lib/src/usecase/barnard_client.dart
@@ -87,6 +87,13 @@ abstract class BarnardClient {
   /// The SDK never transmits TEK over BLE. Calling this exposes the TEK
   /// to the host-app caller, which then decides whether/how to transmit
   /// it elsewhere (e.g. to a server). The SDK makes no such decision.
+  ///
+  /// @Deprecated barnard#63: exposing the raw TEK lets anyone derive every
+  /// RPID and the displayId for it. Use `BarnardIdentity.proveRpidOwnership`
+  /// instead, which proves ownership of a single claimed RPID without
+  /// disclosing the TEK/RPIK. Retained (not removed) for backward
+  /// compatibility with existing callers.
+  @Deprecated("Use BarnardIdentity.proveRpidOwnership instead (barnard#63)")
   Future<Uint8List> exportCurrentTek();
 
   // Pull APIs

--- a/packages/dart/barnard/lib/src/usecase/barnard_identity.dart
+++ b/packages/dart/barnard/lib/src/usecase/barnard_identity.dart
@@ -21,14 +21,52 @@ class BarnardSignature {
   final int v;
 }
 
-/// Barnard's per-event device signing identity (barnard#65).
+/// A verifier-checkable proof that the caller owns a given RPID, without
+/// disclosing the TEK/RPIK it was derived from (barnard#63).
+///
+/// A verifier checks: (1) `sig` verifies under `signingPublicKey` for the
+/// message `"barnard-rpid-proof:v1" ‖ eventIdHash ‖ enin ‖ rpi ‖ challenge`;
+/// (2) `signingPublicKey` is the identity bound to the participant (see
+/// [BarnardIdentity.proveKeyBinding]); (3) `rpi` matches the counterparty's
+/// signed observation.
+class RpidOwnershipProof {
+  const RpidOwnershipProof({
+    required this.rpi,
+    required this.enin,
+    required this.eventIdHash,
+    required this.signingPublicKey,
+    required this.sig,
+  });
+
+  /// 16-byte inner RPI (`AES128-ECB(RPIK, pad(ENIN))`) — the same value
+  /// [BarnardClient.getCurrentRpi] returns for this `enin`.
+  final Uint8List rpi;
+
+  /// ENIN this RPI was generated for.
+  final int enin;
+
+  /// 32 bytes, binds the claim to a single event (prevents cross-event
+  /// stitching; ENIN alone is a global, event-independent counter).
+  final Uint8List eventIdHash;
+
+  /// SEC1-compressed signing public key (33 bytes), same as
+  /// [BarnardIdentity.signingPublicKey] for this `eventCode`.
+  final Uint8List signingPublicKey;
+
+  /// Recoverable signature over the canonical proof message.
+  final BarnardSignature sig;
+}
+
+/// Barnard's per-event device signing identity (barnard#65) and RPID
+/// ownership attestation (barnard#63).
 ///
 /// This is a **sibling module to [BarnardClient]**, not part of it — the
 /// sensing SDK is transport-only by charter
 /// (`specs/001-barnard-core-sdk/spec.md`). `BarnardIdentity` owns the
 /// device's signing capability instead: a per-event, `DeviceSecret`-rooted
 /// secp256k1 keypair whose private key never leaves the SDK (the opposite
-/// of `BarnardClient.exportCurrentTek`).
+/// of `BarnardClient.exportCurrentTek`, which is deprecated in favor of
+/// [proveRpidOwnership]).
 ///
 /// The signing public key is **not** a cross-event-stable identifier: it
 /// is stable only within one `eventCode` and differs across `eventCode`s,
@@ -47,4 +85,31 @@ abstract class BarnardIdentity {
   /// The private key never leaves the SDK; only the resulting signature is
   /// returned. [bytes] is hashed (SHA-256) before ECDSA signing.
   Future<BarnardSignature> sign(String eventCode, Uint8List bytes);
+
+  /// Prove ownership of the RPID generated for [enin] within [eventCode],
+  /// bound to [eventIdHash] and (optionally) a verifier-supplied
+  /// [challenge] for replay resistance, without disclosing the TEK/RPIK
+  /// or any other ENIN's RPI (barnard#63).
+  ///
+  /// Deviation from the issue's literal signature: [eventCode] is
+  /// required here (not implicit "current event" state) because
+  /// [BarnardIdentity] is a module separate from [BarnardClient] and does
+  /// not track live sensing state — see barnard#63 PR description.
+  Future<RpidOwnershipProof> proveRpidOwnership({
+    required String eventCode,
+    required int enin,
+    required Uint8List eventIdHash,
+    Uint8List? challenge,
+  });
+
+  /// Bind [signingPublicKey] to [displayId] for [eventCode]: a
+  /// self-signed statement a verifier can check to establish
+  /// "signingPublicKey ↔ device" at join time, before any
+  /// [proveRpidOwnership] call (barnard#63 acceptance criterion 3).
+  ///
+  /// `sig = sign_deviceKey("barnard-key-binding:v1" ‖ EventCodeHash ‖ displayId)`.
+  Future<BarnardSignature> proveKeyBinding({
+    required String eventCode,
+    required Uint8List displayId,
+  });
 }

--- a/packages/dart/barnard/test/rpid_proof_test.dart
+++ b/packages/dart/barnard/test/rpid_proof_test.dart
@@ -1,0 +1,154 @@
+import "dart:typed_data";
+
+import "package:barnard/barnard.dart";
+import "package:barnard/mock_barnard.dart";
+import "package:test/test.dart";
+
+Uint8List _deviceSecret(int seed) =>
+    Uint8List.fromList(List<int>.generate(32, (i) => (i * 7 + seed) & 0xff));
+
+Uint8List _eventIdHash(int seed) => sha256(Uint8List.fromList(List<int>.generate(40, (i) => (i + seed) & 0xff)));
+
+void main() {
+  group("proveRpidOwnership (barnard#63)", () {
+    test("proof is bound to (eventIdHash, enin): recoverable, verifiable, matches getCurrentRpi's RPI", () async {
+      final secret = _deviceSecret(11);
+      const eventCode = "rpid-proof-event";
+      final identity = MockBarnardIdentity(deviceSecret: secret);
+      final eventIdHash = _eventIdHash(1);
+
+      final proof = await identity.proveRpidOwnership(
+        eventCode: eventCode,
+        enin: 2948599,
+        eventIdHash: eventIdHash,
+      );
+
+      // The proof's rpi matches what BarnardClient.getCurrentRpi would
+      // compute independently for the same TEK/enin.
+      final tek = BarnardCrypto.deriveTekForEvent(secret, eventCode);
+      final rpik = BarnardCrypto.deriveRpikFromTek(tek);
+      final expectedRpi = BarnardCrypto.generateRpiFromRpik(rpik, 2948599);
+      expect(proof.rpi, equals(expectedRpi));
+
+      // The signature recovers to the disclosed signingPublicKey.
+      final message = buildRpidProofMessage(eventIdHash: eventIdHash, enin: proof.enin, rpi: proof.rpi);
+      final recovered = recoverPublicKey(
+        RecoverableSignature(r: proof.sig.r, s: proof.sig.s, v: proof.sig.v),
+        sha256(message),
+      );
+      expect(recovered, equals(proof.signingPublicKey));
+      expect(proof.signingPublicKey, equals(await identity.signingPublicKey(eventCode)));
+    });
+
+    test("discloses neither TEK nor RPIK: proof bytes never contain the TEK/RPIK material", () async {
+      final secret = _deviceSecret(12);
+      const eventCode = "no-tek-leak-event";
+      final identity = MockBarnardIdentity(deviceSecret: secret);
+      final tek = BarnardCrypto.deriveTekForEvent(secret, eventCode);
+      final rpik = BarnardCrypto.deriveRpikFromTek(tek);
+
+      final proof = await identity.proveRpidOwnership(
+        eventCode: eventCode,
+        enin: 100,
+        eventIdHash: _eventIdHash(2),
+      );
+
+      expect(proof.rpi, isNot(equals(tek)));
+      expect(proof.rpi, isNot(equals(rpik)));
+      expect(bytesToHex(proof.sig.r), isNot(contains(bytesToHex(tek))));
+      expect(bytesToHex(proof.sig.s), isNot(contains(bytesToHex(tek))));
+    });
+
+    test("discloses no non-claimed RPI: proof for one enin does not reveal another enin's RPI", () async {
+      final secret = _deviceSecret(13);
+      const eventCode = "single-rpi-event";
+      final identity = MockBarnardIdentity(deviceSecret: secret);
+
+      final proofA = await identity.proveRpidOwnership(eventCode: eventCode, enin: 1, eventIdHash: _eventIdHash(3));
+
+      final tek = BarnardCrypto.deriveTekForEvent(secret, eventCode);
+      final rpik = BarnardCrypto.deriveRpikFromTek(tek);
+      final otherEninRpi = BarnardCrypto.generateRpiFromRpik(rpik, 2);
+
+      expect(proofA.rpi, isNot(equals(otherEninRpi)));
+    });
+
+    test("not replayable to another event: a proof's message differs by eventIdHash", () async {
+      final secret = _deviceSecret(14);
+      const eventCode = "replay-event";
+      final identity = MockBarnardIdentity(deviceSecret: secret);
+
+      final proofA = await identity.proveRpidOwnership(eventCode: eventCode, enin: 5, eventIdHash: _eventIdHash(4));
+      final proofB = await identity.proveRpidOwnership(eventCode: eventCode, enin: 5, eventIdHash: _eventIdHash(5));
+
+      // Same rpi/enin (same TEK), but the signed messages (and thus
+      // signatures) differ because eventIdHash differs — a verifier who
+      // checks eventIdHash rejects proofA's signature replayed against
+      // proofB's claimed event.
+      expect(proofA.rpi, equals(proofB.rpi));
+      expect(proofA.sig.r, isNot(equals(proofB.sig.r)));
+
+      final messageForB = buildRpidProofMessage(eventIdHash: proofB.eventIdHash, enin: proofA.enin, rpi: proofA.rpi);
+      final recoveredWrong = recoverPublicKey(
+        RecoverableSignature(r: proofA.sig.r, s: proofA.sig.s, v: proofA.sig.v),
+        sha256(messageForB),
+      );
+      expect(recoveredWrong, isNot(equals(proofA.signingPublicKey)));
+    });
+
+    test("not replayable to another ENIN: a proof's message differs by enin", () async {
+      final secret = _deviceSecret(15);
+      const eventCode = "replay-enin-event";
+      final identity = MockBarnardIdentity(deviceSecret: secret);
+      final eventIdHash = _eventIdHash(6);
+
+      final proofEnin5 = await identity.proveRpidOwnership(eventCode: eventCode, enin: 5, eventIdHash: eventIdHash);
+
+      final messageForEnin6 = buildRpidProofMessage(eventIdHash: eventIdHash, enin: 6, rpi: proofEnin5.rpi);
+      final recoveredWrong = recoverPublicKey(
+        RecoverableSignature(r: proofEnin5.sig.r, s: proofEnin5.sig.s, v: proofEnin5.sig.v),
+        sha256(messageForEnin6),
+      );
+      expect(recoveredWrong, isNot(equals(proofEnin5.signingPublicKey)));
+    });
+
+    test("challenge (verifier nonce) changes the signed message: non-replayable across challenges", () async {
+      final secret = _deviceSecret(16);
+      const eventCode = "challenge-event";
+      final identity = MockBarnardIdentity(deviceSecret: secret);
+      final eventIdHash = _eventIdHash(7);
+
+      final proofNoChallenge = await identity.proveRpidOwnership(eventCode: eventCode, enin: 9, eventIdHash: eventIdHash);
+      final proofWithChallenge = await identity.proveRpidOwnership(
+        eventCode: eventCode,
+        enin: 9,
+        eventIdHash: eventIdHash,
+        challenge: Uint8List.fromList([1, 2, 3, 4]),
+      );
+
+      expect(proofNoChallenge.sig.r, isNot(equals(proofWithChallenge.sig.r)));
+    });
+  });
+
+  group("proveKeyBinding (barnard#63 acceptance criterion 3)", () {
+    test("binding signature recovers to signingPublicKey for the same eventCode", () async {
+      final secret = _deviceSecret(20);
+      const eventCode = "binding-event";
+      final identity = MockBarnardIdentity(deviceSecret: secret);
+
+      final tek = BarnardCrypto.deriveTekForEvent(secret, eventCode);
+      final displayId = displayIdFromTek(tek);
+      final displayIdBytes = Uint8List.fromList(
+        List<int>.generate(displayId.length ~/ 2, (i) => int.parse(displayId.substring(i * 2, i * 2 + 2), radix: 16)),
+      );
+
+      final sig = await identity.proveKeyBinding(eventCode: eventCode, displayId: displayIdBytes);
+
+      final eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode);
+      final message = buildKeyBindingMessage(eventCodeHash: eventCodeHash, displayId: displayIdBytes);
+      final recovered = recoverPublicKey(RecoverableSignature(r: sig.r, s: sig.s, v: sig.v), sha256(message));
+
+      expect(recovered, equals(await identity.signingPublicKey(eventCode)));
+    });
+  });
+}

--- a/packages/react-native/barnard/__tests__/BarnardIdentity.test.ts
+++ b/packages/react-native/barnard/__tests__/BarnardIdentity.test.ts
@@ -15,6 +15,18 @@ jest.mock('react-native', () => {
       s: 'bb'.repeat(32),
       v: 1,
     }),
+    proveRpidOwnership: jest.fn().mockResolvedValue({
+      rpi: 'cc'.repeat(16),
+      signingPublicKey: '02' + 'dd'.repeat(32),
+      r: 'ee'.repeat(32),
+      s: 'ff'.repeat(32),
+      v: 0,
+    }),
+    proveKeyBinding: jest.fn().mockResolvedValue({
+      r: '11'.repeat(32),
+      s: '22'.repeat(32),
+      v: 1,
+    }),
   };
 
   return {
@@ -31,6 +43,19 @@ const setup = () => {
     BarnardIdentity: new () => {
       signingPublicKey: (eventCode: string) => Promise<string>;
       sign: (eventCode: string, bytesHex: string) => Promise<{ r: string; s: string; v: number }>;
+      proveRpidOwnership: (
+        eventCode: string,
+        enin: number,
+        eventIdHashHex: string,
+        challengeHex?: string
+      ) => Promise<{
+        rpi: string;
+        enin: number;
+        eventIdHash: string;
+        signingPublicKey: string;
+        sig: { r: string; s: string; v: number };
+      }>;
+      proveKeyBinding: (eventCode: string, displayIdHex: string) => Promise<{ r: string; s: string; v: number }>;
     };
   };
 
@@ -89,5 +114,52 @@ describe('BarnardIdentity (sibling module to BarnardManager)', () => {
 
     expect((identity as unknown as Record<string, unknown>).exportPrivateKey).toBeUndefined();
     expect((identity as unknown as Record<string, unknown>).privateKey).toBeUndefined();
+  });
+});
+
+describe('BarnardIdentity.proveRpidOwnership (barnard#63)', () => {
+  it('delegates to the native module and reassembles enin/eventIdHash into the proof', async () => {
+    const { BarnardIdentity, nativeModule } = setup();
+    const identity = new BarnardIdentity();
+    const eventIdHash = 'ab'.repeat(32);
+
+    const proof = await identity.proveRpidOwnership('event-A', 2948599, eventIdHash);
+
+    expect(nativeModule.proveRpidOwnership).toHaveBeenCalledWith('event-A', 2948599, eventIdHash, null);
+    expect(proof.enin).toBe(2948599);
+    expect(proof.eventIdHash).toBe(eventIdHash);
+    expect(proof.rpi).toMatch(/^[0-9a-f]{32}$/);
+    expect(proof.signingPublicKey).toMatch(/^0[23][0-9a-f]{64}$/);
+    expect(proof.sig.r).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('forwards an optional challenge to the native module', async () => {
+    const { BarnardIdentity, nativeModule } = setup();
+    const identity = new BarnardIdentity();
+
+    await identity.proveRpidOwnership('event-A', 1, 'ab'.repeat(32), 'deadbeef');
+
+    expect(nativeModule.proveRpidOwnership).toHaveBeenCalledWith('event-A', 1, 'ab'.repeat(32), 'deadbeef');
+  });
+
+  it('does not disclose TEK/RPIK: the proof shape carries only rpi, not a 16-byte TEK/RPIK field', async () => {
+    const { BarnardIdentity } = setup();
+    const identity = new BarnardIdentity();
+
+    const proof = await identity.proveRpidOwnership('event-A', 1, 'ab'.repeat(32));
+
+    expect(Object.keys(proof).sort()).toEqual(['enin', 'eventIdHash', 'rpi', 'signingPublicKey', 'sig'].sort());
+  });
+});
+
+describe('BarnardIdentity.proveKeyBinding (barnard#63 acceptance criterion 3)', () => {
+  it('delegates to the native module with eventCode and displayId', async () => {
+    const { BarnardIdentity, nativeModule } = setup();
+    const identity = new BarnardIdentity();
+
+    const sig = await identity.proveKeyBinding('event-A', '374708ff');
+
+    expect(nativeModule.proveKeyBinding).toHaveBeenCalledWith('event-A', '374708ff');
+    expect(sig.r).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityModule.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardIdentityModule.kt
@@ -57,6 +57,56 @@ class BarnardIdentityModule(reactContext: ReactApplicationContext) :
         }
     }
 
+    @ReactMethod
+    fun proveRpidOwnership(
+        eventCode: String,
+        enin: Double,
+        eventIdHashHex: String,
+        challengeHex: String?,
+        promise: Promise,
+    ) {
+        try {
+            val proof = BarnardSigning.proveRpidOwnership(
+                getOrCreateDeviceSecret(),
+                eventCode,
+                hexToBytes(eventIdHashHex),
+                enin.toLong(),
+                challengeHex?.let { hexToBytes(it) },
+            )
+
+            val map: WritableMap = com.facebook.react.bridge.Arguments.createMap()
+            map.putString("rpi", proof.rpi.toHex())
+            map.putString("signingPublicKey", proof.signingPublicKey.toHex())
+            map.putString("r", proof.sig.r.toHex())
+            map.putString("s", proof.sig.s.toHex())
+            map.putInt("v", proof.sig.v)
+            promise.resolve(map)
+        } catch (e: Exception) {
+            promise.reject("E_PROVE_RPID_OWNERSHIP", e.message, e)
+        }
+    }
+
+    @ReactMethod
+    fun proveKeyBinding(eventCode: String, displayIdHex: String, promise: Promise) {
+        try {
+            val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+            val sig = BarnardSigning.signKeyBinding(
+                getOrCreateDeviceSecret(),
+                eventCode,
+                eventCodeHash,
+                hexToBytes(displayIdHex),
+            )
+
+            val map: WritableMap = com.facebook.react.bridge.Arguments.createMap()
+            map.putString("r", sig.r.toHex())
+            map.putString("s", sig.s.toHex())
+            map.putInt("v", sig.v)
+            promise.resolve(map)
+        } catch (e: Exception) {
+            promise.reject("E_PROVE_KEY_BINDING", e.message, e)
+        }
+    }
+
     private fun hexToBytes(hex: String): ByteArray {
         val clean = if (hex.length % 2 == 0) hex else "0$hex"
         return ByteArray(clean.length / 2) { i ->

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardModule.kt
@@ -281,6 +281,12 @@ class BarnardModule(reactContext: ReactApplicationContext) :
         }
     }
 
+    /**
+     * @deprecated barnard#63: exposing the raw TEK lets anyone derive every
+     * RPID and the displayId for it. Use BarnardIdentityModule.proveRpidOwnership
+     * instead. Retained (not removed) for backward compatibility.
+     */
+    @Deprecated("Use BarnardIdentityModule.proveRpidOwnership instead (barnard#63)")
     @ReactMethod
     fun exportCurrentTek(promise: Promise) {
         try {

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardSigning.kt
@@ -32,6 +32,12 @@ import javax.crypto.spec.SecretKeySpec
 internal object BarnardSigning {
     const val signingKeyInfo = "barnard-sign"
 
+    /** Domain-separation tag for [buildRpidProofMessage] (barnard#63). */
+    const val rpidProofDomainTag = "barnard-rpid-proof:v1"
+
+    /** Domain-separation tag for [buildKeyBindingMessage] (barnard#63). */
+    const val keyBindingDomainTag = "barnard-key-binding:v1"
+
     // MARK: - secp256k1 curve parameters
 
     private val P = BigInteger(
@@ -155,6 +161,70 @@ internal object BarnardSigning {
 
     private fun sha256(bytes: ByteArray): ByteArray =
         java.security.MessageDigest.getInstance("SHA-256").digest(bytes)
+
+    // MARK: - RPID ownership proof / key binding (barnard#63)
+
+    /**
+     * Canonical, fixed-order/length-prefixed encoding of an RPID ownership
+     * proof claim:
+     * `"barnard-rpid-proof:v1" ‖ eventIdHash(32) ‖ enin(8, BE) ‖ rpi(16) ‖ len(challenge) as u16 BE ‖ challenge`.
+     */
+    fun buildRpidProofMessage(eventIdHash: ByteArray, enin: Long, rpi: ByteArray, challenge: ByteArray?): ByteArray {
+        require(eventIdHash.size == 32) { "eventIdHash must be 32 bytes" }
+        require(rpi.size == 16) { "rpi must be 16 bytes" }
+        val challengeBytes = challenge ?: ByteArray(0)
+        require(challengeBytes.size <= 0xffff) { "challenge too long" }
+
+        val eninBytes = java.nio.ByteBuffer.allocate(8).order(java.nio.ByteOrder.BIG_ENDIAN).putLong(enin).array()
+        val lenBytes = java.nio.ByteBuffer.allocate(2).order(java.nio.ByteOrder.BIG_ENDIAN)
+            .putShort(challengeBytes.size.toShort()).array()
+
+        return rpidProofDomainTag.toByteArray(Charsets.UTF_8) + eventIdHash + eninBytes + rpi + lenBytes + challengeBytes
+    }
+
+    /** Canonical encoding of a signing-key-to-device-identity binding claim. */
+    fun buildKeyBindingMessage(eventCodeHash: ByteArray, displayId: ByteArray): ByteArray {
+        return keyBindingDomainTag.toByteArray(Charsets.UTF_8) + eventCodeHash + displayId
+    }
+
+    data class RpidOwnershipProof(
+        val rpi: ByteArray,
+        val enin: Long,
+        val eventIdHash: ByteArray,
+        val signingPublicKey: ByteArray,
+        val sig: RecoverableSignature,
+    )
+
+    /**
+     * Compute the RPID ownership proof for [enin] within [eventCode], per
+     * barnard#63. Derives the TEK/RPIK/RPI internally from [deviceSecret]
+     * (via [BarnardCrypto]) — only the resulting `rpi` (not the TEK/RPIK)
+     * appears in the output.
+     */
+    fun proveRpidOwnership(
+        deviceSecret: ByteArray,
+        eventCode: String,
+        eventIdHash: ByteArray,
+        enin: Long,
+        challenge: ByteArray?,
+    ): RpidOwnershipProof {
+        val tek = BarnardCrypto.deriveTekForEvent(deviceSecret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+        val rpi = BarnardCrypto.generateRpi(rpik, enin.toUInt())
+
+        val message = buildRpidProofMessage(eventIdHash, enin, rpi, challenge)
+        val keyPair = deriveSigningKeyPair(deviceSecret, eventCode)
+        val sig = signRecoverable(keyPair.privateKey, sha256(message))
+
+        return RpidOwnershipProof(rpi, enin, eventIdHash, keyPair.publicKeyCompressed, sig)
+    }
+
+    /** Sign the key-binding claim per barnard#63 acceptance criterion 3. */
+    fun signKeyBinding(deviceSecret: ByteArray, eventCode: String, eventCodeHash: ByteArray, displayId: ByteArray): RecoverableSignature {
+        val message = buildKeyBindingMessage(eventCodeHash, displayId)
+        val keyPair = deriveSigningKeyPair(deviceSecret, eventCode)
+        return signRecoverable(keyPair.privateKey, sha256(message))
+    }
 
     // MARK: - Recoverable ECDSA (RFC 6979 deterministic k)
 

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardRpidProofTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardRpidProofTest.kt
@@ -1,0 +1,130 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard
+
+import java.math.BigInteger
+import java.security.MessageDigest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+private fun deviceSecret(seed: Int): ByteArray = ByteArray(32) { ((it * 7 + seed) and 0xff).toByte() }
+
+private fun eventIdHash(seed: Int): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest(ByteArray(40) { ((it + seed) and 0xff).toByte() })
+
+class BarnardRpidProofTest {
+
+    @Test
+    fun proofMatchesIndependentlyComputedRpi_andRecoversToSigningPublicKey() {
+        val secret = deviceSecret(11)
+        val eventCode = "rpid-proof-event"
+        val idHash = eventIdHash(1)
+
+        val proof = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 2948599L, null)
+
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+        val expectedRpi = BarnardCrypto.generateRpi(rpik, 2948599u)
+        assertArrayEquals(expectedRpi, proof.rpi)
+
+        val message = BarnardSigning.buildRpidProofMessage(idHash, proof.enin, proof.rpi, null)
+        val recovered = BarnardSigning.recoverPublicKey(
+            proof.sig.v,
+            java.math.BigInteger(1, proof.sig.r),
+            java.math.BigInteger(1, proof.sig.s),
+            MessageDigest.getInstance("SHA-256").digest(message),
+        )
+        assertNotNull(recovered)
+        assertArrayEquals(proof.signingPublicKey, recovered)
+    }
+
+    @Test
+    fun discloseNoTekOrRpik() {
+        val secret = deviceSecret(12)
+        val eventCode = "no-tek-leak-event"
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val rpik = BarnardCrypto.deriveRpik(tek)
+
+        val proof = BarnardSigning.proveRpidOwnership(secret, eventCode, eventIdHash(2), 100L, null)
+
+        assertFalse(proof.rpi.contentEquals(tek))
+        assertFalse(proof.rpi.contentEquals(rpik))
+    }
+
+    @Test
+    fun notReplayableToAnotherEvent() {
+        val secret = deviceSecret(14)
+        val eventCode = "replay-event"
+
+        val proofA = BarnardSigning.proveRpidOwnership(secret, eventCode, eventIdHash(4), 5L, null)
+        val proofB = BarnardSigning.proveRpidOwnership(secret, eventCode, eventIdHash(5), 5L, null)
+
+        assertArrayEquals(proofA.rpi, proofB.rpi)
+        assertFalse(proofA.sig.r.contentEquals(proofB.sig.r))
+
+        val messageForB = BarnardSigning.buildRpidProofMessage(proofB.eventIdHash, proofA.enin, proofA.rpi, null)
+        val recoveredWrong = BarnardSigning.recoverPublicKey(
+            proofA.sig.v,
+            BigInteger(1, proofA.sig.r),
+            BigInteger(1, proofA.sig.s),
+            MessageDigest.getInstance("SHA-256").digest(messageForB),
+        )
+        assertFalse(proofA.signingPublicKey.contentEquals(recoveredWrong ?: ByteArray(0)))
+    }
+
+    @Test
+    fun notReplayableToAnotherEnin() {
+        val secret = deviceSecret(15)
+        val eventCode = "replay-enin-event"
+        val idHash = eventIdHash(6)
+
+        val proofEnin5 = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 5L, null)
+
+        val messageForEnin6 = BarnardSigning.buildRpidProofMessage(idHash, 6L, proofEnin5.rpi, null)
+        val recoveredWrong = BarnardSigning.recoverPublicKey(
+            proofEnin5.sig.v,
+            BigInteger(1, proofEnin5.sig.r),
+            BigInteger(1, proofEnin5.sig.s),
+            MessageDigest.getInstance("SHA-256").digest(messageForEnin6),
+        )
+        assertFalse(proofEnin5.signingPublicKey.contentEquals(recoveredWrong ?: ByteArray(0)))
+    }
+
+    @Test
+    fun challengeChangesSignedMessage() {
+        val secret = deviceSecret(16)
+        val eventCode = "challenge-event"
+        val idHash = eventIdHash(7)
+
+        val proofNoChallenge = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 9L, null)
+        val proofWithChallenge = BarnardSigning.proveRpidOwnership(secret, eventCode, idHash, 9L, byteArrayOf(1, 2, 3, 4))
+
+        assertFalse(proofNoChallenge.sig.r.contentEquals(proofWithChallenge.sig.r))
+    }
+
+    @Test
+    fun keyBindingRecoversToSigningPublicKey() {
+        val secret = deviceSecret(20)
+        val eventCode = "binding-event"
+
+        val tek = BarnardCrypto.deriveTekForEvent(secret, eventCode)
+        val displayId = BarnardCrypto.displayId4(tek)
+        val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+
+        val sig = BarnardSigning.signKeyBinding(secret, eventCode, eventCodeHash, displayId)
+
+        val message = BarnardSigning.buildKeyBindingMessage(eventCodeHash, displayId)
+        val recovered = BarnardSigning.recoverPublicKey(
+            sig.v,
+            BigInteger(1, sig.r),
+            BigInteger(1, sig.s),
+            MessageDigest.getInstance("SHA-256").digest(message),
+        )
+
+        val keyPair = BarnardSigning.deriveSigningKeyPair(secret, eventCode)
+        assertArrayEquals(keyPair.publicKeyCompressed, recovered)
+    }
+}

--- a/packages/react-native/barnard/ios/Barnard.swift
+++ b/packages/react-native/barnard/ios/Barnard.swift
@@ -191,6 +191,10 @@ class Barnard: RCTEventEmitter {
     resolve(controller.getCurrentEnin())
   }
 
+  /// - Deprecated: barnard#63: exposing the raw TEK lets anyone derive
+  ///   every RPID and the displayId for it. Use
+  ///   `BarnardIdentity.proveRpidOwnership` instead. Retained (not
+  ///   removed) for backward compatibility.
   @objc
   func exportCurrentTek(
     _ resolve: @escaping RCTPromiseResolveBlock,

--- a/packages/react-native/barnard/ios/BarnardIdentity.m
+++ b/packages/react-native/barnard/ios/BarnardIdentity.m
@@ -11,6 +11,18 @@ RCT_EXTERN_METHOD(sign:(NSString *)eventCode
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(proveRpidOwnership:(NSString *)eventCode
+                  enin:(nonnull NSNumber *)enin
+                  eventIdHashHex:(NSString *)eventIdHashHex
+                  challengeHex:(NSString *)challengeHex
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(proveKeyBinding:(NSString *)eventCode
+                  displayIdHex:(NSString *)displayIdHex
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 + (BOOL)requiresMainQueueSetup
 {
   return NO;

--- a/packages/react-native/barnard/ios/BarnardIdentity.swift
+++ b/packages/react-native/barnard/ios/BarnardIdentity.swift
@@ -40,6 +40,52 @@ class BarnardIdentity: NSObject {
     ])
   }
 
+  @objc(proveRpidOwnership:enin:eventIdHashHex:challengeHex:resolve:reject:)
+  func proveRpidOwnership(
+    _ eventCode: String,
+    enin: NSNumber,
+    eventIdHashHex: String,
+    challengeHex: String?,
+    resolve: RCTPromiseResolveBlock,
+    reject: RCTPromiseRejectBlock
+  ) {
+    let proof = BarnardSigning.proveRpidOwnership(
+      deviceSecret: getOrCreateDeviceSecret(),
+      eventCode: eventCode,
+      eventIdHash: hexToBytes(eventIdHashHex),
+      enin: enin.uint64Value,
+      challenge: challengeHex.map { hexToBytes($0) }
+    )
+    resolve([
+      "rpi": proof.rpi.hexString,
+      "signingPublicKey": proof.signingPublicKey.hexString,
+      "r": proof.sig.r.hexString,
+      "s": proof.sig.s.hexString,
+      "v": proof.sig.v,
+    ])
+  }
+
+  @objc(proveKeyBinding:displayIdHex:resolve:reject:)
+  func proveKeyBinding(
+    _ eventCode: String,
+    displayIdHex: String,
+    resolve: RCTPromiseResolveBlock,
+    reject: RCTPromiseRejectBlock
+  ) {
+    let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+    let sig = BarnardSigning.signKeyBinding(
+      deviceSecret: getOrCreateDeviceSecret(),
+      eventCode: eventCode,
+      eventCodeHash: eventCodeHash,
+      displayId: hexToBytes(displayIdHex)
+    )
+    resolve([
+      "r": sig.r.hexString,
+      "s": sig.s.hexString,
+      "v": sig.v,
+    ])
+  }
+
   private func hexToBytes(_ hex: String) -> Data {
     var clean = hex
     if clean.count % 2 != 0 { clean = "0" + clean }

--- a/packages/react-native/barnard/ios/BarnardSigning.swift
+++ b/packages/react-native/barnard/ios/BarnardSigning.swift
@@ -31,6 +31,12 @@ import Foundation
 enum BarnardSigning {
   static let signingKeyInfo = "barnard-sign"
 
+  /// Domain-separation tag for `buildRpidProofMessage` (barnard#63).
+  static let rpidProofDomainTag = "barnard-rpid-proof:v1"
+
+  /// Domain-separation tag for `buildKeyBindingMessage` (barnard#63).
+  static let keyBindingDomainTag = "barnard-key-binding:v1"
+
   struct SigningKeyPair {
     let privateKey: Secp256k1.UInt256
     let publicKeyCompressed: Data
@@ -135,6 +141,82 @@ enum BarnardSigning {
     let point = Secp256k1.pointAdd(term1, term2)
     if point.isInfinity { return nil }
     return Secp256k1.compress(point)
+  }
+
+  // MARK: - RPID ownership proof / key binding (barnard#63)
+
+  struct RpidOwnershipProof {
+    let rpi: Data
+    let enin: UInt64
+    let eventIdHash: Data
+    let signingPublicKey: Data
+    let sig: RecoverableSignature
+  }
+
+  /// Canonical, fixed-order/length-prefixed encoding of an RPID ownership
+  /// proof claim:
+  /// `"barnard-rpid-proof:v1" ‖ eventIdHash(32) ‖ enin(8, BE) ‖ rpi(16) ‖ len(challenge) as u16 BE ‖ challenge`.
+  static func buildRpidProofMessage(eventIdHash: Data, enin: UInt64, rpi: Data, challenge: Data?) -> Data {
+    precondition(eventIdHash.count == 32, "eventIdHash must be 32 bytes")
+    precondition(rpi.count == 16, "rpi must be 16 bytes")
+    let challengeBytes = challenge ?? Data()
+    precondition(challengeBytes.count <= 0xffff, "challenge too long")
+
+    var message = Data(rpidProofDomainTag.utf8)
+    message.append(eventIdHash)
+    message.append(contentsOf: withUnsafeBytes(of: enin.bigEndian) { Data($0) })
+    message.append(rpi)
+    message.append(contentsOf: withUnsafeBytes(of: UInt16(challengeBytes.count).bigEndian) { Data($0) })
+    message.append(challengeBytes)
+    return message
+  }
+
+  /// Canonical encoding of a signing-key-to-device-identity binding claim.
+  static func buildKeyBindingMessage(eventCodeHash: Data, displayId: Data) -> Data {
+    var message = Data(keyBindingDomainTag.utf8)
+    message.append(eventCodeHash)
+    message.append(displayId)
+    return message
+  }
+
+  /// Compute the RPID ownership proof for `enin` within `eventCode`, per
+  /// barnard#63. Derives the TEK/RPIK/RPI internally from `deviceSecret`
+  /// (via `BarnardCrypto`) — only the resulting `rpi` (not the TEK/RPIK)
+  /// appears in the output.
+  static func proveRpidOwnership(
+    deviceSecret: Data,
+    eventCode: String,
+    eventIdHash: Data,
+    enin: UInt64,
+    challenge: Data?
+  ) -> RpidOwnershipProof {
+    let tek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: eventCode)
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
+    let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: UInt32(truncatingIfNeeded: enin))
+
+    let message = buildRpidProofMessage(eventIdHash: eventIdHash, enin: enin, rpi: rpi, challenge: challenge)
+    let keyPair = deriveSigningKeyPair(deviceSecret: deviceSecret, eventCode: eventCode)
+    let sig = signRecoverable(privateKey: keyPair.privateKey, messageHash32: Data(SHA256.hash(data: message)))
+
+    return RpidOwnershipProof(
+      rpi: rpi,
+      enin: enin,
+      eventIdHash: eventIdHash,
+      signingPublicKey: keyPair.publicKeyCompressed,
+      sig: sig
+    )
+  }
+
+  /// Sign the key-binding claim per barnard#63 acceptance criterion 3.
+  static func signKeyBinding(
+    deviceSecret: Data,
+    eventCode: String,
+    eventCodeHash: Data,
+    displayId: Data
+  ) -> RecoverableSignature {
+    let message = buildKeyBindingMessage(eventCodeHash: eventCodeHash, displayId: displayId)
+    let keyPair = deriveSigningKeyPair(deviceSecret: deviceSecret, eventCode: eventCode)
+    return signRecoverable(privateKey: keyPair.privateKey, messageHash32: Data(SHA256.hash(data: message)))
   }
 
   /// RFC 6979 deterministic `k` (HMAC-SHA256; qlen == hlen == 32 bytes for secp256k1/SHA-256).

--- a/packages/react-native/barnard/src/BarnardIdentity.ts
+++ b/packages/react-native/barnard/src/BarnardIdentity.ts
@@ -1,5 +1,5 @@
 import { BarnardIdentityModule } from './NativeBarnardIdentity';
-import type { BarnardSignature } from './types';
+import type { BarnardSignature, RpidOwnershipProof } from './types';
 
 /**
  * Barnard's per-event device signing identity (barnard#65).
@@ -44,5 +44,47 @@ export class BarnardIdentity {
    */
   async sign(eventCode: string, bytesHex: string): Promise<BarnardSignature> {
     return BarnardIdentityModule.sign(eventCode, bytesHex);
+  }
+
+  /**
+   * Prove ownership of the RPID generated for `enin` within `eventCode`,
+   * bound to `eventIdHashHex` and (optionally) a verifier-supplied
+   * `challengeHex` for replay resistance, without disclosing the
+   * TEK/RPIK or any other ENIN's RPI (barnard#63).
+   *
+   * `eventIdHashHex` must be 64 hex chars (32 bytes); `challengeHex`, if
+   * given, is arbitrary hex.
+   */
+  async proveRpidOwnership(
+    eventCode: string,
+    enin: number,
+    eventIdHashHex: string,
+    challengeHex?: string
+  ): Promise<RpidOwnershipProof> {
+    const native = await BarnardIdentityModule.proveRpidOwnership(
+      eventCode,
+      enin,
+      eventIdHashHex,
+      challengeHex ?? null
+    );
+    return {
+      rpi: native.rpi,
+      enin,
+      eventIdHash: eventIdHashHex,
+      signingPublicKey: native.signingPublicKey,
+      sig: { r: native.r, s: native.s, v: native.v },
+    };
+  }
+
+  /**
+   * Bind `signingPublicKey` to `displayIdHex` for `eventCode`: a
+   * self-signed statement a verifier can check to establish
+   * "signingPublicKey ↔ device" at join time, before any
+   * `proveRpidOwnership` call (barnard#63 acceptance criterion 3).
+   *
+   * `displayIdHex` must be 8 hex chars (4 bytes), matching `getMyDisplayId()`.
+   */
+  async proveKeyBinding(eventCode: string, displayIdHex: string): Promise<BarnardSignature> {
+    return BarnardIdentityModule.proveKeyBinding(eventCode, displayIdHex);
   }
 }

--- a/packages/react-native/barnard/src/BarnardManager.ts
+++ b/packages/react-native/barnard/src/BarnardManager.ts
@@ -100,6 +100,12 @@ export class BarnardManager {
   /**
    * v2: raw 16-byte TEK as 32-char lowercase hex. Explicit privacy egress;
    * the SDK never transmits TEK over BLE.
+   *
+   * @deprecated barnard#63: exposing the raw TEK lets anyone derive every
+   * RPID and the displayId for it. Use `BarnardIdentity.proveRpidOwnership`
+   * instead, which proves ownership of a single claimed RPID without
+   * disclosing the TEK/RPIK. Retained (not removed) for backward
+   * compatibility with existing callers.
    */
   async exportCurrentTek(): Promise<string> {
     return BarnardModule.exportCurrentTek();

--- a/packages/react-native/barnard/src/NativeBarnard.ts
+++ b/packages/react-native/barnard/src/NativeBarnard.ts
@@ -36,6 +36,11 @@ interface BarnardNativeModule {
   getMyDisplayId(): Promise<string>;
   getCurrentRpi(): Promise<string>;
   getCurrentEnin(): Promise<number>;
+  /**
+   * @deprecated barnard#63: exposing the raw TEK lets anyone derive every
+   * RPID and the displayId for it. Use `BarnardIdentity.proveRpidOwnership`
+   * instead. Retained (not removed) for backward compatibility.
+   */
   exportCurrentTek(): Promise<string>;
 
   startScan(config?: ScanConfig): Promise<void>;

--- a/packages/react-native/barnard/src/NativeBarnardIdentity.ts
+++ b/packages/react-native/barnard/src/NativeBarnardIdentity.ts
@@ -1,6 +1,20 @@
 import { NativeModules } from 'react-native';
 import type { BarnardSignature } from './types';
 
+/**
+ * Raw native return shape for `proveRpidOwnership`: the native side does
+ * not echo back the caller-supplied `enin`/`eventIdHash` (it only computes
+ * `rpi`/`signingPublicKey`/the signature); `BarnardIdentity.proveRpidOwnership`
+ * reassembles the full `RpidOwnershipProof` from the call arguments.
+ */
+export interface NativeRpidOwnershipProof {
+  rpi: string;
+  signingPublicKey: string;
+  r: string;
+  s: string;
+  v: number;
+}
+
 const LINKING_ERROR =
   "The package 'barnard' doesn't seem to be linked. Make sure: \n\n" +
   '- You rebuilt the app after installing the package\n' +
@@ -17,6 +31,15 @@ interface BarnardIdentityNativeModule {
   signingPublicKey(eventCode: string): Promise<string>;
   /** `bytesHex` is signed after being SHA-256 hashed natively. */
   sign(eventCode: string, bytesHex: string): Promise<BarnardSignature>;
+  /** `eventIdHashHex` is 64 hex chars (32 bytes); `challengeHex` is optional. */
+  proveRpidOwnership(
+    eventCode: string,
+    enin: number,
+    eventIdHashHex: string,
+    challengeHex?: string | null
+  ): Promise<NativeRpidOwnershipProof>;
+  /** `displayIdHex` is 8 hex chars (4 bytes), matching `getMyDisplayId()`. */
+  proveKeyBinding(eventCode: string, displayIdHex: string): Promise<BarnardSignature>;
 }
 
 const BarnardIdentityModule = NativeModules.BarnardIdentity

--- a/packages/react-native/barnard/src/index.ts
+++ b/packages/react-native/barnard/src/index.ts
@@ -34,4 +34,5 @@ export type {
   DebugEvent,
   BarnardEvent,
   BarnardSignature,
+  RpidOwnershipProof,
 } from './types';

--- a/packages/react-native/barnard/src/types.ts
+++ b/packages/react-native/barnard/src/types.ts
@@ -232,3 +232,19 @@ export interface BarnardSignature {
   s: string;
   v: number;
 }
+
+/**
+ * A verifier-checkable proof that the caller owns a given RPID, without
+ * disclosing the TEK/RPIK it was derived from (barnard#63).
+ */
+export interface RpidOwnershipProof {
+  /** 32-char lowercase hex: 16-byte inner RPI (same value `getCurrentRpi` returns for this `enin`). */
+  rpi: string;
+  /** ENIN this RPI was generated for. */
+  enin: number;
+  /** 64-char lowercase hex: 32 bytes, binds the claim to a single event. */
+  eventIdHash: string;
+  /** 66-char lowercase hex: SEC1-compressed signing public key (33 bytes). */
+  signingPublicKey: string;
+  sig: BarnardSignature;
+}


### PR DESCRIPTION
## Summary

Implements barnard#63 on top of the barnard#65 identity module (**this PR's base branch is `feat/issue-65-per-event-signing`, not `main`** — #63 depends on #65's `BarnardIdentity` module; will be re-targeted to `main` automatically once #65 merges, per the task brief's instruction to branch #63 from the #65 tip).

Adds `proveRpidOwnership` — a verifier-checkable proof that the caller owns a given RPID for `(eventIdHash, enin)`, without disclosing the TEK/RPIK or any other ENIN's RPI:

```
sig = sign_deviceKey("barnard-rpid-proof:v1" ‖ eventIdHash ‖ enin ‖ rpi ‖ challenge)
```

Also adds `proveKeyBinding` (acceptance criterion 3: `signingPublicKey ↔ device` binding established at join) and deprecates `exportCurrentTek` everywhere (without removing it).

## Deviation from the issue's literal signature

The issue's sketch is `proveRpidOwnership({required int enin, required Uint8List eventIdHash, Uint8List? challenge})` with no `eventCode` — implying it reads "current event" state. But `BarnardIdentity` (barnard#65) is deliberately a module separate from `BarnardClient` and does not track live sensing state (no `currentEventCode`/`currentTek`). I added `eventCode` as a required parameter, matching the pattern already established by `signingPublicKey(eventCode)`/`sign(eventCode, bytes)` in #65. This still satisfies every acceptance bullet.

## Canonical message encoding

Fixed-order, length-prefixed (documented in `signing.dart`/`BarnardSigning.kt`/`BarnardSigning.swift`):
```
"barnard-rpid-proof:v1" (ASCII, fixed) ‖ eventIdHash(32) ‖ enin(8, BE) ‖ rpi(16) ‖ len(challenge) as u16 BE ‖ challenge
```
`rpi` is the 16-byte inner RPI (`BarnardClient.getCurrentRpi()`'s value), not the 17-byte wire payload — chosen for consistency with the existing `RPI = AES128-ECB(RPIK, pad(ENIN))` definition in `crypto.dart`, called out here since the issue doesn't specify which.

`proveKeyBinding`: `sig = sign_deviceKey("barnard-key-binding:v1" ‖ EventCodeHash ‖ displayId)` — lets a verifier who already has `displayId` (from GATT B003) and `signingPublicKey` (disclosed at join) confirm they belong to the same device.

## Changed files (by platform)

**Dart**: `signing.dart` (message builders + `signRpidOwnershipProof`/`signKeyBinding`), `barnard_identity.dart` (`RpidOwnershipProof`, `proveRpidOwnership`/`proveKeyBinding` on the `BarnardIdentity` interface), mock + BLE implementations, `barnard_client.dart` (`@Deprecated` on `exportCurrentTek`), `test/rpid_proof_test.dart` (7 tests: acceptance bullets 1–3 + non-replayability + challenge binding).

**Kotlin** (both platform copies, byte-identical): `BarnardSigning.kt` (message builders + `proveRpidOwnership`/`signKeyBinding`), `BarnardIdentityController.kt` / `BarnardIdentityModule.kt` (new method-channel/RN-module handlers), `BarnardController.kt` / `BarnardModule.kt` (`exportCurrentTek` deprecation comment/`@Deprecated`), `BarnardRpidProofTest.kt` (6 JVM tests, same coverage as Dart).

**Swift** (both platform copies, byte-identical): `BarnardSigning.swift` (message builders + `proveRpidOwnership`/`signKeyBinding`), `BarnardIdentityController.swift` / `BarnardIdentity.swift`+`.m` (new channel/module handlers), `BarnardBleController.swift` / `Barnard.swift` (`exportCurrentTek` deprecation doc comment).

**React Native TS**: `types.ts` (`RpidOwnershipProof`), `NativeBarnardIdentity.ts`/`BarnardIdentity.ts` (`proveRpidOwnership`/`proveKeyBinding` — the TS layer reassembles the full proof from the native module's narrower return plus the caller-supplied `enin`/`eventIdHash`, since native doesn't echo those back), `NativeBarnard.ts`/`BarnardManager.ts` (`@deprecated` JSDoc on `exportCurrentTek`), `__tests__/BarnardIdentity.test.ts` (4 new tests).

## Validation run + output

**Dart**: `flutter test` → `107/107 passed`. `flutter analyze` → `No issues found!` (no unexpected deprecation warnings from `@Deprecated` — `deprecated_member_use_from_same_package` isn't in `flutter_lints`' default rule set, so same-package callers like `mock_barnard_test.dart` continue to build clean, same as before).

**Kotlin (Dart-plugin `android/`)**: `JAVA_HOME=<jdk17> ./gradlew testDebugUnitTest` → all green (incl. 6/6 new `BarnardRpidProofTest`). Local JDK 25 still breaks Gradle (pre-existing toolchain issue, same as #65's PR).

**Kotlin (RN `android/`)**: no standalone Gradle wrapper/example app (toolchain gap, same as #65). `BarnardSigning.kt`/`BarnardRpidProofTest.kt` are byte-identical (diff-confirmed) to the Gradle-and-JVM-verified Dart-plugin copy.

**Swift (both copies)**: no XCTest target in this repo (toolchain gap, same as #65). Validated the actual production `BarnardSigning.swift` (+ `Secp256k1.swift`/`BarnardCrypto.swift`) by compiling with `swiftc -O` and a standalone driver exercising the same 9-check matrix as the Dart test — all pass, including the proof `rpi` matching an independently-computed `AES128-ECB(RPIK, pad(ENIN))` and the signature recovering to the disclosed `signingPublicKey`.

**React Native**: `npm test -- --runInBand` → `24/24 passed` (4 new). `npx tsc --noEmit` → clean. `npm run lint` still fails on the same pre-existing `prettier.resolveConfig.sync` toolchain error noted in #65, unrelated to this change.

## Acceptance criteria

1. **`proveRpidOwnership` yields a verifier-checkable proof bound to `(eventIdHash, enin)`** — ✅ tested: signature recovers to `signingPublicKey` under the canonical message; `rpi` matches the independently-derived value.
2. **Discloses neither TEK nor RPIK, nor any non-claimed RPI; not replayable to another event/ENIN** — ✅ tested: proof bytes never contain TEK/RPIK material; a proof for `enin=5` doesn't reveal `enin=6`'s RPI; a signature computed against one `eventIdHash`/`enin` fails to recover the signer's key when checked against a different `eventIdHash`/`enin`'s message; an optional `challenge` further changes the signed message.
3. **`signingPublicKey ↔ device` binding established at join** — ✅ `proveKeyBinding` lets a device produce a self-signed statement (`EventCodeHash ‖ displayId`) a verifier checks against the disclosed `signingPublicKey`, usable at join time before any RPID proof is needed.
4. **`exportCurrentTek()` deprecated; host apps no longer need the raw TEK** — ✅ `@Deprecated`/`@deprecated` on every platform's public surface, not removed (existing callers unaffected).

## Notes for the checker

- Same caveat as #65: Swift's secp256k1 is a from-scratch implementation, cross-verified against Dart/Kotlin but not against a reference library's test vectors.
- I did not implement or touch the ZK-based variant the issue explicitly defers ("the *eventual* privacy-maximal answer, not the pragmatic first step") — this PR implements exactly the recommended signed-credential primitive.
- Not self-reviewed/declared mergeable per maker≠checker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMPEzZ2FFCDWx1GHNpSPw1