### PR TITLE
feat(ios): first-class SwiftPM package for native iOS SDK (barnard#56 slice)

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -1,0 +1,71 @@
+name: Native SDK CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  swift-package:
+    # Flutter-free: builds/tests packages/swift/barnard directly. No Flutter
+    # toolchain is installed in this job (barnard#56 acceptance criterion:
+    # "CI validates each first-class SDK surface independently").
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: packages/swift/barnard
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+      - name: Resolve simulator destination
+        id: destination
+        run: |
+          UDID=$(xcrun simctl list devices available iOS -j | \
+            python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; \
+            runtimes=[k for k in d if 'iOS' in k]; \
+            runtimes.sort(reverse=True); \
+            devices=[dev for rt in runtimes for dev in d[rt] if 'iPhone' in dev['name']]; \
+            print(devices[0]['udid'])")
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+      - name: swift build (package graph sanity check)
+        run: xcodebuild -scheme Barnard -destination "id=${{ steps.destination.outputs.udid }}" build
+      - name: swift test (crypto/TEK/RPID + signing unit tests)
+        run: xcodebuild -scheme Barnard -destination "id=${{ steps.destination.outputs.udid }}" test
+
+  swift-mirror-sync-check:
+    # packages/swift/barnard mirrors the Flutter-free crypto/signing/RPID
+    # sources under packages/dart/barnard/ios; this guards against drift
+    # (see scripts/check-swift-mirror.sh).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check-swift-mirror.sh
+
+  ios-native-example:
+    runs-on: macos-15
+    defaults:
+      run:
+        working-directory: examples/ios-native
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+      - name: Install XcodeGen
+        run: brew install xcodegen
+      - name: Generate Xcode project
+        run: xcodegen generate
+      - name: Resolve simulator destination
+        id: destination
+        run: |
+          UDID=$(xcrun simctl list devices available iOS -j | \
+            python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; \
+            runtimes=[k for k in d if 'iOS' in k]; \
+            runtimes.sort(reverse=True); \
+            devices=[dev for rt in runtimes for dev in d[rt] if 'iPhone' in dev['name']]; \
+            print(devices[0]['udid'])")
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+      - name: Build native iOS example (Flutter-free)
+        run: |
+          xcodebuild -project BarnardNativeExample.xcodeproj -scheme BarnardNativeExample \
+            -destination "id=${{ steps.destination.outputs.udid }}" build

--- a/examples/ios-native/.gitignore
+++ b/examples/ios-native/.gitignore
@@ -1,0 +1,2 @@
+*.xcodeproj/
+DerivedData/

--- a/examples/ios-native/BarnardNativeExample/BarnardNativeExampleApp.swift
+++ b/examples/ios-native/BarnardNativeExample/BarnardNativeExampleApp.swift
@@ -1,0 +1,13 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import SwiftUI
+
+@main
+struct BarnardNativeExampleApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}

--- a/examples/ios-native/BarnardNativeExample/ContentView.swift
+++ b/examples/ios-native/BarnardNativeExample/ContentView.swift
@@ -1,0 +1,94 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import Barnard
+import SwiftUI
+
+/// Minimal native iOS example (barnard#56): start/stop scan+advertise
+/// against the Flutter-free `Barnard` SwiftPM package and print events.
+/// No Flutter runtime involved.
+@MainActor
+final class BarnardExampleModel: ObservableObject {
+  private let engine = BarnardEngine()
+
+  @Published var isScanning = false
+  @Published var isAdvertising = false
+  @Published var log: [String] = []
+
+  init() {
+    engine.onEvent = { [weak self] event in
+      guard let self = self else { return }
+      Task { @MainActor in
+        self.handle(event)
+      }
+    }
+  }
+
+  private func handle(_ event: BarnardEvent) {
+    switch event {
+    case .state(let state):
+      isScanning = state.isScanning
+      isAdvertising = state.isAdvertising
+      append("state: scanning=\(state.isScanning) advertising=\(state.isAdvertising) reason=\(state.reasonCode ?? "-")")
+    case .detection(let detection):
+      append("detection: rpid=\(detection.rpid) rssi=\(detection.rssi) enin=\(detection.enin)")
+    case .rssiUpdate(let update):
+      append("rssi_update: rpid=\(update.rpid) rssi=\(update.rssi)")
+    case .error(let error):
+      append("error: \(error.code) \(error.message)")
+    case .constraint(let constraint):
+      append("constraint: \(constraint.code) \(constraint.message ?? "")")
+    }
+  }
+
+  private func append(_ line: String) {
+    print("[Barnard] \(line)")
+    log.append(line)
+    if log.count > 200 {
+      log.removeFirst(log.count - 200)
+    }
+  }
+
+  func requestPermissionsThenStart() {
+    engine.requestPermissions { [weak self] status in
+      guard let self = self else { return }
+      Task { @MainActor in
+        self.append("permissions: canScan=\(status.canScan) canAdvertise=\(status.canAdvertise)")
+        if status.canScan && status.canAdvertise {
+          self.engine.startAuto()
+        }
+      }
+    }
+  }
+
+  func stopAuto() {
+    engine.stopAuto()
+  }
+}
+
+struct ContentView: View {
+  @StateObject private var model = BarnardExampleModel()
+
+  var body: some View {
+    NavigationView {
+      VStack(spacing: 12) {
+        HStack {
+          Text("Scanning: \(model.isScanning ? "on" : "off")")
+          Spacer()
+          Text("Advertising: \(model.isAdvertising ? "on" : "off")")
+        }
+        .padding(.horizontal)
+
+        HStack {
+          Button("Start") { model.requestPermissionsThenStart() }
+          Button("Stop") { model.stopAuto() }
+        }
+
+        List(model.log.reversed(), id: \.self) { line in
+          Text(line).font(.system(.footnote, design: .monospaced))
+        }
+      }
+      .navigationTitle("Barnard Native")
+    }
+  }
+}

--- a/examples/ios-native/BarnardNativeExample/Info.plist
+++ b/examples/ios-native/BarnardNativeExample/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Barnard uses Bluetooth to scan for and advertise to nearby devices running the Barnard protocol.</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>Barnard uses Bluetooth to scan for and advertise to nearby devices running the Barnard protocol.</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/examples/ios-native/project.yml
+++ b/examples/ios-native/project.yml
@@ -1,0 +1,28 @@
+name: BarnardNativeExample
+options:
+  bundleIdPrefix: network.greeting.barnard.example
+  deploymentTarget:
+    iOS: "16.0"
+packages:
+  Barnard:
+    path: ../../packages/swift/barnard
+targets:
+  BarnardNativeExample:
+    type: application
+    platform: iOS
+    sources:
+      - BarnardNativeExample
+    dependencies:
+      - package: Barnard
+        product: Barnard
+    info:
+      path: BarnardNativeExample/Info.plist
+      properties:
+        UILaunchScreen: {}
+        NSBluetoothAlwaysUsageDescription: "Barnard uses Bluetooth to scan for and advertise to nearby devices running the Barnard protocol."
+        NSBluetoothPeripheralUsageDescription: "Barnard uses Bluetooth to scan for and advertise to nearby devices running the Barnard protocol."
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: network.greeting.barnard.example.native
+        SWIFT_VERSION: "5.0"
+        TARGETED_DEVICE_FAMILY: "1,2"

--- a/packages/swift/barnard/.gitignore
+++ b/packages/swift/barnard/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+*.xcodeproj

--- a/packages/swift/barnard/Package.swift
+++ b/packages/swift/barnard/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Barnard",
+    platforms: [
+        .iOS("14.0")
+    ],
+    products: [
+        .library(name: "Barnard", targets: ["Barnard"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Barnard",
+            dependencies: [],
+            resources: [
+                .process("PrivacyInfo.xcprivacy")
+            ]
+        ),
+        .testTarget(
+            name: "BarnardTests",
+            dependencies: ["Barnard"]
+        )
+    ]
+)

--- a/packages/swift/barnard/README.md
+++ b/packages/swift/barnard/README.md
@@ -1,0 +1,72 @@
+# Barnard (Swift)
+
+First-class Swift Package Manager library for native iOS apps to adopt the
+Barnard protocol without a Flutter runtime dependency (barnard#56).
+
+## Installation
+
+Add as a Swift Package dependency (local path shown; publish via a Git tag
+once this package is released):
+
+```swift
+dependencies: [
+    .package(path: "../path/to/packages/swift/barnard")
+]
+```
+
+Then depend on the `Barnard` product in your app target.
+
+## Usage
+
+```swift
+import Barnard
+
+let engine = BarnardEngine()
+engine.onEvent = { event in
+  switch event {
+  case .detection(let d):
+    print("detected rpid=\(d.rpid) rssi=\(d.rssi)")
+  default:
+    break
+  }
+}
+
+engine.requestPermissions { status in
+  guard status.canScan, status.canAdvertise else { return }
+  engine.startAuto()
+}
+```
+
+For per-event device signing identity (RPID ownership proofs, key binding),
+use `BarnardIdentity` — see `Sources/Barnard/BarnardIdentity.swift`.
+
+See `examples/ios-native` for a runnable minimal app.
+
+## Relationship to the Flutter plugin
+
+This package is currently a **mirror**, not a move, of
+`packages/dart/barnard/ios/barnard`:
+
+- `BarnardCrypto.swift`, `Secp256k1.swift`, `BarnardSigning.swift`,
+  `BarnardRpidGenerator.swift`, `BarnardV2Policy.swift`, and
+  `PrivacyInfo.xcprivacy` are byte-for-byte copies of the Flutter plugin's
+  Flutter-free sources. `scripts/check-swift-mirror.sh` (repo root) fails CI
+  if they drift.
+- `BarnardEngine.swift` (Flutter-free port of `BarnardBleController`) and
+  `BarnardIdentity.swift` (Flutter-free port of `BarnardIdentityController`)
+  are new files, not mirrors — the originals are woven into Flutter's
+  method-channel API (`FlutterEventSink`, `FlutterMethodCall`) and cannot be
+  copied verbatim. They re-implement the same behavior with a Swift-first
+  public API (closures/return values instead of a method-channel
+  dispatcher).
+
+**Why mirror instead of making the Flutter plugin depend on this package**:
+the Flutter plugin ships via a CocoaPods podspec
+(`packages/dart/barnard/ios/barnard.podspec`); making a CocoaPods pod depend
+on a sibling local SwiftPM package is possible but nontrivial to wire up
+safely, and this repo's CI/tooling here has no Flutter/CocoaPods toolchain
+to validate that path end-to-end. Mirroring the pure, dependency-free
+sources with a byte-identical sync check is lower-risk for this first
+slice. Follow-up: evaluate making `packages/dart/barnard/ios` depend on
+this package directly (true move) once that path is validated against a
+real Flutter build.

--- a/packages/swift/barnard/Sources/Barnard/BarnardCrypto.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardCrypto.swift
@@ -1,0 +1,251 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CommonCrypto
+import CryptoKit
+import Foundation
+
+/// GAEN v1.2-compatible cryptographic utilities for Resolvable ID.
+///
+/// Key derivation chain:
+/// ```
+/// DeviceSecret (32 bytes)
+///      |
+///      +-- Anonymous Mode: TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)
+///      |
+///      +-- Event Mode: TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)
+///                           |
+///                           v
+///                      RPIK = HKDF(TEK, "EN-RPIK", 16)
+///                           |
+///                           v
+///                      RPI = AES128-ECB(RPIK, PaddedData)
+/// ```
+enum BarnardCrypto {
+  enum EninMode {
+    case fixedLength
+    case beaconSlot
+  }
+
+  struct BeaconChainConfig {
+    let chainId: String
+    let genesisUnixSeconds: Int
+    let slotSeconds: Int
+
+    static let ethereumMainnet = BeaconChainConfig(
+      chainId: "mainnet",
+      genesisUnixSeconds: 1_606_824_023,
+      slotSeconds: 12
+    )
+
+    var effectiveGenesisUnixSeconds: Int { max(0, genesisUnixSeconds) }
+    var effectiveSlotSeconds: Int { max(1, slotSeconds) }
+  }
+
+  // MARK: - TEK Derivation
+
+  /// Derive TEK for Event Mode from DeviceSecret and EventCode.
+  ///
+  /// `TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`
+  static func deriveTekForEvent(deviceSecret: Data, eventCode: String) -> Data {
+    guard let eventCodeData = eventCode.data(using: .utf8) else {
+      return generateRandomBytes(16)
+    }
+
+    var combined = deviceSecret
+    combined.append(eventCodeData)
+
+    let key = SymmetricKey(data: combined)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "barnard-tek".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  /// Derive TEK for Anonymous Mode from DeviceSecret.
+  ///
+  /// `TEK = HKDF(DeviceSecret, "barnard-tek-anonymous", 16)`
+  static func deriveTekForAnonymous(deviceSecret: Data) -> Data {
+    let key = SymmetricKey(data: deviceSecret)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "barnard-tek-anonymous".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  // MARK: - RPIK Derivation
+
+  /// Derive RPIK (Rolling Proximity Identifier Key) from TEK.
+  ///
+  /// `RPIK = HKDF(TEK, "EN-RPIK", 16)`
+  static func deriveRpik(from tek: Data) -> Data {
+    guard tek.count == 16 else {
+      return Data(count: 16)
+    }
+
+    let key = SymmetricKey(data: tek)
+    let derived = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: "EN-RPIK".data(using: .utf8)!,
+      outputByteCount: 16
+    )
+
+    return derived.withUnsafeBytes { Data($0) }
+  }
+
+  // MARK: - RPI Generation
+
+  /// Generate RPI from RPIK and ENIN.
+  ///
+  /// `RPI = AES128-ECB(RPIK, PaddedData)`
+  ///
+  /// Where PaddedData = "EN-RPI" (6 bytes) + 0x000000000000 (6 bytes) + ENIN (4 bytes big-endian)
+  static func generateRpi(rpik: Data, enin: UInt32) -> Data {
+    guard rpik.count == 16 else {
+      return Data(count: 16)
+    }
+
+    // Build PaddedData: "EN-RPI" + 6 zero bytes + ENIN (4 bytes big-endian)
+    var paddedData = Data(count: 16)
+
+    // "EN-RPI" (6 bytes)
+    let prefix = "EN-RPI".data(using: .utf8)!
+    paddedData.replaceSubrange(0 ..< 6, with: prefix)
+
+    // 6 zero bytes (already initialized to 0)
+
+    // ENIN as 4 bytes big-endian at offset 12
+    var eninBE = enin.bigEndian
+    let eninBytes = Data(bytes: &eninBE, count: 4)
+    paddedData.replaceSubrange(12 ..< 16, with: eninBytes)
+
+    // AES-128-ECB encryption
+    return aes128EcbEncrypt(key: rpik, plaintext: paddedData)
+  }
+
+  /// AES-128-ECB encryption of a single 16-byte block.
+  private static func aes128EcbEncrypt(key: Data, plaintext: Data) -> Data {
+    guard key.count == 16, plaintext.count == 16 else {
+      return Data(count: 16)
+    }
+
+    var outputBuffer = [UInt8](repeating: 0, count: 16)
+    var dataOutMoved = 0
+
+    // Use CommonCrypto for AES-ECB (CryptoKit doesn't support ECB)
+    let status = key.withUnsafeBytes { keyPtr in
+      plaintext.withUnsafeBytes { inputPtr in
+        CCCrypt(
+          CCOperation(kCCEncrypt),
+          CCAlgorithm(kCCAlgorithmAES128),
+          CCOptions(kCCOptionECBMode),
+          keyPtr.baseAddress, key.count,
+          nil, // No IV for ECB
+          inputPtr.baseAddress, plaintext.count,
+          &outputBuffer, outputBuffer.count,
+          &dataOutMoved
+        )
+      }
+    }
+
+    return status == kCCSuccess ? Data(outputBuffer) : Data(count: 16)
+  }
+
+  // MARK: - ENIN Calculation
+
+  /// Calculate ENIN (EN Interval Number) for a given timestamp.
+  ///
+  /// Defaults to `ENIN = floor(unix_timestamp_seconds / 300)`.
+  ///
+  /// Each default ENIN represents a 5-minute interval.
+  static func calculateEnin(
+    for date: Date = Date(),
+    mode: EninMode = .fixedLength,
+    eninSeconds: Int = 300,
+    beaconChain: BeaconChainConfig = .ethereumMainnet
+  ) -> UInt32 {
+    let unixSeconds = Int(date.timeIntervalSince1970)
+    switch mode {
+    case .fixedLength:
+      let effectiveSeconds = min(max(eninSeconds, 12), 3600)
+      return UInt32(unixSeconds / effectiveSeconds)
+    case .beaconSlot:
+      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
+      if elapsed <= 0 { return 0 }
+      return UInt32(elapsed / beaconChain.effectiveSlotSeconds)
+    }
+  }
+
+  /// Returns the completion-time ENIN only when a GATT RPID read stayed inside
+  /// one ENIN window. If the read straddled a boundary, the Central cannot
+  /// assign the peer RPID to a single observation timestamp.
+  static func stableReadEnin(
+    startedAt: Date,
+    completedAt: Date,
+    mode: EninMode = .fixedLength,
+    eninSeconds: Int = 300,
+    beaconChain: BeaconChainConfig = .ethereumMainnet
+  ) -> UInt32? {
+    let startedEnin = calculateEnin(
+      for: startedAt,
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    )
+    let completedEnin = calculateEnin(
+      for: completedAt,
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    )
+    return startedEnin == completedEnin ? completedEnin : nil
+  }
+
+  // MARK: - EventCodeHash
+
+  /// Calculate EventCodeHash from EventCode.
+  ///
+  /// `EventCodeHash = SHA256(EventCode)[0:8]`
+  static func computeEventCodeHash(_ eventCode: String) -> Data {
+    guard let eventCodeData = eventCode.data(using: .utf8) else {
+      return Data(count: 8)
+    }
+
+    let hash = SHA256.hash(data: eventCodeData)
+    return Data(hash).prefix(8)
+  }
+
+  // MARK: - Display ID (v2)
+
+  /// v2 displayId: `SHA256(TEK)[0:4]` = 4 bytes.
+  static func displayId4(from tek: Data) -> Data {
+    let hash = SHA256.hash(data: tek)
+    return Data(hash).prefix(4)
+  }
+
+  /// v2 displayId hex: 8 lowercase hex chars, `SHA256(TEK)[0:4]`.
+  static func displayIdString(from tek: Data) -> String {
+    displayId4(from: tek).hexString
+  }
+
+  // MARK: - Random Bytes
+
+  /// Generate cryptographically secure random bytes.
+  static func generateRandomBytes(_ count: Int) -> Data {
+    var bytes = [UInt8](repeating: 0, count: count)
+    _ = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+    return Data(bytes)
+  }
+}
+
+/// Lowercase-hex helpers for the method-channel boundary.
+extension Data {
+  var hexString: String {
+    map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
@@ -1,0 +1,1557 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CoreBluetooth
+import Foundation
+import UIKit
+
+/// Flutter-free, Swift-first public event/value types for `BarnardEngine`.
+///
+/// These mirror the shapes emitted on the Flutter `barnard/events` and
+/// `barnard/debugEvents` channels (see
+/// `packages/dart/barnard/ios/barnard/Sources/barnard/BarnardBleController.swift`)
+/// but are expressed as native Swift types instead of untyped
+/// `[String: Any]` dictionaries.
+
+public struct BarnardBeaconChain: Equatable {
+  public let chainId: String
+  public let genesisUnixSeconds: Int
+  public let slotSeconds: Int
+
+  public static let ethereumMainnet = BarnardBeaconChain(
+    chainId: "mainnet",
+    genesisUnixSeconds: 1_606_824_023,
+    slotSeconds: 12
+  )
+
+  public init(chainId: String, genesisUnixSeconds: Int, slotSeconds: Int) {
+    self.chainId = chainId
+    self.genesisUnixSeconds = genesisUnixSeconds
+    self.slotSeconds = slotSeconds
+  }
+
+  fileprivate var internalConfig: BarnardCrypto.BeaconChainConfig {
+    BarnardCrypto.BeaconChainConfig(
+      chainId: chainId,
+      genesisUnixSeconds: genesisUnixSeconds,
+      slotSeconds: slotSeconds
+    )
+  }
+}
+
+public enum BarnardEninMode: String {
+  case fixedLength
+  case beaconSlot
+
+  fileprivate var internalMode: BarnardCrypto.EninMode {
+    switch self {
+    case .fixedLength: return .fixedLength
+    case .beaconSlot: return .beaconSlot
+    }
+  }
+}
+
+public struct BarnardCapabilities {
+  public let supportedTransports: [String]
+  public let supportsConnectionlessRpid: Bool
+  public let supportsGattFallback: Bool
+  public let supportsBackground: Bool
+  public let supportsHighRateRssi: Bool
+  public let eninMode: BarnardEninMode
+  public let eninSeconds: Int
+  public let beaconChain: BarnardBeaconChain
+}
+
+public struct BarnardState {
+  public let isScanning: Bool
+  public let isAdvertising: Bool
+  public let eventCode: String?
+  public let eninMode: BarnardEninMode
+  public let eninSeconds: Int
+  public let beaconChain: BarnardBeaconChain
+  public let reasonCode: String?
+}
+
+public struct BarnardPermissionStatus {
+  public let platform: String
+  public let permissions: [String: String]
+  public let requiredPermissions: [String]
+  public let missingPermissions: [String]
+  public let requestablePermissions: [String]
+  public let blockedPermissions: [String]
+  public let canScan: Bool
+  public let canAdvertise: Bool
+}
+
+public struct BarnardDetectionEvent {
+  public let timestamp: Date
+  public let rssi: Int
+  public let formatVersion: Int
+  /// Lowercase hex, 17 bytes.
+  public let rpid: String
+  /// Lowercase hex, this device's own current RPID at `timestamp`.
+  public let reporterRpid: String
+  public let detectedDisplayId: String?
+  public let enin: Int
+  public let debugLocalName: String?
+}
+
+public struct BarnardRssiUpdateEvent {
+  public let timestamp: Date
+  public let rssi: Int
+  public let rpid: String
+  public let reporterRpid: String
+  public let enin: Int
+  public let detectedDisplayId: String?
+  public let debugLocalName: String?
+}
+
+public struct BarnardErrorEvent {
+  public let code: String
+  public let message: String
+  public let recoverable: Bool?
+}
+
+public struct BarnardConstraintEvent {
+  public let code: String
+  public let message: String?
+}
+
+public enum BarnardEvent {
+  case state(BarnardState)
+  case constraint(BarnardConstraintEvent)
+  case error(BarnardErrorEvent)
+  case detection(BarnardDetectionEvent)
+  case rssiUpdate(BarnardRssiUpdateEvent)
+}
+
+public struct BarnardDebugEvent {
+  public let timestamp: Date
+  public let level: String
+  public let name: String
+  public let data: [String: Any]?
+}
+
+/// Barnard v2 BLE engine — Flutter-free, Swift-first port of
+/// `BarnardBleController` (the Flutter plugin's native controller). Same
+/// GATT service (fixed UUID), same v2 wire behavior:
+///
+/// - B002 RPID (Read, 17 bytes)
+/// - B003 displayId (Read, 4 bytes when joined to an event) — `SHA256(TEK)[0:4]`. v2 no longer serves TEK.
+/// - B004 EventCodeHash (Read, 0 or 8 bytes)
+///
+/// TEK is never transmitted over BLE in v2. No device-unique persistent
+/// identifier is placed on the wire (same invariant as the Flutter plugin).
+public final class BarnardEngine: NSObject {
+  // MARK: - UUIDs
+
+  private let discoveryServiceUUID = CBUUID(string: "0000B001-0000-1000-8000-00805F9B34FB")
+  private let rpidCharacteristicUUID = CBUUID(string: "0000B002-0000-1000-8000-00805F9B34FB")
+  private let displayIdCharacteristicUUID = CBUUID(string: "0000B003-0000-1000-8000-00805F9B34FB")
+  private let eventCodeHashCharacteristicUUID = CBUUID(string: "0000B004-0000-1000-8000-00805F9B34FB")
+  private let localName = "BNRD"
+  private let unavailableRssi = 127
+
+  private var debugLocalName: String {
+    #if DEBUG
+    let suffix = debugDeviceSuffix()
+    return "BND-\(suffix)"
+    #else
+    return localName
+    #endif
+  }
+
+  private func debugDeviceSuffix() -> String {
+    let deviceSecret = rpid.getDeviceSecret()
+    let tail = deviceSecret.suffix(2)
+    let hex = tail.map { String(format: "%02x", $0) }.joined().uppercased()
+    return hex.isEmpty ? "DEAD" : hex
+  }
+
+  private let iso8601: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+  }()
+
+  // MARK: - Components
+
+  private let rpid = BarnardRpidGenerator()
+
+  // MARK: - BLE Managers
+
+  private var centralManager: CBCentralManager?
+  private var peripheralManager: CBPeripheralManager?
+  private var pendingPermissionCompletions: [(BarnardPermissionStatus) -> Void] = []
+
+  // MARK: - GATT Characteristics (Peripheral)
+
+  private var rpidCharacteristic: CBMutableCharacteristic?
+  private var displayIdCharacteristic: CBMutableCharacteristic?
+  private var eventCodeHashCharacteristic: CBMutableCharacteristic?
+
+  // MARK: - State
+
+  private var isScanning = false
+  private var isAdvertising = false
+  private var shouldStartScanWhenReady = false
+  private var shouldStartAdvertiseWhenReady = false
+  private var allowDuplicates = true
+  private var formatVersion: UInt8 = 1
+  private var eninMode: BarnardCrypto.EninMode = .fixedLength
+  private var eninSeconds: Int = 300
+  private var beaconChain: BarnardCrypto.BeaconChainConfig = .ethereumMainnet
+
+  private var lastDiscoveryNameById: [UUID: String] = [:]
+
+  // MARK: - Discovery State
+
+  private var discoveredRssi: [UUID: Int] = [:]
+  private var discoveredAt: [UUID: Date] = [:]
+
+  // MARK: - Connection Queue
+
+  private var connectQueue: [UUID] = []
+  private var peripheralsById: [UUID: CBPeripheral] = [:]
+  private var lastConnectAttemptAt: [UUID: Date] = [:]
+  private var resolutionBackoffUntil: [UUID: Date] = [:]
+  private var pendingBoundaryRetryPeripherals: [UUID: CBPeripheral] = [:]
+  private var activePeripheral: CBPeripheral?
+
+  private let maxConcurrentConnections = 1
+  private let cooldownPerPeerSeconds: TimeInterval = 10
+  private let resolutionFailureBackoffSeconds: TimeInterval = 30
+  private let resolutionRejectedBackoffSeconds: TimeInterval = 5 * 60
+  private let rpidBoundaryRetryDelaySeconds: TimeInterval = 0.25
+  private let maxConnectQueue = 20
+  // See BarnardBleController (issue this mirrors): CoreBluetooth's
+  // connection/GATT callbacks have no built-in deadline, so a manual
+  // watchdog releases a hung `activePeripheral` pin after this many seconds.
+  private let connectTimeoutSeconds: TimeInterval = 8
+  private var connectWatchdog: DispatchWorkItem?
+  private var connectCooldownWorkItem: DispatchWorkItem?
+
+  // MARK: - Central GATT State (per connection)
+
+  private var peripheralCharacteristics: [UUID: [CBUUID: CBCharacteristic]] = [:]
+  private var peripheralReadValues: [UUID: PeripheralGattValues] = [:]
+  private var b004ReadRetries: [UUID: Int] = [:]
+  private let maxB004ReadRetries = 2
+  private let b004ReadRetryDelaySeconds: TimeInterval = 0.25
+
+  private struct PeripheralGattValues {
+    var eventCodeHash: Data?
+    var rpid: Data?
+    var rpidReadStartedAt: Date?
+    var rpidReadCompletedAt: Date?
+    var detectedDisplayId: Data?
+  }
+
+  // MARK: - Known Peers (for high-rate RSSI updates)
+
+  private struct KnownPeer {
+    let rpid: Data
+    let enin: UInt32
+    var detectedDisplayId: String?
+    var debugLocalName: String?
+  }
+
+  private var knownPeers: [UUID: KnownPeer] = [:]
+
+  private func shouldServeGattDisplayId() -> Bool {
+    BarnardV2Policy.shouldServeGattDisplayId(eventCode: rpid.eventCode)
+  }
+
+  private func currentEnin(_ date: Date = Date()) -> UInt32 {
+    BarnardCrypto.calculateEnin(
+      for: date,
+      mode: eninMode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    )
+  }
+
+  private func currentPayload(now: Date) -> Data {
+    rpid.currentPayload(
+      formatVersion: formatVersion,
+      now: now,
+      eninMode: eninMode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    )
+  }
+
+  private func eninModeName() -> BarnardEninMode {
+    switch eninMode {
+    case .beaconSlot: return .beaconSlot
+    case .fixedLength: return .fixedLength
+    }
+  }
+
+  private func beaconChainInfo() -> BarnardBeaconChain {
+    BarnardBeaconChain(
+      chainId: beaconChain.chainId,
+      genesisUnixSeconds: beaconChain.effectiveGenesisUnixSeconds,
+      slotSeconds: beaconChain.effectiveSlotSeconds
+    )
+  }
+
+  // MARK: - Event Delivery
+
+  /// Called on the main queue with the same event stream the Flutter plugin
+  /// exposes on the `barnard/events` channel.
+  public var onEvent: ((BarnardEvent) -> Void)?
+  /// Called on the main queue with the same event stream the Flutter plugin
+  /// exposes on the `barnard/debugEvents` channel.
+  public var onDebugEvent: ((BarnardDebugEvent) -> Void)?
+
+  // MARK: - Initialization
+
+  override public init() {
+    super.init()
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(appDidBecomeActive),
+      name: UIApplication.didBecomeActiveNotification,
+      object: nil
+    )
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(appWillResignActive),
+      name: UIApplication.willResignActiveNotification,
+      object: nil
+    )
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  private func ensureCentralManager() -> CBCentralManager {
+    if let manager = centralManager {
+      return manager
+    }
+    let manager = CBCentralManager(delegate: self, queue: nil)
+    centralManager = manager
+    return manager
+  }
+
+  private func ensurePeripheralManager() -> CBPeripheralManager {
+    if let manager = peripheralManager {
+      return manager
+    }
+    let manager = CBPeripheralManager(delegate: self, queue: nil)
+    peripheralManager = manager
+    return manager
+  }
+
+  private func ensureBleManagers() {
+    _ = ensureCentralManager()
+    _ = ensurePeripheralManager()
+  }
+
+  private func bluetoothPermissionStatus() -> String {
+    switch CBManager.authorization {
+    case .allowedAlways:
+      return "granted"
+    case .denied:
+      return "denied"
+    case .restricted:
+      return "restricted"
+    case .notDetermined:
+      return "notDetermined"
+    @unknown default:
+      return "unknown"
+    }
+  }
+
+  private func permissionStatusPayload() -> BarnardPermissionStatus {
+    let permissionName = "ios.bluetooth"
+    let status = bluetoothPermissionStatus()
+    let missing = status == "granted" ? [] : [permissionName]
+    let blocked = (status == "denied" || status == "restricted") ? [permissionName] : []
+    let requestable = missing.filter { !blocked.contains($0) }
+    // iOS Simulator cannot scan or advertise over BLE even when CoreBluetooth
+    // authorization is granted, so capability flags must reflect that gap
+    // independently of authorization state. See issue #57.
+    let canBle = status == "granted" && !Self.isIosSimulator
+    return BarnardPermissionStatus(
+      platform: "ios",
+      permissions: [permissionName: status],
+      requiredPermissions: [permissionName],
+      missingPermissions: missing,
+      requestablePermissions: requestable,
+      blockedPermissions: blocked,
+      canScan: canBle,
+      canAdvertise: canBle
+    )
+  }
+
+  private static var isIosSimulator: Bool {
+    #if targetEnvironment(simulator)
+    return true
+    #else
+    return false
+    #endif
+  }
+
+  // MARK: - Public API
+
+  public func getCapabilities() -> BarnardCapabilities {
+    BarnardCapabilities(
+      supportedTransports: ["ble"],
+      supportsConnectionlessRpid: false,
+      supportsGattFallback: true,
+      supportsBackground: false,
+      supportsHighRateRssi: false,
+      eninMode: eninModeName(),
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChainInfo()
+    )
+  }
+
+  public func getState() -> BarnardState {
+    BarnardState(
+      isScanning: isScanning,
+      isAdvertising: isAdvertising,
+      eventCode: rpid.eventCode,
+      eninMode: eninModeName(),
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChainInfo(),
+      reasonCode: nil
+    )
+  }
+
+  public func configure(
+    eninMode: BarnardEninMode = .fixedLength,
+    eninSeconds requestedSeconds: Int = 300,
+    beaconChain requestedBeaconChain: BarnardBeaconChain = .ethereumMainnet,
+    eventCode: String? = nil
+  ) {
+    self.eninMode = eninMode.internalMode
+    self.eninSeconds = min(max(requestedSeconds, 12), 3600)
+    beaconChain = requestedBeaconChain.internalConfig
+
+    if let eventCode = eventCode, !eventCode.isEmpty, eventCode != rpid.eventCode {
+      resetPeerDiscoveryState(reason: "configure_event")
+      rpid.joinEvent(eventCode)
+      rebuildGattServiceIfNeeded()
+      emitState(reasonCode: "configure_event")
+    }
+
+    knownPeers.removeAll()
+    emitDebug(level: "info", name: "configure", data: [
+      "eninMode": eninModeName().rawValue,
+      "eninSeconds": self.eninSeconds,
+      "beaconChain": beaconChainInfo().chainId,
+    ])
+  }
+
+  public func getCurrentEventCode() -> String? {
+    rpid.eventCode
+  }
+
+  public func getMyDisplayId() -> String {
+    BarnardCrypto.displayIdString(from: rpid.getCurrentTek())
+  }
+
+  public func getCurrentRpi() -> String {
+    let rpik = BarnardCrypto.deriveRpik(from: rpid.getCurrentTek())
+    let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: currentEnin())
+    return rpi.hexString
+  }
+
+  public func getCurrentEnin() -> Int {
+    Int(currentEnin())
+  }
+
+  /// Explicit privacy egress. The SDK never transmits TEK over BLE; callers
+  /// decide whether/how to transmit it via another channel. Deprecated
+  /// (barnard#63): exposing the raw TEK lets anyone derive every RPID and
+  /// the displayId for it. Prefer `BarnardIdentity.proveRpidOwnership`. Kept
+  /// for parity with the Flutter plugin's `exportCurrentTek`.
+  public func exportCurrentTek() -> String {
+    rpid.getCurrentTek().hexString
+  }
+
+  public func getPermissionStatus() -> BarnardPermissionStatus {
+    permissionStatusPayload()
+  }
+
+  public func requestPermissions(completion: @escaping (BarnardPermissionStatus) -> Void) {
+    if bluetoothPermissionStatus() != "notDetermined" {
+      completion(permissionStatusPayload())
+      return
+    }
+
+    pendingPermissionCompletions.append(completion)
+    ensureBleManagers()
+    resolvePendingPermissionCompletionsIfPossible()
+  }
+
+  private func resolvePendingPermissionCompletionsIfPossible() {
+    guard !pendingPermissionCompletions.isEmpty else { return }
+    guard bluetoothPermissionStatus() != "notDetermined" else { return }
+
+    let payload = permissionStatusPayload()
+    let completions = pendingPermissionCompletions
+    pendingPermissionCompletions.removeAll()
+    for completion in completions {
+      completion(payload)
+    }
+  }
+
+  public func openAppSettings() {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+    DispatchQueue.main.async {
+      UIApplication.shared.open(url)
+    }
+  }
+
+  public func startScan(allowDuplicates: Bool = true) {
+    self.allowDuplicates = allowDuplicates
+    startScanInternal()
+  }
+
+  public func stopScan() {
+    stopScanInternal()
+  }
+
+  public func startAdvertise(formatVersion: Int = 1) {
+    self.formatVersion = acceptFormatVersion(formatVersion)
+    startAdvertiseInternal()
+  }
+
+  public func stopAdvertise() {
+    stopAdvertiseInternal()
+  }
+
+  @discardableResult
+  public func startAuto(
+    scanAllowDuplicates: Bool = true,
+    advertiseFormatVersion: Int = 1
+  ) -> (scanningStarted: Bool, advertisingStarted: Bool) {
+    allowDuplicates = scanAllowDuplicates
+    formatVersion = acceptFormatVersion(advertiseFormatVersion)
+
+    let wasScanning = isScanning
+    let wasAdvertising = isAdvertising
+    startScanInternal()
+    startAdvertiseInternal()
+    return (
+      scanningStarted: !wasScanning && isScanning,
+      advertisingStarted: !wasAdvertising && isAdvertising
+    )
+  }
+
+  public func stopAuto() {
+    stopScanInternal()
+    stopAdvertiseInternal()
+  }
+
+  public func dispose() {
+    stopScanInternal()
+    stopAdvertiseInternal()
+  }
+
+  public func joinEvent(_ eventCode: String) {
+    resetPeerDiscoveryState(reason: "join_event")
+    rpid.joinEvent(eventCode)
+    rebuildGattServiceIfNeeded()
+    emitState(reasonCode: "join_event")
+    emitDebug(level: "info", name: "join_event", data: [
+      "eventCode": eventCode,
+      "myDisplayId": rpid.getCurrentDisplayId(),
+    ])
+  }
+
+  public func leaveEvent() {
+    resetPeerDiscoveryState(reason: "leave_event")
+    rpid.leaveEvent()
+    rebuildGattServiceIfNeeded()
+    emitState(reasonCode: "leave_event")
+    emitDebug(level: "info", name: "leave_event", data: nil)
+  }
+
+  // MARK: - Lifecycle
+
+  // On background, iOS demotes our advertised service UUID from the AdvData
+  // section to the overflow area (Apple-only scanners can still see it, but
+  // generic centrals cannot). When the app returns to foreground, iOS does
+  // not automatically repromote the UUID, so peers that started their scan
+  // while we were backgrounded will never discover us. Bounce advertising on
+  // foreground resume to repopulate the AdvData section. See issue #45.
+  @objc private func appDidBecomeActive() {
+    guard isAdvertising else {
+      emitDebug(level: "trace", name: "foreground_resume", data: ["isAdvertising": false])
+      return
+    }
+    peripheralManager?.stopAdvertising()
+    isAdvertising = false
+    startAdvertiseInternal()
+    emitDebug(level: "info", name: "advertise_restart_on_foreground", data: nil)
+  }
+
+  @objc private func appWillResignActive() {
+    emitDebug(level: "info", name: "advertise_backgrounded", data: [
+      "isAdvertising": isAdvertising,
+    ])
+  }
+
+  // MARK: - Scan Control
+
+  private func startScanInternal() {
+    let manager = ensureCentralManager()
+    if isScanning {
+      shouldStartScanWhenReady = false
+      return
+    }
+    guard manager.state == .poweredOn else {
+      if manager.state == .unknown || manager.state == .resetting {
+        shouldStartScanWhenReady = true
+        emitDebug(level: "info", name: "scan_waiting_for_powered_on", data: [
+          "state": manager.state.rawValue,
+        ])
+      } else {
+        shouldStartScanWhenReady = false
+        emitConstraint(code: "bluetooth_not_ready", message: "CentralManager state=\(manager.state.rawValue)")
+      }
+      return
+    }
+    shouldStartScanWhenReady = false
+    let options: [String: Any] = [CBCentralManagerScanOptionAllowDuplicatesKey: allowDuplicates]
+    manager.scanForPeripherals(withServices: [discoveryServiceUUID], options: options)
+    isScanning = true
+    emitState(reasonCode: "scan_start")
+    emitDebug(level: "info", name: "scan_start", data: ["allowDuplicates": allowDuplicates])
+  }
+
+  private func stopScanInternal() {
+    shouldStartScanWhenReady = false
+    if !isScanning { return }
+    centralManager?.stopScan()
+    isScanning = false
+    resetPeerDiscoveryState(reason: "scan_stop")
+
+    emitState(reasonCode: "scan_stop")
+    emitDebug(level: "info", name: "scan_stop", data: nil)
+  }
+
+  private func resetPeerDiscoveryState(reason: String) {
+    connectQueue.removeAll()
+    if let active = activePeripheral {
+      centralManager?.cancelPeripheralConnection(active)
+    }
+    activePeripheral = nil
+    cancelConnectWatchdog()
+    cancelConnectCooldownWorkItem()
+
+    discoveredRssi.removeAll()
+    discoveredAt.removeAll()
+    peripheralsById.removeAll()
+    lastConnectAttemptAt.removeAll()
+    resolutionBackoffUntil.removeAll()
+    pendingBoundaryRetryPeripherals.removeAll()
+    peripheralCharacteristics.removeAll()
+    peripheralReadValues.removeAll()
+    b004ReadRetries.removeAll()
+    lastDiscoveryNameById.removeAll()
+    knownPeers.removeAll()
+
+    emitDebug(level: "info", name: "peer_cache_reset", data: ["reason": reason])
+  }
+
+  // MARK: - Advertise Control
+
+  private func startAdvertiseInternal() {
+    let manager = ensurePeripheralManager()
+    if isAdvertising {
+      shouldStartAdvertiseWhenReady = false
+      return
+    }
+    guard manager.state == .poweredOn else {
+      if manager.state == .unknown || manager.state == .resetting {
+        shouldStartAdvertiseWhenReady = true
+        emitDebug(level: "info", name: "advertise_waiting_for_powered_on", data: [
+          "state": manager.state.rawValue,
+        ])
+      } else {
+        shouldStartAdvertiseWhenReady = false
+        emitConstraint(code: "bluetooth_not_ready", message: "PeripheralManager state=\(manager.state.rawValue)")
+      }
+      return
+    }
+    shouldStartAdvertiseWhenReady = false
+    ensureGattService()
+    var ad: [String: Any] = [
+      CBAdvertisementDataServiceUUIDsKey: [discoveryServiceUUID],
+    ]
+    #if DEBUG
+    ad[CBAdvertisementDataLocalNameKey] = debugLocalName
+    #endif
+    manager.startAdvertising(ad)
+    isAdvertising = true
+    emitState(reasonCode: "advertise_start")
+    emitDebug(
+      level: "info",
+      name: "advertise_start",
+      data: [
+        "formatVersion": Int(formatVersion),
+        "serviceUuid": discoveryServiceUUID.uuidString,
+        "localName": debugLocalName,
+      ]
+    )
+  }
+
+  private func stopAdvertiseInternal() {
+    shouldStartAdvertiseWhenReady = false
+    if !isAdvertising { return }
+    peripheralManager?.stopAdvertising()
+    isAdvertising = false
+    emitState(reasonCode: "advertise_stop")
+    emitDebug(level: "info", name: "advertise_stop", data: nil)
+  }
+
+  // MARK: - GATT Service Management
+
+  private func ensureGattService() {
+    _ = ensurePeripheralManager()
+    if rpidCharacteristic != nil { return }
+    buildAndAddGattService()
+  }
+
+  private func rebuildGattServiceIfNeeded() {
+    guard let manager = peripheralManager, manager.state == .poweredOn else { return }
+
+    manager.removeAllServices()
+    rpidCharacteristic = nil
+    displayIdCharacteristic = nil
+    eventCodeHashCharacteristic = nil
+
+    buildAndAddGattService()
+
+    emitDebug(level: "info", name: "gatt_service_rebuilt", data: nil)
+  }
+
+  private func buildAndAddGattService() {
+    guard let manager = peripheralManager else { return }
+
+    // B002 RPID (Read only)
+    let rpidCh = CBMutableCharacteristic(
+      type: rpidCharacteristicUUID,
+      properties: [.read],
+      value: nil,
+      permissions: [.readable]
+    )
+
+    // B003 displayId (Read only, 4 bytes) — v2: was TEK, now event-scoped SHA256(TEK)[0:4]
+    let displayIdCh = CBMutableCharacteristic(
+      type: displayIdCharacteristicUUID,
+      properties: [.read],
+      value: nil,
+      permissions: [.readable]
+    )
+
+    // B004 EventCodeHash (Read only)
+    let eventCodeHashCh = CBMutableCharacteristic(
+      type: eventCodeHashCharacteristicUUID,
+      properties: [.read],
+      value: nil,
+      permissions: [.readable]
+    )
+
+    let svc = CBMutableService(type: discoveryServiceUUID, primary: true)
+    svc.characteristics = [rpidCh, displayIdCh, eventCodeHashCh]
+    manager.add(svc)
+
+    rpidCharacteristic = rpidCh
+    displayIdCharacteristic = displayIdCh
+    eventCodeHashCharacteristic = eventCodeHashCh
+
+    emitDebug(level: "info", name: "gatt_service_added", data: [
+      "characteristics": ["RPID", "displayId", "EventCodeHash"],
+    ])
+  }
+
+  // MARK: - Connection Queue
+
+  private func enqueueConnect(_ peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    peripheralsById[id] = peripheral
+
+    let now = Date()
+    if isResolutionBackedOff(id, now: now) {
+      emitResolutionBackoff(id, now: now)
+      return
+    }
+
+    if connectQueue.contains(id) || (activePeripheral?.identifier == id) { return }
+
+    if connectQueue.count >= maxConnectQueue {
+      emitDebug(level: "warn", name: "connect_queue_full", data: ["max": maxConnectQueue])
+      return
+    }
+
+    connectQueue.append(id)
+    pumpConnectQueue()
+  }
+
+  private func pumpConnectQueue() {
+    if maxConcurrentConnections <= 0 { return }
+    if activePeripheral != nil { return }
+    guard let nextId = connectQueue.first else { return }
+
+    let now = Date()
+    if let last = lastConnectAttemptAt[nextId] {
+      let remaining = cooldownPerPeerSeconds - now.timeIntervalSince(last)
+      if remaining > 0 {
+        connectQueue.removeFirst()
+        connectQueue.append(nextId)
+        scheduleConnectQueuePump(after: remaining)
+        return
+      }
+    }
+
+    guard let p = peripheralsById[nextId] else {
+      connectQueue.removeFirst()
+      return
+    }
+    guard let manager = centralManager else { return }
+
+    connectQueue.removeFirst()
+    activePeripheral = p
+    lastConnectAttemptAt[nextId] = now
+
+    peripheralReadValues[nextId] = PeripheralGattValues()
+    b004ReadRetries[nextId] = 0
+
+    p.delegate = self
+    manager.connect(p, options: nil)
+    emitDebug(level: "trace", name: "connect_attempt", data: ["id": nextId.uuidString])
+    armConnectWatchdog(for: nextId)
+  }
+
+  private func armConnectWatchdog(for id: UUID) {
+    connectWatchdog?.cancel()
+    let work = DispatchWorkItem { [weak self] in
+      guard let self = self else { return }
+      guard let pinned = self.activePeripheral, pinned.identifier == id else {
+        return
+      }
+      self.emitDebug(level: "warn", name: "gatt_exchange_timeout", data: [
+        "id": id.uuidString,
+        "seconds": self.connectTimeoutSeconds,
+      ])
+      self.markGattResolutionFailed(
+        id,
+        reason: "gatt_exchange_timeout",
+        recoverable: true,
+        extra: ["seconds": self.connectTimeoutSeconds]
+      )
+      self.centralManager?.cancelPeripheralConnection(pinned)
+      self.peripheralCharacteristics.removeValue(forKey: id)
+      self.peripheralReadValues.removeValue(forKey: id)
+      self.lastDiscoveryNameById.removeValue(forKey: id)
+      self.activePeripheral = nil
+      self.pumpConnectQueue()
+    }
+    connectWatchdog = work
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + connectTimeoutSeconds,
+      execute: work
+    )
+  }
+
+  private func cancelConnectWatchdog() {
+    connectWatchdog?.cancel()
+    connectWatchdog = nil
+  }
+
+  private func scheduleConnectQueuePump(after delay: TimeInterval) {
+    guard connectCooldownWorkItem == nil else { return }
+    let work = DispatchWorkItem { [weak self] in
+      guard let self = self else { return }
+      self.connectCooldownWorkItem = nil
+      self.pumpConnectQueue()
+    }
+    connectCooldownWorkItem = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+  }
+
+  private func cancelConnectCooldownWorkItem() {
+    connectCooldownWorkItem?.cancel()
+    connectCooldownWorkItem = nil
+  }
+
+  private func isResolutionBackedOff(_ id: UUID, now: Date) -> Bool {
+    guard let until = resolutionBackoffUntil[id] else { return false }
+    if now < until { return true }
+    resolutionBackoffUntil.removeValue(forKey: id)
+    return false
+  }
+
+  private func emitResolutionBackoff(_ id: UUID, now: Date) {
+    guard let until = resolutionBackoffUntil[id] else { return }
+    emitDebug(level: "trace", name: "gatt_resolution_backoff", data: [
+      "id": id.uuidString,
+      "remainingMs": max(0, Int(until.timeIntervalSince(now) * 1000)),
+    ])
+  }
+
+  private func markGattResolutionFailed(
+    _ id: UUID,
+    reason: String,
+    recoverable: Bool,
+    extra: [String: Any] = [:]
+  ) {
+    let backoffSeconds = recoverable ? resolutionFailureBackoffSeconds : resolutionRejectedBackoffSeconds
+    resolutionBackoffUntil[id] = Date().addingTimeInterval(backoffSeconds)
+    var data: [String: Any] = [
+      "id": id.uuidString,
+      "reason": reason,
+      "recoverable": recoverable,
+      "backoffMs": Int(backoffSeconds * 1000),
+    ]
+    for (key, value) in extra {
+      data[key] = value
+    }
+    emitDebug(
+      level: recoverable ? "warn" : "info",
+      name: "gatt_resolution_failed",
+      data: data
+    )
+  }
+
+  // MARK: - GATT Exchange (Central side, v2 flow: B004 → B002 → B003)
+
+  private func startGattExchange(for peripheral: CBPeripheral, service: CBService) {
+    let id = peripheral.identifier
+    var charMap: [CBUUID: CBCharacteristic] = [:]
+
+    guard let characteristics = service.characteristics else {
+      markGattResolutionFailed(id, reason: "characteristics_missing", recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+
+    for ch in characteristics {
+      charMap[ch.uuid] = ch
+    }
+    peripheralCharacteristics[id] = charMap
+
+    // Step 1: EventCodeHash. B004 gates B002/B003 exchange.
+    guard let eventCodeHashCh = charMap[eventCodeHashCharacteristicUUID] else {
+      markGattResolutionFailed(id, reason: "b004_missing", recoverable: true)
+      emitDebug(level: "warn", name: "gatt_b004_missing", data: [
+        "id": id.uuidString,
+      ])
+      finishConnection(peripheral)
+      return
+    }
+    peripheral.readValue(for: eventCodeHashCh)
+  }
+
+  private func eventCodeHashMatches(_ peerHash: Data) -> Bool {
+    peerHash == rpid.getEventCodeHash()
+  }
+
+  private func readRpidCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let rpidCh = charMap[rpidCharacteristicUUID]
+    else {
+      markGattResolutionFailed(id, reason: "b002_missing", recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+    peripheralReadValues[id]?.rpidReadStartedAt = Date()
+    peripheral.readValue(for: rpidCh)
+  }
+
+  private func readDisplayIdCharacteristic(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let charMap = peripheralCharacteristics[id],
+      let displayIdCh = charMap[displayIdCharacteristicUUID]
+    else {
+      // Missing B003 — per v2 policy, still emit detection with null displayId.
+      emitDebug(level: "warn", name: "gatt_b003_missing", data: [
+        "id": id.uuidString,
+      ])
+      completeGattExchange(for: peripheral)
+      return
+    }
+    peripheral.readValue(for: displayIdCh)
+  }
+
+  private func completeGattExchange(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let values = peripheralReadValues[id] else {
+      finishConnection(peripheral)
+      return
+    }
+
+    if let rpidData = values.rpid {
+      let rssi = discoveredRssi[id] ?? 0
+      let completedAt = values.rpidReadCompletedAt ?? Date()
+      guard let peerEnin = BarnardCrypto.stableReadEnin(
+        startedAt: values.rpidReadStartedAt ?? completedAt,
+        completedAt: completedAt,
+        mode: eninMode,
+        eninSeconds: eninSeconds,
+        beaconChain: beaconChain
+      ) else {
+        emitDebug(level: "warn", name: "gatt_rpid_read_crossed_enin_boundary", data: [
+          "id": id.uuidString,
+          "startedAt": (values.rpidReadStartedAt ?? completedAt).timeIntervalSince1970,
+          "completedAt": completedAt.timeIntervalSince1970,
+        ])
+        retryAfterRpidBoundaryCrossing(peripheral)
+        return
+      }
+      let detectedDisplayId = values.detectedDisplayId?.hexString
+      emitDetection(
+        timestamp: completedAt,
+        rssi: rssi,
+        payload: rpidData,
+        detectedDisplayId: detectedDisplayId,
+        debugLocalName: lastDiscoveryNameById[id]
+      )
+
+      if rpidData.count == 17 {
+        knownPeers[id] = KnownPeer(
+          rpid: rpidData,
+          enin: peerEnin,
+          detectedDisplayId: detectedDisplayId,
+          debugLocalName: lastDiscoveryNameById[id]
+        )
+        resolutionBackoffUntil.removeValue(forKey: id)
+      }
+    }
+
+    finishConnection(peripheral)
+  }
+
+  private func finishConnection(_ peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
+    b004ReadRetries.removeValue(forKey: id)
+    lastDiscoveryNameById.removeValue(forKey: id)
+    centralManager?.cancelPeripheralConnection(peripheral)
+  }
+
+  private func retryAfterRpidBoundaryCrossing(_ peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    lastConnectAttemptAt.removeValue(forKey: id)
+    pendingBoundaryRetryPeripherals[id] = peripheral
+    finishConnection(peripheral)
+  }
+
+  private func schedulePendingBoundaryRetry(for id: UUID) {
+    guard let peripheral = pendingBoundaryRetryPeripherals.removeValue(forKey: id) else { return }
+    DispatchQueue.main.asyncAfter(deadline: .now() + rpidBoundaryRetryDelaySeconds) { [weak self, weak peripheral] in
+      guard let self = self, let peripheral = peripheral else { return }
+      if self.isScanning {
+        self.enqueueConnect(peripheral)
+      }
+    }
+  }
+
+  // MARK: - Event Emission
+
+  private func emitState(reasonCode: String?) {
+    onEvent?(.state(BarnardState(
+      isScanning: isScanning,
+      isAdvertising: isAdvertising,
+      eventCode: rpid.eventCode,
+      eninMode: eninModeName(),
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChainInfo(),
+      reasonCode: reasonCode
+    )))
+  }
+
+  private func emitConstraint(code: String, message: String?) {
+    onEvent?(.constraint(BarnardConstraintEvent(code: code, message: message)))
+  }
+
+  private func emitError(code: String, message: String, recoverable: Bool? = nil) {
+    onEvent?(.error(BarnardErrorEvent(code: code, message: message, recoverable: recoverable)))
+  }
+
+  /// Emit v2 detection event. Byte fields are lowercase hex.
+  private func emitDetection(
+    timestamp: Date,
+    rssi: Int,
+    payload: Data,
+    detectedDisplayId: String?,
+    debugLocalName: String? = nil
+  ) {
+    guard payload.count == 17 else {
+      emitDebug(level: "warn", name: "payload_invalid_length", data: ["length": payload.count])
+      return
+    }
+    let version = Int(payload[0])
+    if version != 1 {
+      emitDebug(level: "warn", name: "payload_unsupported_version", data: ["formatVersion": version])
+      return
+    }
+
+    // Atomic snapshot: use the observation timestamp for both reporterRpid
+    // and enin, so they always agree across ENIN boundaries.
+    let reporterPayload = currentPayload(now: timestamp)
+    let enin = Int(currentEnin(timestamp))
+
+    var resolvedDebugLocalName: String?
+    #if DEBUG
+    resolvedDebugLocalName = debugLocalName
+    #endif
+
+    onEvent?(.detection(BarnardDetectionEvent(
+      timestamp: timestamp,
+      rssi: rssi,
+      formatVersion: version,
+      rpid: payload.hexString,
+      reporterRpid: reporterPayload.hexString,
+      detectedDisplayId: detectedDisplayId,
+      enin: enin,
+      debugLocalName: resolvedDebugLocalName
+    )))
+  }
+
+  private func emitRssiUpdate(peripheralId: UUID, rssi: Int, timestamp: Date) {
+    guard isUsableRssi(rssi) else { return }
+    guard let peer = knownPeers[peripheralId] else { return }
+
+    // Atomic reporter snapshot (same contract as DetectionEvent).
+    let reporterPayload = currentPayload(now: timestamp)
+    let enin = Int(currentEnin(timestamp))
+
+    onEvent?(.rssiUpdate(BarnardRssiUpdateEvent(
+      timestamp: timestamp,
+      rssi: rssi,
+      rpid: peer.rpid.hexString,
+      reporterRpid: reporterPayload.hexString,
+      enin: enin,
+      detectedDisplayId: peer.detectedDisplayId,
+      debugLocalName: peer.debugLocalName
+    )))
+  }
+
+  private func emitDebug(level: String, name: String, data: [String: Any]?) {
+    onDebugEvent?(BarnardDebugEvent(timestamp: Date(), level: level, name: name, data: data))
+  }
+
+  /// Accept a caller-provided formatVersion. v2 only ships format 1, so
+  /// clamp to 1 and emit a debug warning when callers request an
+  /// unsupported value — advertising format 2+ would otherwise make the
+  /// device silently undiscoverable to all v2 peers.
+  private func acceptFormatVersion(_ raw: Int?) -> UInt8 {
+    guard let v = raw else { return 1 }
+    if v == 1 { return 1 }
+    emitDebug(
+      level: "warn",
+      name: "format_version_clamped",
+      data: ["requested": v, "applied": 1]
+    )
+    return 1
+  }
+
+  private func characteristicName(_ uuid: CBUUID) -> String {
+    switch uuid {
+    case rpidCharacteristicUUID:
+      return "B002_RPID"
+    case displayIdCharacteristicUUID:
+      return "B003_displayId"
+    case eventCodeHashCharacteristicUUID:
+      return "B004_eventCodeHash"
+    default:
+      return uuid.uuidString
+    }
+  }
+
+  private func respondRead(
+    _ peripheral: CBPeripheralManager,
+    request: CBATTRequest,
+    value: Data,
+    debugName: String,
+    debugData: [String: Any] = [:]
+  ) {
+    guard request.offset <= value.count else {
+      peripheral.respond(to: request, withResult: .invalidOffset)
+      emitDebug(level: "warn", name: "\(debugName)_invalid_offset", data: [
+        "offset": request.offset,
+        "bytes": value.count,
+      ])
+      return
+    }
+    request.value = value.subdata(in: request.offset..<value.count)
+    peripheral.respond(to: request, withResult: .success)
+    var data = debugData
+    data["bytes"] = value.count
+    data["offset"] = request.offset
+    emitDebug(level: "trace", name: debugName, data: data)
+  }
+
+  private func isUsableRssi(_ rssi: Int) -> Bool {
+    // CoreBluetooth uses 127 when RSSI is unavailable. Do not surface it as a
+    // real dBm value because downstream timelines and aggregations treat RSSI
+    // numerically.
+    rssi != unavailableRssi
+  }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension BarnardEngine: CBCentralManagerDelegate {
+  public func centralManagerDidUpdateState(_ central: CBCentralManager) {
+    resolvePendingPermissionCompletionsIfPossible()
+    emitDebug(level: "info", name: "central_state", data: ["state": central.state.rawValue])
+    if central.state == .poweredOn, shouldStartScanWhenReady {
+      startScanInternal()
+    } else if central.state != .poweredOn, isScanning {
+      stopScanInternal()
+    }
+  }
+
+  public func centralManager(
+    _ central: CBCentralManager,
+    didDiscover peripheral: CBPeripheral,
+    advertisementData: [String: Any],
+    rssi RSSI: NSNumber
+  ) {
+    let rssi = RSSI.intValue
+    guard isUsableRssi(rssi) else {
+      emitDebug(level: "trace", name: "ble_discovery_rssi_unavailable", data: [
+        "id": peripheral.identifier.uuidString,
+        "rssi": rssi,
+        "name": (advertisementData[CBAdvertisementDataLocalNameKey] as? String) as Any,
+      ])
+      return
+    }
+    let now = Date()
+    discoveredRssi[peripheral.identifier] = rssi
+    discoveredAt[peripheral.identifier] = now
+
+    emitDebug(level: "trace", name: "ble_discovery_result", data: [
+      "id": peripheral.identifier.uuidString,
+      "rssi": rssi,
+      "name": (advertisementData[CBAdvertisementDataLocalNameKey] as? String) as Any,
+    ])
+
+    #if DEBUG
+    if let name = advertisementData[CBAdvertisementDataLocalNameKey] as? String, !name.isEmpty {
+      lastDiscoveryNameById[peripheral.identifier] = name
+    }
+    #endif
+
+    if let knownPeer = knownPeers[peripheral.identifier] {
+      let currentEninValue = currentEnin(now)
+      if BarnardV2Policy.shouldEmitRssiUpdate(cachedPeerEnin: knownPeer.enin, currentEnin: currentEninValue) {
+        emitRssiUpdate(peripheralId: peripheral.identifier, rssi: rssi, timestamp: now)
+      } else {
+        knownPeers.removeValue(forKey: peripheral.identifier)
+        emitDebug(level: "trace", name: "known_peer_rpid_expired", data: [
+          "id": peripheral.identifier.uuidString,
+          "cachedEnin": Int(knownPeer.enin),
+          "currentEnin": Int(currentEninValue),
+        ])
+        // Force a fresh resolution. enqueueConnect dedups against in-flight /
+        // queued connects, so following advertisements on the same identifier
+        // remain safe.
+        enqueueConnect(peripheral)
+      }
+    } else if isResolutionBackedOff(peripheral.identifier, now: now) {
+      emitResolutionBackoff(peripheral.identifier, now: now)
+    } else {
+      enqueueConnect(peripheral)
+    }
+  }
+
+  public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+    guard activePeripheral?.identifier == peripheral.identifier else {
+      emitDebug(level: "trace", name: "stale_connect_ignored", data: [
+        "id": peripheral.identifier.uuidString,
+      ])
+      return
+    }
+    emitDebug(level: "trace", name: "connected", data: ["id": peripheral.identifier.uuidString])
+    peripheral.discoverServices([discoveryServiceUUID])
+  }
+
+  public func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+    guard activePeripheral?.identifier == peripheral.identifier else {
+      emitDebug(level: "trace", name: "stale_connect_failed_ignored", data: [
+        "id": peripheral.identifier.uuidString,
+      ])
+      return
+    }
+    cancelConnectWatchdog()
+    emitError(code: "connect_failed", message: error?.localizedDescription ?? "unknown", recoverable: true)
+    let id = peripheral.identifier
+    markGattResolutionFailed(
+      id,
+      reason: "connect_failed",
+      recoverable: true,
+      extra: ["error": error?.localizedDescription ?? "unknown"]
+    )
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
+    activePeripheral = nil
+    pumpConnectQueue()
+  }
+
+  public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+    guard activePeripheral?.identifier == peripheral.identifier else {
+      emitDebug(level: "trace", name: "stale_disconnect_ignored", data: [
+        "id": peripheral.identifier.uuidString,
+      ])
+      return
+    }
+    cancelConnectWatchdog()
+    let id = peripheral.identifier
+    peripheralCharacteristics.removeValue(forKey: id)
+    peripheralReadValues.removeValue(forKey: id)
+    activePeripheral = nil
+    schedulePendingBoundaryRetry(for: id)
+    pumpConnectQueue()
+  }
+}
+
+// MARK: - CBPeripheralDelegate
+
+extension BarnardEngine: CBPeripheralDelegate {
+  public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+    if let error = error {
+      markGattResolutionFailed(
+        peripheral.identifier,
+        reason: "service_discovery_failed",
+        recoverable: true,
+        extra: ["error": error.localizedDescription]
+      )
+      emitError(code: "service_discovery_failed", message: error.localizedDescription, recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+    guard let services = peripheral.services, let svc = services.first(where: { $0.uuid == discoveryServiceUUID }) else {
+      markGattResolutionFailed(peripheral.identifier, reason: "service_not_found", recoverable: true)
+      emitError(code: "service_not_found", message: "Barnard service not found", recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+    peripheral.discoverCharacteristics(
+      [rpidCharacteristicUUID, displayIdCharacteristicUUID, eventCodeHashCharacteristicUUID],
+      for: svc
+    )
+  }
+
+  public func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+    if let error = error {
+      markGattResolutionFailed(
+        peripheral.identifier,
+        reason: "characteristic_discovery_failed",
+        recoverable: true,
+        extra: ["error": error.localizedDescription]
+      )
+      emitError(code: "characteristic_discovery_failed", message: error.localizedDescription, recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+    startGattExchange(for: peripheral, service: service)
+  }
+
+  public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+    let id = peripheral.identifier
+
+    // Distinguish B003 read failure (still emit detection with null) from
+    // B002 read failure (drop the detection — no RPID, nothing to emit).
+    if let error = error {
+      if characteristic.uuid == displayIdCharacteristicUUID {
+        emitDebug(level: "warn", name: "gatt_b003_read_failed", data: [
+          "id": id.uuidString,
+          "error": error.localizedDescription,
+        ])
+        peripheralReadValues[id]?.detectedDisplayId = nil
+        completeGattExchange(for: peripheral)
+        return
+      }
+      if characteristic.uuid == eventCodeHashCharacteristicUUID {
+        let retries = b004ReadRetries[id] ?? 0
+        if retries < maxB004ReadRetries {
+          b004ReadRetries[id] = retries + 1
+          emitDebug(level: "warn", name: "gatt_b004_read_retry", data: [
+            "id": id.uuidString,
+            "attempt": retries + 1,
+            "max": maxB004ReadRetries,
+            "error": error.localizedDescription,
+          ])
+          DispatchQueue.main.asyncAfter(deadline: .now() + b004ReadRetryDelaySeconds) { [weak self, weak peripheral] in
+            guard let self = self, let peripheral = peripheral else { return }
+            guard self.activePeripheral?.identifier == id else { return }
+            peripheral.readValue(for: characteristic)
+          }
+          return
+        }
+      }
+      let name = characteristicName(characteristic.uuid)
+      markGattResolutionFailed(
+        id,
+        reason: "read_failed",
+        recoverable: true,
+        extra: [
+          "characteristic": name,
+          "error": error.localizedDescription,
+        ]
+      )
+      emitDebug(level: "warn", name: "gatt_read_failed", data: [
+        "id": id.uuidString,
+        "characteristic": name,
+        "error": error.localizedDescription,
+      ])
+      emitError(code: "read_failed", message: "\(name): \(error.localizedDescription)", recoverable: true)
+      finishConnection(peripheral)
+      return
+    }
+
+    let value = characteristic.value ?? Data()
+
+    switch characteristic.uuid {
+    case eventCodeHashCharacteristicUUID:
+      peripheralReadValues[id]?.eventCodeHash = value
+      let matches = eventCodeHashMatches(value)
+      emitDebug(level: "trace", name: "gatt_read_event_code_hash", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+        "isEmpty": value.isEmpty,
+        "matches": matches,
+      ])
+      guard matches else {
+        markGattResolutionFailed(
+          id,
+          reason: "b004_mismatch",
+          recoverable: false,
+          extra: ["bytes": value.count]
+        )
+        emitDebug(level: "info", name: "gatt_b004_mismatch", data: [
+          "id": id.uuidString,
+          "bytes": value.count,
+        ])
+        finishConnection(peripheral)
+        return
+      }
+      readRpidCharacteristic(for: peripheral)
+
+    case rpidCharacteristicUUID:
+      peripheralReadValues[id]?.rpid = value
+      peripheralReadValues[id]?.rpidReadCompletedAt = Date()
+      emitDebug(level: "trace", name: "gatt_read_rpid", data: [
+        "id": id.uuidString,
+        "bytes": value.count,
+      ])
+      readDisplayIdCharacteristic(for: peripheral)
+
+    case displayIdCharacteristicUUID:
+      if value.count == 4 {
+        peripheralReadValues[id]?.detectedDisplayId = value
+        emitDebug(level: "trace", name: "gatt_read_display_id", data: [
+          "id": id.uuidString,
+          "displayId": value.hexString,
+        ])
+      } else {
+        emitDebug(level: "warn", name: "gatt_b003_invalid_length", data: [
+          "id": id.uuidString,
+          "length": value.count,
+        ])
+        peripheralReadValues[id]?.detectedDisplayId = nil
+      }
+      completeGattExchange(for: peripheral)
+
+    default:
+      break
+    }
+  }
+}
+
+// MARK: - CBPeripheralManagerDelegate
+
+extension BarnardEngine: CBPeripheralManagerDelegate {
+  public func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+    resolvePendingPermissionCompletionsIfPossible()
+    emitDebug(level: "info", name: "peripheral_state", data: ["state": peripheral.state.rawValue])
+    if peripheral.state == .poweredOn, shouldStartAdvertiseWhenReady {
+      startAdvertiseInternal()
+    } else if peripheral.state != .poweredOn, isAdvertising {
+      stopAdvertiseInternal()
+    }
+  }
+
+  public func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+    if let error = error {
+      emitError(code: "gatt_service_add_failed", message: error.localizedDescription, recoverable: false)
+    }
+  }
+
+  public func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+    if let error = error {
+      emitError(code: "advertise_failed", message: error.localizedDescription, recoverable: true)
+      isAdvertising = false
+      emitState(reasonCode: "advertise_failed")
+    }
+  }
+
+  public func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+    switch request.characteristic.uuid {
+    case rpidCharacteristicUUID:
+      let payload = currentPayload(now: Date())
+      respondRead(
+        peripheral,
+        request: request,
+        value: payload,
+        debugName: "gatt_respond_rpid",
+        debugData: ["formatVersion": Int(formatVersion)]
+      )
+
+    case displayIdCharacteristicUUID:
+      guard shouldServeGattDisplayId() else {
+        peripheral.respond(to: request, withResult: .readNotPermitted)
+        emitDebug(level: "trace", name: "gatt_reject_display_id_read", data: [
+          "reason": "not_joined_to_event",
+        ])
+        return
+      }
+
+      // v2: event-scoped B003 serves 4-byte SHA256(TEK)[0:4]. Read-only.
+      let displayId = BarnardCrypto.displayId4(from: rpid.getCurrentTek())
+      respondRead(
+        peripheral,
+        request: request,
+        value: displayId,
+        debugName: "gatt_respond_display_id"
+      )
+
+    case eventCodeHashCharacteristicUUID:
+      let hash = rpid.getEventCodeHash()
+      respondRead(
+        peripheral,
+        request: request,
+        value: hash,
+        debugName: "gatt_respond_event_code_hash",
+        debugData: ["isEmpty": hash.isEmpty]
+      )
+
+    default:
+      peripheral.respond(to: request, withResult: .attributeNotFound)
+    }
+  }
+
+  // v2 has no writable characteristics. Reject any write attempt.
+  public func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
+    for request in requests {
+      peripheral.respond(to: request, withResult: .writeNotPermitted)
+    }
+    emitDebug(level: "warn", name: "gatt_write_rejected", data: [
+      "count": requests.count,
+    ])
+  }
+}

--- a/packages/swift/barnard/Sources/Barnard/BarnardIdentity.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardIdentity.swift
@@ -1,0 +1,97 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import Foundation
+
+/// Recoverable secp256k1 signature `(r, s, v)`, Swift-first mirror of
+/// `BarnardSigning.RecoverableSignature`.
+public struct BarnardRecoverableSignature {
+  public let r: Data
+  public let s: Data
+  public let v: Int
+}
+
+/// Result of `BarnardIdentity.proveRpidOwnership`.
+public struct BarnardRpidOwnershipProof {
+  public let rpi: Data
+  public let signingPublicKey: Data
+  public let signature: BarnardRecoverableSignature
+}
+
+/// Barnard per-event device signing identity (barnard#65), Flutter-free
+/// port of `BarnardIdentityController`.
+///
+/// A module separate from `BarnardEngine` (the sensing client) — it shares
+/// the same on-device `DeviceSecret` storage (`UserDefaults` key
+/// `barnard.rpidSeed`) as `BarnardEngine`/`BarnardRpidGenerator` so the
+/// signing identity is rooted in the same secret as the sensing client's
+/// TEK, but the private signing key it derives never leaves this type —
+/// only the public key and signatures do.
+public final class BarnardIdentity {
+  private let deviceSecretKey = "barnard.rpidSeed"
+
+  public init() {}
+
+  public func signingPublicKey(eventCode: String) -> Data {
+    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
+    return keyPair.publicKeyCompressed
+  }
+
+  /// Signs `SHA256(bytes)` with the per-event signing key derived from
+  /// `eventCode`.
+  public func sign(eventCode: String, bytes: Data) -> BarnardRecoverableSignature {
+    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
+    let messageHash = Data(SHA256.hash(data: bytes))
+    let sig = BarnardSigning.signRecoverable(privateKey: keyPair.privateKey, messageHash32: messageHash)
+    return BarnardRecoverableSignature(r: sig.r, s: sig.s, v: sig.v)
+  }
+
+  public func proveRpidOwnership(
+    eventCode: String,
+    enin: UInt64,
+    eventIdHash: Data,
+    challenge: Data? = nil
+  ) -> BarnardRpidOwnershipProof {
+    let proof = BarnardSigning.proveRpidOwnership(
+      deviceSecret: getOrCreateDeviceSecret(),
+      eventCode: eventCode,
+      eventIdHash: eventIdHash,
+      enin: enin,
+      challenge: challenge
+    )
+    return BarnardRpidOwnershipProof(
+      rpi: proof.rpi,
+      signingPublicKey: proof.signingPublicKey,
+      signature: BarnardRecoverableSignature(r: proof.sig.r, s: proof.sig.s, v: proof.sig.v)
+    )
+  }
+
+  public func proveKeyBinding(eventCode: String, displayId: Data) -> BarnardRecoverableSignature {
+    let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+    let sig = BarnardSigning.signKeyBinding(
+      deviceSecret: getOrCreateDeviceSecret(),
+      eventCode: eventCode,
+      eventCodeHash: eventCodeHash,
+      displayId: displayId
+    )
+    return BarnardRecoverableSignature(r: sig.r, s: sig.s, v: sig.v)
+  }
+
+  // MARK: - DeviceSecret Management
+  //
+  // Same storage key as BarnardRpidGenerator.getOrCreateDeviceSecret — the
+  // signing identity and the sensing client are rooted in the same
+  // DeviceSecret, but this type never exposes it (unlike
+  // BarnardEngine.exportCurrentTek, which is the TEK, not the raw secret).
+
+  private func getOrCreateDeviceSecret() -> Data {
+    let defaults = UserDefaults.standard
+    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
+      return existing
+    }
+    let newSecret = BarnardCrypto.generateRandomBytes(32)
+    defaults.set(newSecret, forKey: deviceSecretKey)
+    return newSecret
+  }
+}

--- a/packages/swift/barnard/Sources/Barnard/BarnardRpidGenerator.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardRpidGenerator.swift
@@ -1,0 +1,154 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import Foundation
+import Security
+
+/// GAEN v1.2-compatible RPI generator with Event Mode support.
+///
+/// Two modes of operation:
+/// - **Anonymous Mode** (default): Deterministic TEK derived from DeviceSecret
+/// - **Event Mode**: Deterministic TEK derived from DeviceSecret + EventCode
+final class BarnardRpidGenerator {
+  // MARK: - Storage Keys
+
+  private let deviceSecretKey = "barnard.rpidSeed"
+  private let eventCodeKey = "barnard.eventCode"
+
+  // MARK: - State
+
+  /// Current Event Code (nil for Anonymous Mode)
+  private(set) var eventCode: String? {
+    didSet {
+      if eventCode != oldValue {
+        regenerateTek()
+      }
+    }
+  }
+
+  /// Current TEK (Temporary Exposure Key)
+  private var currentTek: Data
+
+  // MARK: - Initialization
+
+  init() {
+    // Load persisted event code
+    let defaults = UserDefaults.standard
+    eventCode = defaults.string(forKey: eventCodeKey)
+    currentTek = Data()
+
+    // Initialize TEK based on mode
+    regenerateTek()
+  }
+
+  // MARK: - Mode Control
+
+  /// Join an event, switching to Event Mode.
+  ///
+  /// - Parameter code: The event code to join
+  func joinEvent(_ code: String) {
+    let defaults = UserDefaults.standard
+    defaults.set(code, forKey: eventCodeKey)
+    eventCode = code
+  }
+
+  /// Leave the current event, switching to Anonymous Mode.
+  func leaveEvent() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: eventCodeKey)
+    eventCode = nil
+  }
+
+  /// Check if currently in Event Mode.
+  var isEventMode: Bool {
+    eventCode != nil
+  }
+
+  // MARK: - TEK Management
+
+  /// Get the current TEK.
+  func getCurrentTek() -> Data {
+    currentTek
+  }
+
+  /// Regenerate TEK based on current mode.
+  private func regenerateTek() {
+    if let code = eventCode {
+      // Event Mode: derive TEK from DeviceSecret + EventCode
+      let deviceSecret = getOrCreateDeviceSecret()
+      currentTek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: code)
+    } else {
+      // Anonymous Mode: derive TEK from DeviceSecret
+      let deviceSecret = getOrCreateDeviceSecret()
+      currentTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret: deviceSecret)
+    }
+  }
+
+  // MARK: - EventCodeHash
+
+  /// Get the EventCodeHash for GATT characteristic (8 bytes, or empty for Anonymous Mode).
+  func getEventCodeHash() -> Data {
+    guard let code = eventCode else {
+      return Data() // Empty for Anonymous Mode
+    }
+    return BarnardCrypto.computeEventCodeHash(code)
+  }
+
+  // MARK: - RPID Payload Generation
+
+  /// Generate the current RPID payload for BLE advertisement/GATT.
+  ///
+  /// - Parameters:
+  ///   - formatVersion: Protocol version byte (default: 1)
+  ///   - now: Current timestamp (default: now)
+  /// - Returns: 17 bytes: [formatVersion(1) + RPI(16)]
+  func currentPayload(
+    formatVersion: UInt8 = 1,
+    now: Date = Date(),
+    eninMode: BarnardCrypto.EninMode = .fixedLength,
+    eninSeconds: Int = 300,
+    beaconChain: BarnardCrypto.BeaconChainConfig = .ethereumMainnet
+  ) -> Data {
+    let enin = BarnardCrypto.calculateEnin(
+      for: now,
+      mode: eninMode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    )
+    let rpik = BarnardCrypto.deriveRpik(from: currentTek)
+    let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: enin)
+
+    var payload = Data([formatVersion])
+    payload.append(rpi)
+    return payload
+  }
+
+  // MARK: - DeviceSecret Management
+
+  /// Get or create the DeviceSecret (32 bytes, device-unique, never transmitted).
+  private func getOrCreateDeviceSecret() -> Data {
+    let defaults = UserDefaults.standard
+
+    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
+      return existing
+    }
+
+    // Generate new 32-byte DeviceSecret
+    let newSecret = BarnardCrypto.generateRandomBytes(32)
+    defaults.set(newSecret, forKey: deviceSecretKey)
+    return newSecret
+  }
+
+  /// Get the DeviceSecret (for platform channel access).
+  func getDeviceSecret() -> Data {
+    getOrCreateDeviceSecret()
+  }
+
+  // MARK: - Display IDs
+
+  /// v2 displayId for the current TEK: `SHA256(TEK)[0:4]` as 8 hex chars.
+  func getCurrentDisplayId() -> String {
+    BarnardCrypto.displayIdString(from: currentTek)
+  }
+}

--- a/packages/swift/barnard/Sources/Barnard/BarnardSigning.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardSigning.swift
@@ -1,0 +1,249 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import Foundation
+
+/// Per-event device signing identity (barnard#65).
+///
+/// Key derivation chain:
+/// ```
+/// DeviceSecret (32 bytes)
+///      |
+///      +-- signSeed = HKDF(DeviceSecret || EventCode, "barnard-sign", 32)
+///                          |
+///                          v
+///                     secp256k1 keypair (signSeed reduced mod curve order)
+/// ```
+///
+/// Mirrors the TEK event-mode derivation shape
+/// (`TEK = HKDF(DeviceSecret || EventCode, "barnard-tek", 16)`, see
+/// `BarnardCrypto.deriveTekForEvent`) but uses a distinct HKDF `info`
+/// string ("barnard-sign" vs "barnard-tek" / "EN-RPIK") so the signing key
+/// and the TEK/RPIK chain are not cross-computable.
+///
+/// iOS has no system-provided secp256k1 (CryptoKit only covers P-256/384/521
+/// and Curve25519), so this implements the minimal field/point arithmetic
+/// and RFC 6979 deterministic ECDSA directly on a fixed-width 256-bit
+/// integer. It has been cross-verified byte-for-byte against the Dart
+/// (`package:pointycastle`) and Kotlin (`java.math.BigInteger`)
+/// implementations of the same algorithm for the same test vectors.
+enum BarnardSigning {
+  static let signingKeyInfo = "barnard-sign"
+
+  /// Domain-separation tag for `buildRpidProofMessage` (barnard#63).
+  static let rpidProofDomainTag = "barnard-rpid-proof:v1"
+
+  /// Domain-separation tag for `buildKeyBindingMessage` (barnard#63).
+  static let keyBindingDomainTag = "barnard-key-binding:v1"
+
+  struct SigningKeyPair {
+    let privateKey: Secp256k1.UInt256
+    let publicKeyCompressed: Data
+  }
+
+  struct RecoverableSignature {
+    let r: Data
+    let s: Data
+    let v: Int
+  }
+
+  /// Derive the per-event signing keypair from `deviceSecret` and `eventCode`.
+  static func deriveSigningKeyPair(deviceSecret: Data, eventCode: String) -> SigningKeyPair {
+    let eventCodeData = eventCode.data(using: .utf8) ?? Data()
+    var combined = deviceSecret
+    combined.append(eventCodeData)
+
+    let key = SymmetricKey(data: combined)
+    var seed = HKDF<SHA256>.deriveKey(
+      inputKeyMaterial: key,
+      info: signingKeyInfo.data(using: .utf8)!,
+      outputByteCount: 32
+    ).withUnsafeBytes { Data($0) }
+
+    var d = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: seed), Secp256k1.N)
+    while d.isZero {
+      seed = Data(SHA256.hash(data: seed))
+      d = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: seed), Secp256k1.N)
+    }
+
+    let q = Secp256k1.scalarMult(d, Secp256k1.G)
+    return SigningKeyPair(privateKey: d, publicKeyCompressed: Secp256k1.compress(q))
+  }
+
+  /// Sign a 32-byte message hash with `privateKey`, returning a recoverable
+  /// signature `(r, s, v)`. Deterministic (RFC 6979 / HMAC-SHA256 `k`),
+  /// normalizes `s` to the lower half of the curve order (canonical /
+  /// "low-S" form), and searches for the recovery id (`0` or `1`) against
+  /// the caller's own public key.
+  static func signRecoverable(privateKey: Secp256k1.UInt256, messageHash32: Data) -> RecoverableSignature {
+    precondition(messageHash32.count == 32, "messageHash must be 32 bytes")
+
+    let e = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N)
+    let expectedPub = Secp256k1.compress(Secp256k1.scalarMult(privateKey, Secp256k1.G))
+
+    var r = Secp256k1.UInt256.zero
+    var s = Secp256k1.UInt256.zero
+    while true {
+      let k = deterministicK(privateKey: privateKey, messageHash32: messageHash32)
+      let rPoint = Secp256k1.scalarMult(k, Secp256k1.G)
+      guard let rx = rPoint.x else { continue }
+      r = Secp256k1.Field.reduceOnce(rx, Secp256k1.N)
+      if r.isZero { continue }
+      let kInv = Secp256k1.Field.invMod(k, Secp256k1.N)
+      s = Secp256k1.Field.mulMod(
+        kInv,
+        Secp256k1.Field.addMod(e, Secp256k1.Field.mulMod(privateKey, r, Secp256k1.N), Secp256k1.N),
+        Secp256k1.N
+      )
+      if s.isZero { continue }
+      break
+    }
+
+    let halfOrder = Secp256k1.N.shiftedRight1()
+    if s > halfOrder {
+      s = Secp256k1.N.subtracting(s)
+    }
+
+    var recoveryId = -1
+    for id in 0..<4 {
+      if let candidate = recoverPublicKey(recId: id, r: r, s: s, messageHash32: messageHash32),
+        candidate == expectedPub
+      {
+        recoveryId = id
+        break
+      }
+    }
+    precondition(recoveryId != -1, "signRecoverable: could not determine recovery id")
+
+    return RecoverableSignature(r: r.data, s: s.data, v: recoveryId)
+  }
+
+  /// Recover the SEC1-compressed public key from `(recId, r, s)` and the
+  /// signed message hash. Returns nil if the signature/recovery id is
+  /// invalid.
+  static func recoverPublicKey(recId: Int, r: Secp256k1.UInt256, s: Secp256k1.UInt256, messageHash32: Data) -> Data? {
+    guard recId / 2 == 0 else { return nil }
+    if r >= Secp256k1.P { return nil }
+    guard let rPoint = Secp256k1.decompress(x: r, yIsOdd: (recId & 1) == 1) else { return nil }
+    // secp256k1 has cofactor 1: every point satisfying the curve equation
+    // already has order N, so the "N*R == infinity" order check other
+    // implementations run here is mathematically redundant and skipped.
+
+    let e = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N)
+    let eNeg = Secp256k1.N.subtracting(e)
+    let rInv = Secp256k1.Field.invMod(r, Secp256k1.N)
+    let srInv = Secp256k1.Field.mulMod(rInv, s, Secp256k1.N)
+    let eInvrInv = Secp256k1.Field.mulMod(rInv, eNeg, Secp256k1.N)
+
+    let term1 = Secp256k1.scalarMult(eInvrInv, Secp256k1.G)
+    let term2 = Secp256k1.scalarMult(srInv, rPoint)
+    let point = Secp256k1.pointAdd(term1, term2)
+    if point.isInfinity { return nil }
+    return Secp256k1.compress(point)
+  }
+
+  // MARK: - RPID ownership proof / key binding (barnard#63)
+
+  struct RpidOwnershipProof {
+    let rpi: Data
+    let enin: UInt64
+    let eventIdHash: Data
+    let signingPublicKey: Data
+    let sig: RecoverableSignature
+  }
+
+  /// Canonical, fixed-order/length-prefixed encoding of an RPID ownership
+  /// proof claim:
+  /// `"barnard-rpid-proof:v1" ‖ eventIdHash(32) ‖ enin(8, BE) ‖ rpi(16) ‖ len(challenge) as u16 BE ‖ challenge`.
+  static func buildRpidProofMessage(eventIdHash: Data, enin: UInt64, rpi: Data, challenge: Data?) -> Data {
+    precondition(eventIdHash.count == 32, "eventIdHash must be 32 bytes")
+    precondition(rpi.count == 16, "rpi must be 16 bytes")
+    let challengeBytes = challenge ?? Data()
+    precondition(challengeBytes.count <= 0xffff, "challenge too long")
+
+    var message = Data(rpidProofDomainTag.utf8)
+    message.append(eventIdHash)
+    message.append(contentsOf: withUnsafeBytes(of: enin.bigEndian) { Data($0) })
+    message.append(rpi)
+    message.append(contentsOf: withUnsafeBytes(of: UInt16(challengeBytes.count).bigEndian) { Data($0) })
+    message.append(challengeBytes)
+    return message
+  }
+
+  /// Canonical encoding of a signing-key-to-device-identity binding claim.
+  static func buildKeyBindingMessage(eventCodeHash: Data, displayId: Data) -> Data {
+    var message = Data(keyBindingDomainTag.utf8)
+    message.append(eventCodeHash)
+    message.append(displayId)
+    return message
+  }
+
+  /// Compute the RPID ownership proof for `enin` within `eventCode`, per
+  /// barnard#63. Derives the TEK/RPIK/RPI internally from `deviceSecret`
+  /// (via `BarnardCrypto`) — only the resulting `rpi` (not the TEK/RPIK)
+  /// appears in the output.
+  static func proveRpidOwnership(
+    deviceSecret: Data,
+    eventCode: String,
+    eventIdHash: Data,
+    enin: UInt64,
+    challenge: Data?
+  ) -> RpidOwnershipProof {
+    let tek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: eventCode)
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
+    let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: UInt32(truncatingIfNeeded: enin))
+
+    let message = buildRpidProofMessage(eventIdHash: eventIdHash, enin: enin, rpi: rpi, challenge: challenge)
+    let keyPair = deriveSigningKeyPair(deviceSecret: deviceSecret, eventCode: eventCode)
+    let sig = signRecoverable(privateKey: keyPair.privateKey, messageHash32: Data(SHA256.hash(data: message)))
+
+    return RpidOwnershipProof(
+      rpi: rpi,
+      enin: enin,
+      eventIdHash: eventIdHash,
+      signingPublicKey: keyPair.publicKeyCompressed,
+      sig: sig
+    )
+  }
+
+  /// Sign the key-binding claim per barnard#63 acceptance criterion 3.
+  static func signKeyBinding(
+    deviceSecret: Data,
+    eventCode: String,
+    eventCodeHash: Data,
+    displayId: Data
+  ) -> RecoverableSignature {
+    let message = buildKeyBindingMessage(eventCodeHash: eventCodeHash, displayId: displayId)
+    let keyPair = deriveSigningKeyPair(deviceSecret: deviceSecret, eventCode: eventCode)
+    return signRecoverable(privateKey: keyPair.privateKey, messageHash32: Data(SHA256.hash(data: message)))
+  }
+
+  /// RFC 6979 deterministic `k` (HMAC-SHA256; qlen == hlen == 32 bytes for secp256k1/SHA-256).
+  private static func deterministicK(privateKey: Secp256k1.UInt256, messageHash32: Data) -> Secp256k1.UInt256 {
+    let x = privateKey.data
+    let h1 = Secp256k1.Field.reduceOnce(Secp256k1.UInt256(data: messageHash32), Secp256k1.N).data
+
+    func hmac(_ key: Data, _ data: Data) -> Data {
+      Data(HMAC<SHA256>.authenticationCode(for: data, using: SymmetricKey(data: key)))
+    }
+
+    var v = Data(repeating: 0x01, count: 32)
+    var k = Data(repeating: 0x00, count: 32)
+
+    k = hmac(k, v + Data([0x00]) + x + h1)
+    v = hmac(k, v)
+    k = hmac(k, v + Data([0x01]) + x + h1)
+    v = hmac(k, v)
+
+    while true {
+      v = hmac(k, v)
+      let candidate = Secp256k1.UInt256(data: v)
+      if !candidate.isZero && candidate < Secp256k1.N {
+        return candidate
+      }
+      k = hmac(k, v + Data([0x00]))
+      v = hmac(k, v)
+    }
+  }
+}

--- a/packages/swift/barnard/Sources/Barnard/BarnardV2Policy.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardV2Policy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Pure-logic policy decisions for Barnard v2.
+///
+/// Mirrors `BarnardV2Policy` on the Android side so the same review-fix
+/// rules are expressed in the same shape on both platforms.
+enum BarnardV2Policy {
+  /// B003 displayId may only be served while the peripheral is joined to an event.
+  /// Anonymous reads are rejected so the device-secret-derived TEK does not
+  /// surface as a stable on-wire displayId.
+  static func shouldServeGattDisplayId(eventCode: String?) -> Bool {
+    guard let code = eventCode, !code.isEmpty else { return false }
+    return true
+  }
+
+  /// Cached known-peer RPID is reusable only within the ENIN window in which
+  /// it was resolved. After ENIN rotation the SDK must re-read B002/B003.
+  struct KnownPeerWindow {
+    let enin: UInt32
+    func matches(_ currentEnin: UInt32) -> Bool { enin == currentEnin }
+  }
+
+  /// RSSI updates may reuse a cached peer RPID only while the cache belongs to
+  /// the current ENIN. After rotation, Central must re-resolve B002/B003 first.
+  static func shouldEmitRssiUpdate(
+    cachedPeerEnin: UInt32,
+    currentEnin: UInt32
+  ) -> Bool {
+    KnownPeerWindow(enin: cachedPeerEnin).matches(currentEnin)
+  }
+}

--- a/packages/swift/barnard/Sources/Barnard/PrivacyInfo.xcprivacy
+++ b/packages/swift/barnard/Sources/Barnard/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/swift/barnard/Sources/Barnard/Secp256k1.swift
+++ b/packages/swift/barnard/Sources/Barnard/Secp256k1.swift
@@ -1,0 +1,274 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+
+/// Minimal secp256k1 field/point arithmetic and a fixed-width 256-bit
+/// integer, used by `BarnardSigning` (barnard#65) for recoverable
+/// ("ecrecover"-able) ECDSA. iOS has no system-provided secp256k1 curve
+/// (CryptoKit covers P-256/384/521 and Curve25519 only).
+enum Secp256k1 {
+  /// Fixed-width 256-bit unsigned integer for secp256k1 field/scalar
+  /// arithmetic. Stored as 4 big-endian `UInt64` limbs (`limbs.0` most
+  /// significant).
+  struct UInt256: Comparable {
+    var limbs: (UInt64, UInt64, UInt64, UInt64)
+
+    static func == (lhs: UInt256, rhs: UInt256) -> Bool {
+      lhs.limbs == rhs.limbs
+    }
+
+    static let zero = UInt256(limbs: (0, 0, 0, 0))
+    static let one = UInt256(limbs: (0, 0, 0, 1))
+
+    init(limbs: (UInt64, UInt64, UInt64, UInt64)) {
+      self.limbs = limbs
+    }
+
+    init?(hex: String) {
+      var h = hex
+      if h.count > 64 { return nil }
+      while h.count < 64 { h = "0" + h }
+      var parts: [UInt64] = []
+      var idx = h.startIndex
+      for _ in 0..<4 {
+        let next = h.index(idx, offsetBy: 16)
+        guard let v = UInt64(h[idx..<next], radix: 16) else { return nil }
+        parts.append(v)
+        idx = next
+      }
+      self.limbs = (parts[0], parts[1], parts[2], parts[3])
+    }
+
+    /// Interprets `data` as a big-endian integer, truncating/left-padding
+    /// to 32 bytes if the input isn't exactly 32 bytes.
+    init(data: Data) {
+      var bytes = [UInt8](data)
+      if bytes.count > 32 {
+        bytes = Array(bytes.suffix(32))
+      } else if bytes.count < 32 {
+        bytes = [UInt8](repeating: 0, count: 32 - bytes.count) + bytes
+      }
+      func limb(_ range: Range<Int>) -> UInt64 {
+        var v: UInt64 = 0
+        for i in range { v = (v << 8) | UInt64(bytes[i]) }
+        return v
+      }
+      self.limbs = (limb(0..<8), limb(8..<16), limb(16..<24), limb(24..<32))
+    }
+
+    /// Big-endian 32-byte encoding.
+    var data: Data {
+      var out = [UInt8](repeating: 0, count: 32)
+      let parts = [limbs.0, limbs.1, limbs.2, limbs.3]
+      for (i, part) in parts.enumerated() {
+        for j in 0..<8 {
+          out[i * 8 + j] = UInt8((part >> (56 - 8 * j)) & 0xff)
+        }
+      }
+      return Data(out)
+    }
+
+    static func < (lhs: UInt256, rhs: UInt256) -> Bool {
+      if lhs.limbs.0 != rhs.limbs.0 { return lhs.limbs.0 < rhs.limbs.0 }
+      if lhs.limbs.1 != rhs.limbs.1 { return lhs.limbs.1 < rhs.limbs.1 }
+      if lhs.limbs.2 != rhs.limbs.2 { return lhs.limbs.2 < rhs.limbs.2 }
+      return lhs.limbs.3 < rhs.limbs.3
+    }
+
+    var isZero: Bool { self == .zero }
+
+    @inline(__always)
+    func testBit(_ n: Int) -> Bool {
+      let bitIndex = n % 64
+      switch n / 64 {
+      case 0: return (limbs.3 >> bitIndex) & 1 == 1
+      case 1: return (limbs.2 >> bitIndex) & 1 == 1
+      case 2: return (limbs.1 >> bitIndex) & 1 == 1
+      default: return (limbs.0 >> bitIndex) & 1 == 1
+      }
+    }
+
+    /// Adds `x + y + carryIn`, returning `(result, carryOut)`.
+    @inline(__always)
+    private static func addLimb(_ x: UInt64, _ y: UInt64, _ carryIn: UInt64) -> (UInt64, UInt64) {
+      let (s1, o1) = x.addingReportingOverflow(y)
+      let (s2, o2) = s1.addingReportingOverflow(carryIn)
+      return (s2, (o1 ? 1 : 0) &+ (o2 ? 1 : 0))
+    }
+
+    /// Unsigned add with carry-out (across all 4 limbs), ripple-carry from
+    /// the least-significant limb (`limbs.3`). Operates directly on the
+    /// tuple fields (no array allocation) since this is the innermost loop
+    /// of `Field.mulMod`/`powMod`, called millions of times per signature.
+    @inline(__always)
+    func addingWithCarry(_ other: UInt256) -> (UInt256, Bool) {
+      let (r3, c3) = UInt256.addLimb(limbs.3, other.limbs.3, 0)
+      let (r2, c2) = UInt256.addLimb(limbs.2, other.limbs.2, c3)
+      let (r1, c1) = UInt256.addLimb(limbs.1, other.limbs.1, c2)
+      let (r0, c0) = UInt256.addLimb(limbs.0, other.limbs.0, c1)
+      return (UInt256(limbs: (r0, r1, r2, r3)), c0 != 0)
+    }
+
+    /// Subtracts `x - y - borrowIn`, returning `(result, borrowOut)`.
+    @inline(__always)
+    private static func subLimb(_ x: UInt64, _ y: UInt64, _ borrowIn: UInt64) -> (UInt64, UInt64) {
+      let (d1, b1) = x.subtractingReportingOverflow(y)
+      let (d2, b2) = d1.subtractingReportingOverflow(borrowIn)
+      return (d2, (b1 ? 1 : 0) &+ (b2 ? 1 : 0))
+    }
+
+    /// Unsigned subtract assuming `self >= other` (across all 4 limbs).
+    @inline(__always)
+    func subtracting(_ other: UInt256) -> UInt256 {
+      let (d3, b3) = UInt256.subLimb(limbs.3, other.limbs.3, 0)
+      let (d2, b2) = UInt256.subLimb(limbs.2, other.limbs.2, b3)
+      let (d1, b1) = UInt256.subLimb(limbs.1, other.limbs.1, b2)
+      let (d0, _) = UInt256.subLimb(limbs.0, other.limbs.0, b1)
+      return UInt256(limbs: (d0, d1, d2, d3))
+    }
+
+    @inline(__always)
+    func shiftedRight1() -> UInt256 {
+      let c1 = limbs.0 & 1
+      let c2 = limbs.1 & 1
+      let c3 = limbs.2 & 1
+      return UInt256(
+        limbs: (
+          limbs.0 >> 1,
+          (limbs.1 >> 1) | (c1 << 63),
+          (limbs.2 >> 1) | (c2 << 63),
+          (limbs.3 >> 1) | (c3 << 63)
+        )
+      )
+    }
+  }
+
+  /// Field/scalar arithmetic mod an arbitrary 256-bit modulus `m` (either
+  /// the field prime `P` or the curve order `N`). Reduced with modular
+  /// addition/doubling only (no full-width multiply+reduce): every
+  /// 256-bit input here is already `< 2 * m` (`m` is within ~2^129 of
+  /// 2^256 for both `P` and `N`), so a single conditional subtraction
+  /// reduces it.
+  enum Field {
+    static func reduceOnce(_ a: UInt256, _ m: UInt256) -> UInt256 {
+      a >= m ? a.subtracting(m) : a
+    }
+
+    static func addMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      let (sum, carry) = a.addingWithCarry(b)
+      if carry || sum >= m { return sum.subtracting(m) }
+      return sum
+    }
+
+    static func subMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      if a >= b { return a.subtracting(b) }
+      return m.subtracting(b.subtracting(a))
+    }
+
+    /// Modular multiplication via double-and-add (avoids a full 512-bit
+    /// multiply + reduction step).
+    static func mulMod(_ a: UInt256, _ b: UInt256, _ m: UInt256) -> UInt256 {
+      var result = UInt256.zero
+      let addend = reduceOnce(a, m)
+      for i in stride(from: 255, through: 0, by: -1) {
+        result = addMod(result, result, m)
+        if b.testBit(i) {
+          result = addMod(result, addend, m)
+        }
+      }
+      return result
+    }
+
+    static func powMod(_ base: UInt256, _ exponent: UInt256, _ m: UInt256) -> UInt256 {
+      var result = UInt256.one
+      let b = reduceOnce(base, m)
+      for i in stride(from: 255, through: 0, by: -1) {
+        result = mulMod(result, result, m)
+        if exponent.testBit(i) {
+          result = mulMod(result, b, m)
+        }
+      }
+      return result
+    }
+
+    /// Modular inverse via Fermat's little theorem (`m` must be prime):
+    /// `a^-1 = a^(m-2) mod m`.
+    static func invMod(_ a: UInt256, _ m: UInt256) -> UInt256 {
+      let mMinus2 = m.subtracting(UInt256(limbs: (0, 0, 0, 2)))
+      return powMod(a, mMinus2, m)
+    }
+  }
+
+  static let P = UInt256(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F")!
+  static let N = UInt256(hex: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141")!
+  static let Gx = UInt256(hex: "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798")!
+  static let Gy = UInt256(hex: "483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8")!
+
+  struct Point: Equatable {
+    var x: UInt256?
+    var y: UInt256?
+    static let infinity = Point(x: nil, y: nil)
+    var isInfinity: Bool { x == nil || y == nil }
+  }
+
+  static let G = Point(x: Gx, y: Gy)
+
+  static func pointDouble(_ p: Point) -> Point {
+    guard let x = p.x, let y = p.y, !y.isZero else { return .infinity }
+    let num = Field.mulMod(UInt256(limbs: (0, 0, 0, 3)), Field.mulMod(x, x, P), P)
+    let den = Field.invMod(Field.mulMod(UInt256(limbs: (0, 0, 0, 2)), y, P), P)
+    let slope = Field.mulMod(num, den, P)
+    let x3 = Field.subMod(Field.subMod(Field.mulMod(slope, slope, P), x, P), x, P)
+    let y3 = Field.subMod(Field.mulMod(slope, Field.subMod(x, x3, P), P), y, P)
+    return Point(x: x3, y: y3)
+  }
+
+  static func pointAdd(_ p1: Point, _ p2: Point) -> Point {
+    if p1.isInfinity { return p2 }
+    if p2.isInfinity { return p1 }
+    guard let x1 = p1.x, let y1 = p1.y, let x2 = p2.x, let y2 = p2.y else { return .infinity }
+    if x1 == x2 {
+      if Field.addMod(y1, y2, P).isZero { return .infinity }
+      return pointDouble(p1)
+    }
+    let slope = Field.mulMod(Field.subMod(y2, y1, P), Field.invMod(Field.subMod(x2, x1, P), P), P)
+    let x3 = Field.subMod(Field.subMod(Field.mulMod(slope, slope, P), x1, P), x2, P)
+    let y3 = Field.subMod(Field.mulMod(slope, Field.subMod(x1, x3, P), P), y1, P)
+    return Point(x: x3, y: y3)
+  }
+
+  static func scalarMult(_ k: UInt256, _ point: Point) -> Point {
+    var result = Point.infinity
+    let addend = point
+    for i in stride(from: 255, through: 0, by: -1) {
+      result = pointDouble(result)
+      if k.testBit(i) {
+        result = pointAdd(result, addend)
+      }
+    }
+    return result
+  }
+
+  /// SEC1-compressed encoding (33 bytes: 0x02/0x03 prefix + 32-byte X).
+  static func compress(_ point: Point) -> Data {
+    guard let x = point.x, let y = point.y else { return Data() }
+    let prefix: UInt8 = y.testBit(0) ? 0x03 : 0x02
+    return Data([prefix]) + x.data
+  }
+
+  /// Decompress a point from its X coordinate and Y parity bit. Returns
+  /// nil if X is not on the curve.
+  static func decompress(x: UInt256, yIsOdd: Bool) -> Point? {
+    let x3 = Field.mulMod(Field.mulMod(x, x, P), x, P)
+    let rhs = Field.addMod(x3, UInt256(limbs: (0, 0, 0, 7)), P)
+    // secp256k1's P is congruent to 3 mod 4, so sqrt(a) = a^((P+1)/4) mod P.
+    let sqrtExponent = P.addingWithCarry(UInt256.one).0.shiftedRight1().shiftedRight1()
+    var y = Field.powMod(rhs, sqrtExponent, P)
+    if Field.mulMod(y, y, P) != rhs { return nil }
+    if y.testBit(0) != yIsOdd {
+      y = P.subtracting(y)
+    }
+    return Point(x: x, y: y)
+  }
+}

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardCryptoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardCryptoTests.swift
@@ -1,0 +1,150 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import XCTest
+@testable import Barnard
+
+final class BarnardCryptoTests: XCTestCase {
+  func testDeriveTekForEventIsDeterministic() {
+    let deviceSecret = Data(repeating: 0xAB, count: 32)
+    let tek1 = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: "EVT1")
+    let tek2 = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: "EVT1")
+    XCTAssertEqual(tek1, tek2)
+    XCTAssertEqual(tek1.count, 16)
+  }
+
+  func testDeriveTekForEventDependsOnEventCode() {
+    let deviceSecret = Data(repeating: 0xAB, count: 32)
+    let tekA = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: "EVT-A")
+    let tekB = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: "EVT-B")
+    XCTAssertNotEqual(tekA, tekB)
+  }
+
+  func testDeriveTekForAnonymousDiffersFromEventMode() {
+    let deviceSecret = Data(repeating: 0xCD, count: 32)
+    let anonymousTek = BarnardCrypto.deriveTekForAnonymous(deviceSecret: deviceSecret)
+    let eventTek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: "EVT1")
+    XCTAssertEqual(anonymousTek.count, 16)
+    XCTAssertNotEqual(anonymousTek, eventTek)
+  }
+
+  func testDeriveRpikRequires16ByteTek() {
+    let shortTek = Data(repeating: 0x01, count: 8)
+    XCTAssertEqual(BarnardCrypto.deriveRpik(from: shortTek), Data(count: 16))
+
+    let tek = Data(repeating: 0x02, count: 16)
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
+    XCTAssertEqual(rpik.count, 16)
+  }
+
+  func testGenerateRpiIsDeterministicForSameEnin() {
+    let rpik = Data(repeating: 0x03, count: 16)
+    let rpi1 = BarnardCrypto.generateRpi(rpik: rpik, enin: 42)
+    let rpi2 = BarnardCrypto.generateRpi(rpik: rpik, enin: 42)
+    XCTAssertEqual(rpi1, rpi2)
+    XCTAssertEqual(rpi1.count, 16)
+  }
+
+  func testGenerateRpiChangesWithEnin() {
+    let rpik = Data(repeating: 0x03, count: 16)
+    let rpiA = BarnardCrypto.generateRpi(rpik: rpik, enin: 1)
+    let rpiB = BarnardCrypto.generateRpi(rpik: rpik, enin: 2)
+    XCTAssertNotEqual(rpiA, rpiB)
+  }
+
+  func testCalculateEninFixedLengthFloorsToWindow() {
+    // 300s window: unix seconds 900...1199 all map to ENIN 3.
+    let date = Date(timeIntervalSince1970: 1000)
+    let enin = BarnardCrypto.calculateEnin(for: date, mode: .fixedLength, eninSeconds: 300)
+    XCTAssertEqual(enin, 3)
+  }
+
+  func testCalculateEninFixedLengthClampsSeconds() {
+    let date = Date(timeIntervalSince1970: 1_000_000)
+    // Request an out-of-range window; must clamp to [12, 3600].
+    let eninTooSmall = BarnardCrypto.calculateEnin(for: date, mode: .fixedLength, eninSeconds: 1)
+    let eninAt12 = BarnardCrypto.calculateEnin(for: date, mode: .fixedLength, eninSeconds: 12)
+    XCTAssertEqual(eninTooSmall, eninAt12)
+
+    let eninTooLarge = BarnardCrypto.calculateEnin(for: date, mode: .fixedLength, eninSeconds: 999_999)
+    let eninAt3600 = BarnardCrypto.calculateEnin(for: date, mode: .fixedLength, eninSeconds: 3600)
+    XCTAssertEqual(eninTooLarge, eninAt3600)
+  }
+
+  func testCalculateEninBeaconSlotBeforeGenesisIsZero() {
+    let chain = BarnardCrypto.BeaconChainConfig(chainId: "test", genesisUnixSeconds: 1_000_000, slotSeconds: 12)
+    let beforeGenesis = Date(timeIntervalSince1970: 500_000)
+    XCTAssertEqual(BarnardCrypto.calculateEnin(for: beforeGenesis, mode: .beaconSlot, beaconChain: chain), 0)
+  }
+
+  func testCalculateEninBeaconSlotAfterGenesis() {
+    let chain = BarnardCrypto.BeaconChainConfig(chainId: "test", genesisUnixSeconds: 1_000_000, slotSeconds: 12)
+    let date = Date(timeIntervalSince1970: 1_000_000 + 36)
+    XCTAssertEqual(BarnardCrypto.calculateEnin(for: date, mode: .beaconSlot, beaconChain: chain), 3)
+  }
+
+  func testStableReadEninReturnsNilAcrossBoundary() {
+    let startedAt = Date(timeIntervalSince1970: 899)
+    let completedAt = Date(timeIntervalSince1970: 901)
+    XCTAssertNil(BarnardCrypto.stableReadEnin(startedAt: startedAt, completedAt: completedAt, eninSeconds: 300))
+  }
+
+  func testStableReadEninReturnsEninWithinSameWindow() {
+    let startedAt = Date(timeIntervalSince1970: 905)
+    let completedAt = Date(timeIntervalSince1970: 907)
+    XCTAssertEqual(
+      BarnardCrypto.stableReadEnin(startedAt: startedAt, completedAt: completedAt, eninSeconds: 300),
+      3
+    )
+  }
+
+  func testComputeEventCodeHashIs8BytesAndDeterministic() {
+    let hash1 = BarnardCrypto.computeEventCodeHash("EVT1")
+    let hash2 = BarnardCrypto.computeEventCodeHash("EVT1")
+    XCTAssertEqual(hash1, hash2)
+    XCTAssertEqual(hash1.count, 8)
+
+    let otherHash = BarnardCrypto.computeEventCodeHash("EVT2")
+    XCTAssertNotEqual(hash1, otherHash)
+  }
+
+  func testDisplayId4Is4BytesAndDeterministic() {
+    let tek = Data(repeating: 0x09, count: 16)
+    let id1 = BarnardCrypto.displayId4(from: tek)
+    let id2 = BarnardCrypto.displayId4(from: tek)
+    XCTAssertEqual(id1, id2)
+    XCTAssertEqual(id1.count, 4)
+  }
+
+  func testDisplayIdStringIs8LowercaseHexChars() {
+    let tek = Data(repeating: 0x0A, count: 16)
+    let str = BarnardCrypto.displayIdString(from: tek)
+    XCTAssertEqual(str.count, 8)
+    XCTAssertEqual(str, str.lowercased())
+    XCTAssertNotNil(UInt32(str, radix: 16))
+  }
+
+  func testGenerateRandomBytesProducesRequestedLengthAndVaries() {
+    let a = BarnardCrypto.generateRandomBytes(32)
+    let b = BarnardCrypto.generateRandomBytes(32)
+    XCTAssertEqual(a.count, 32)
+    XCTAssertEqual(b.count, 32)
+    // Astronomically unlikely to collide; guards against a broken/stubbed RNG.
+    XCTAssertNotEqual(a, b)
+  }
+
+  // MARK: - On-wire invariant
+
+  /// Barnard's core privacy invariant (AGENTS.md, issue #56): no
+  /// device-unique persistent identifier may appear on the wire. RPI must
+  /// rotate every ENIN window instead of staying fixed per device.
+  func testRpiRotatesAcrossEninWindowsForSameDevice() {
+    let deviceSecret = Data(repeating: 0x11, count: 32)
+    let tek = BarnardCrypto.deriveTekForEvent(deviceSecret: deviceSecret, eventCode: "EVT1")
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
+
+    let rpiWindow1 = BarnardCrypto.generateRpi(rpik: rpik, enin: 100)
+    let rpiWindow2 = BarnardCrypto.generateRpi(rpik: rpik, enin: 101)
+    XCTAssertNotEqual(rpiWindow1, rpiWindow2, "RPI must not stay constant across ENIN windows")
+  }
+}

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardRpidGeneratorTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardRpidGeneratorTests.swift
@@ -1,0 +1,96 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import XCTest
+@testable import Barnard
+
+/// `BarnardRpidGenerator` persists to `UserDefaults.standard` under fixed
+/// keys (`barnard.rpidSeed`, `barnard.eventCode`) — the same behavior as
+/// the Flutter plugin's original. Each test clears those keys first so
+/// runs are independent of execution order and of state left by the
+/// example app or other test targets sharing the same defaults domain.
+final class BarnardRpidGeneratorTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    clearPersistedState()
+  }
+
+  override func tearDown() {
+    clearPersistedState()
+    super.tearDown()
+  }
+
+  private func clearPersistedState() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: "barnard.rpidSeed")
+    defaults.removeObject(forKey: "barnard.eventCode")
+  }
+
+  func testStartsInAnonymousMode() {
+    let generator = BarnardRpidGenerator()
+    XCTAssertNil(generator.eventCode)
+    XCTAssertFalse(generator.isEventMode)
+  }
+
+  func testJoinEventSwitchesToEventModeAndChangesTek() {
+    let generator = BarnardRpidGenerator()
+    let anonymousTek = generator.getCurrentTek()
+
+    generator.joinEvent("EVT1")
+    XCTAssertEqual(generator.eventCode, "EVT1")
+    XCTAssertTrue(generator.isEventMode)
+    XCTAssertNotEqual(generator.getCurrentTek(), anonymousTek)
+  }
+
+  func testLeaveEventReturnsToAnonymousModeWithOriginalTek() {
+    let generator = BarnardRpidGenerator()
+    let anonymousTek = generator.getCurrentTek()
+
+    generator.joinEvent("EVT1")
+    generator.leaveEvent()
+
+    XCTAssertNil(generator.eventCode)
+    XCTAssertFalse(generator.isEventMode)
+    XCTAssertEqual(generator.getCurrentTek(), anonymousTek)
+  }
+
+  func testDeviceSecretIsStableAcrossInstances() {
+    let first = BarnardRpidGenerator()
+    let secret1 = first.getDeviceSecret()
+
+    let second = BarnardRpidGenerator()
+    let secret2 = second.getDeviceSecret()
+
+    XCTAssertEqual(secret1, secret2)
+    XCTAssertEqual(secret1.count, 32)
+  }
+
+  func testCurrentPayloadIs17BytesWithFormatVersionPrefix() {
+    let generator = BarnardRpidGenerator()
+    let payload = generator.currentPayload(formatVersion: 1, now: Date(timeIntervalSince1970: 1000))
+    XCTAssertEqual(payload.count, 17)
+    XCTAssertEqual(payload.first, 1)
+  }
+
+  func testCurrentPayloadRotatesAcrossEninWindowsButRpidGeneratorSecretDoesNot() {
+    let generator = BarnardRpidGenerator()
+    let payload1 = generator.currentPayload(now: Date(timeIntervalSince1970: 0), eninSeconds: 300)
+    let payload2 = generator.currentPayload(now: Date(timeIntervalSince1970: 301), eninSeconds: 300)
+    XCTAssertNotEqual(payload1, payload2, "on-wire payload must rotate; the device secret must not appear on the wire")
+  }
+
+  func testGetCurrentDisplayIdIs8LowercaseHexChars() {
+    let generator = BarnardRpidGenerator()
+    let displayId = generator.getCurrentDisplayId()
+    XCTAssertEqual(displayId.count, 8)
+    XCTAssertEqual(displayId, displayId.lowercased())
+  }
+
+  func testEventCodeHashEmptyInAnonymousModeAnd8BytesInEventMode() {
+    let generator = BarnardRpidGenerator()
+    XCTAssertEqual(generator.getEventCodeHash().count, 0)
+
+    generator.joinEvent("EVT1")
+    XCTAssertEqual(generator.getEventCodeHash().count, 8)
+  }
+}

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardSigningTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardSigningTests.swift
@@ -1,0 +1,131 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import CryptoKit
+import XCTest
+@testable import Barnard
+
+final class BarnardSigningTests: XCTestCase {
+  func testDeriveSigningKeyPairIsDeterministic() {
+    let secret = Data(repeating: 0x21, count: 32)
+    let pair1 = BarnardSigning.deriveSigningKeyPair(deviceSecret: secret, eventCode: "EVT1")
+    let pair2 = BarnardSigning.deriveSigningKeyPair(deviceSecret: secret, eventCode: "EVT1")
+    XCTAssertEqual(pair1.publicKeyCompressed, pair2.publicKeyCompressed)
+    XCTAssertEqual(pair1.privateKey.data, pair2.privateKey.data)
+    XCTAssertEqual(pair1.publicKeyCompressed.count, 33)
+  }
+
+  func testDeriveSigningKeyPairDiffersFromTekChain() {
+    // barnard#65: "barnard-sign" HKDF info must not be cross-computable
+    // from the TEK chain ("barnard-tek" / "EN-RPIK").
+    let secret = Data(repeating: 0x22, count: 32)
+    let signingKeyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: secret, eventCode: "EVT1")
+    let tek = BarnardCrypto.deriveTekForEvent(deviceSecret: secret, eventCode: "EVT1")
+    XCTAssertNotEqual(signingKeyPair.privateKey.data, tek)
+  }
+
+  func testSignRecoverableRoundTripsThroughRecoverPublicKey() {
+    let secret = Data(repeating: 0x23, count: 32)
+    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: secret, eventCode: "EVT1")
+    let messageHash = Data(SHA256.hash(data: Data("hello barnard".utf8)))
+
+    let sig = BarnardSigning.signRecoverable(privateKey: keyPair.privateKey, messageHash32: messageHash)
+    let recovered = BarnardSigning.recoverPublicKey(
+      recId: sig.v,
+      r: Secp256k1.UInt256(data: sig.r),
+      s: Secp256k1.UInt256(data: sig.s),
+      messageHash32: messageHash
+    )
+
+    XCTAssertEqual(recovered, keyPair.publicKeyCompressed)
+  }
+
+  func testSignRecoverableProducesLowSSignatures() {
+    let secret = Data(repeating: 0x24, count: 32)
+    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: secret, eventCode: "EVT1")
+    let messageHash = Data(SHA256.hash(data: Data("canonical low-s check".utf8)))
+
+    let sig = BarnardSigning.signRecoverable(privateKey: keyPair.privateKey, messageHash32: messageHash)
+    let s = Secp256k1.UInt256(data: sig.s)
+    let halfOrder = Secp256k1.N.shiftedRight1()
+    XCTAssertFalse(s > halfOrder, "signature must be normalized to the lower half of the curve order")
+  }
+
+  func testProveRpidOwnershipEmbedsMatchingRpiAndVerifies() {
+    let secret = Data(repeating: 0x25, count: 32)
+    let eventIdHash = Data(SHA256.hash(data: Data("event-id".utf8)))
+
+    let proof = BarnardSigning.proveRpidOwnership(
+      deviceSecret: secret,
+      eventCode: "EVT1",
+      eventIdHash: eventIdHash,
+      enin: 12345,
+      challenge: nil
+    )
+
+    // The proof's RPI must match independently-derived TEK/RPIK/RPI for the
+    // same (deviceSecret, eventCode, enin).
+    let tek = BarnardCrypto.deriveTekForEvent(deviceSecret: secret, eventCode: "EVT1")
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
+    let expectedRpi = BarnardCrypto.generateRpi(rpik: rpik, enin: UInt32(truncatingIfNeeded: UInt64(12345)))
+    XCTAssertEqual(proof.rpi, expectedRpi)
+
+    let message = BarnardSigning.buildRpidProofMessage(
+      eventIdHash: eventIdHash,
+      enin: 12345,
+      rpi: proof.rpi,
+      challenge: nil
+    )
+    let messageHash = Data(SHA256.hash(data: message))
+    let recovered = BarnardSigning.recoverPublicKey(
+      recId: proof.sig.v,
+      r: Secp256k1.UInt256(data: proof.sig.r),
+      s: Secp256k1.UInt256(data: proof.sig.s),
+      messageHash32: messageHash
+    )
+    XCTAssertEqual(recovered, proof.signingPublicKey)
+  }
+
+  func testSignKeyBindingVerifiesAgainstSigningPublicKey() {
+    let secret = Data(repeating: 0x26, count: 32)
+    let eventCodeHash = BarnardCrypto.computeEventCodeHash("EVT1")
+    let displayId = Data(repeating: 0xAA, count: 4)
+
+    let sig = BarnardSigning.signKeyBinding(
+      deviceSecret: secret,
+      eventCode: "EVT1",
+      eventCodeHash: eventCodeHash,
+      displayId: displayId
+    )
+    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: secret, eventCode: "EVT1")
+
+    let message = BarnardSigning.buildKeyBindingMessage(eventCodeHash: eventCodeHash, displayId: displayId)
+    let messageHash = Data(SHA256.hash(data: message))
+    let recovered = BarnardSigning.recoverPublicKey(
+      recId: sig.v,
+      r: Secp256k1.UInt256(data: sig.r),
+      s: Secp256k1.UInt256(data: sig.s),
+      messageHash32: messageHash
+    )
+    XCTAssertEqual(recovered, keyPair.publicKeyCompressed)
+  }
+
+  // MARK: - BarnardIdentity (public, Flutter-free API)
+
+  func testBarnardIdentitySignAndProveRoundTrip() {
+    UserDefaults.standard.removeObject(forKey: "barnard.rpidSeed")
+    let identity = BarnardIdentity()
+
+    let publicKey = identity.signingPublicKey(eventCode: "EVT1")
+    XCTAssertEqual(publicKey.count, 33)
+
+    let sig = identity.sign(eventCode: "EVT1", bytes: Data("payload".utf8))
+    XCTAssertEqual(sig.r.count, 32)
+    XCTAssertEqual(sig.s.count, 32)
+
+    let eventIdHash = Data(SHA256.hash(data: Data("event".utf8)))
+    let proof = identity.proveRpidOwnership(eventCode: "EVT1", enin: 100, eventIdHash: eventIdHash)
+    XCTAssertEqual(proof.signingPublicKey, publicKey)
+    XCTAssertEqual(proof.rpi.count, 16)
+  }
+}

--- a/scripts/check-swift-mirror.sh
+++ b/scripts/check-swift-mirror.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 The Greeting Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+#
+# barnard#56: packages/swift/barnard mirrors the Flutter-free crypto/RPID
+# sources from packages/dart/barnard/ios/barnard/Sources/barnard (byte-for-
+# byte, not re-implemented) so the two packages cannot silently drift.
+# Fails with a diff if any mirrored file no longer matches its origin.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+origin_dir="$repo_root/packages/dart/barnard/ios/barnard/Sources/barnard"
+mirror_dir="$repo_root/packages/swift/barnard/Sources/Barnard"
+
+mirrored_files=(
+  "BarnardCrypto.swift"
+  "Secp256k1.swift"
+  "BarnardSigning.swift"
+  "BarnardRpidGenerator.swift"
+  "BarnardV2Policy.swift"
+  "PrivacyInfo.xcprivacy"
+)
+
+status=0
+for f in "${mirrored_files[@]}"; do
+  origin_file="$origin_dir/$f"
+  mirror_file="$mirror_dir/$f"
+  if [[ ! -f "$origin_file" ]]; then
+    echo "MISSING origin: $origin_file"
+    status=1
+    continue
+  fi
+  if [[ ! -f "$mirror_file" ]]; then
+    echo "MISSING mirror: $mirror_file"
+    status=1
+    continue
+  fi
+  if ! diff -q "$origin_file" "$mirror_file" >/dev/null 2>&1; then
+    echo "DRIFT: $origin_file != $mirror_file"
+    diff -u "$origin_file" "$mirror_file" || true
+    status=1
+  fi
+done
+
+if [[ $status -eq 0 ]]; then
+  echo "OK: packages/swift/barnard mirrors match their origin byte-for-byte."
+fi
+exit $status


### PR DESCRIPTION
## Summary

First slice of barnard#56 ("Native mobile apps cannot adopt Barnard as first-class SDKs") — **iOS only**. Android is explicitly deferred as a follow-up (see below) rather than shipping a half-built native Android package in the same PR, per the epic's own guidance that partial completion is expected.

Adds `packages/swift/barnard`: a first-class, Flutter-free SwiftPM library exposing a Swift-first public API for native iOS apps.

## Approach: mirror, not move (stated explicitly, per repo convention)

- `BarnardCrypto.swift`, `Secp256k1.swift`, `BarnardSigning.swift`, `BarnardRpidGenerator.swift`, `BarnardV2Policy.swift`, `PrivacyInfo.xcprivacy` are **byte-for-byte mirrors** of the Flutter-free sources already in `packages/dart/barnard/ios/barnard/Sources/barnard`. `scripts/check-swift-mirror.sh` diffs origin vs. mirror and fails CI on drift (wired into `.github/workflows/native-sdk.yml` as `swift-mirror-sync-check`).
- `BarnardEngine.swift` (replaces `BarnardBleController`) and `BarnardIdentity.swift` (replaces `BarnardIdentityController`) are **new files, not mirrors** — the originals are woven into Flutter's method-channel API (`FlutterEventSink`, `FlutterMethodCall`/`FlutterResult`) and cannot be copied verbatim. They re-implement the identical scan/advertise/GATT/signing behavior with a Swift-first public API (typed events via closures, direct methods, typed return values) instead of a method-channel dispatcher. Logic (state machine, GATT UUIDs, retry/backoff/watchdog timers, event shapes) is a line-by-line port, not a rewrite.

**Why mirror instead of making the Flutter plugin depend on this package**: the Flutter plugin ships via a CocoaPods podspec (`packages/dart/barnard/ios/barnard.podspec`). Making that pod depend on a sibling local SwiftPM package is possible but nontrivial to wire up safely, and I have no Flutter/CocoaPods toolchain available to validate that path end-to-end. Mirroring the pure, dependency-free sources with a byte-identical CI-enforced sync check is lower-risk for this first slice. Follow-up: evaluate a true move once validated against a real Flutter build.

**`packages/dart/barnard` is completely untouched by this PR** (`git diff origin/main -- packages/dart/` is empty) — zero risk to the existing Flutter plugin.

## What's included (iOS)

1. First-class SwiftPM package `packages/swift/barnard` (product `Barnard`), Flutter-free public API.
2. Minimal native iOS example app `examples/ios-native` (SwiftUI, XcodeGen-generated project) — Start/Stop buttons drive `BarnardEngine.startAuto()`/`stopAuto()`, live event log prints `state`/`detection`/`rssi_update`/`error`/`constraint` events.
3. Unit tests for crypto/TEK/RPID/signing (`packages/swift/barnard/Tests/BarnardTests`) — 32 tests, including an explicit on-wire invariant test (`testRpiRotatesAcrossEninWindowsForSameDevice`, `testCurrentPayloadRotatesAcrossEninWindowsButRpidGeneratorSecretDoesNot`).
4. CI (`.github/workflows/native-sdk.yml`), Flutter-free:
   - `swift-package`: `xcodebuild build` + `xcodebuild test` on iOS Simulator for the SwiftPM package.
   - `swift-mirror-sync-check`: runs `scripts/check-swift-mirror.sh` (pure `diff`, no Xcode needed).
   - `ios-native-example`: `xcodegen generate` + `xcodebuild build` for the example app.

Android (`packages/android/barnard`, native Android example, Kotlin CI job) is **deferred** — flagging as a follow-up rather than shipping something half-built in this PR, per instruction. The equivalent Kotlin sources (`BarnardCrypto.kt`, `BarnardSigning.kt`, `BarnardV2Policy.kt`, `BarnardIso8601.kt`) are already Flutter-free in `packages/dart/barnard/android`, so the same mirror approach applies cleanly there; `BarnardController.kt`/`BarnardIdentityController.kt` need the same kind of Flutter-channel-to-native-API port as `BarnardEngine.swift`/`BarnardIdentity.swift`.

## On-wire invariant (barnard#56 acceptance criterion)

No device-unique persistent identifier is added to the wire by this refactor — `BarnardEngine`/`BarnardRpidGenerator` are a direct port of the existing v2 RPID rotation logic (RPI = `AES128-ECB(RPIK, ...)` keyed by TEK, itself derived from a device secret that never leaves the device or appears in any emitted event). Verified in tests:
- `BarnardCryptoTests.testRpiRotatesAcrossEninWindowsForSameDevice`
- `BarnardRpidGeneratorTests.testCurrentPayloadRotatesAcrossEninWindowsButRpidGeneratorSecretDoesNot`

## Validation

Swift toolchain: Xcode 27.0 (Swift 6.4), simulator iPhone 17 Pro (iOS 26.5).

```
$ cd packages/swift/barnard
$ xcodebuild -scheme Barnard -destination 'id=<sim udid>' test
...
Test Suite 'All tests' passed at 2026-07-08 17:27:15.312.
** TEST SUCCEEDED **
```
32/32 tests passed (`BarnardCryptoTests`, `BarnardRpidGeneratorTests`, `BarnardSigningTests`).

```
$ cd examples/ios-native
$ xcodegen generate && xcodebuild -project BarnardNativeExample.xcodeproj -scheme BarnardNativeExample -destination 'id=<sim udid>' build
...
** BUILD SUCCEEDED **
```

```
$ ./scripts/check-swift-mirror.sh
OK: packages/swift/barnard mirrors match their origin byte-for-byte.
```

`swift build` (plain SwiftPM CLI, no destination) fails with "unable to resolve module dependency: 'UIKit'" — expected, since `BarnardEngine` needs `UIApplication` lifecycle notifications (same as the original `BarnardBleController`) and SwiftPM CLI defaults to the macOS host SDK. CI uses `xcodebuild -destination` against an iOS Simulator, which is the correct way to build/test this package (documented in the CI job and package README).

## barnard#56 checklist (this PR's scope: Native iOS / SwiftPM only)

- [x] Decide whether the SwiftPM package should remain under the Flutter plugin path or move to a first-class package path such as `packages/swift/barnard` — moved to `packages/swift/barnard` (mirror, see above).
- [x] Expose a Swift-first public API that does not require Flutter runtime concepts.
- [x] Document installation through Swift Package Manager (`packages/swift/barnard/README.md`).
- [x] Provide a minimal native iOS example app that starts/stops Barnard behavior and observes events.
- [x] Add Swift tests for crypto, TEK/RPID generation — done. Config mapping/lifecycle/bounded-storage tests: not added in this slice (deferred).
- [x] Add CI that builds and tests the SwiftPM package independently of Flutter.
- [ ] Native Android / Gradle or Maven — deferred, follow-up issue.
- [ ] Schema/spec/cross-SDK-consistency/documentation-matrix/release-and-distribution sections of #56 — out of scope for this implementation slice (roadmap/spec-level work).

Closes nothing (roadmap issue #56 stays open for Android + spec/docs work). 

Refs #56
