### PR TITLE
Add native Android device-lab rendezvous harness

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -112,5 +112,7 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
-      - name: Build native Android example (Flutter-free)
-        run: ./gradlew assembleDebug
+      - name: Check device-lab host script syntax
+        run: bash -n device-lab/run_two_device_loop.sh
+      - name: Build native Android example and device-lab test APKs (Flutter-free)
+        run: ./gradlew assembleDebug assembleDebugAndroidTest

--- a/examples/android-native/app/build.gradle.kts
+++ b/examples/android-native/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
@@ -41,4 +42,9 @@ dependencies {
     implementation("network.greeting.barnard:barnard:1.0-SNAPSHOT")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
+
+    // Real-device roles for issue #72. These tests drive BarnardEngine
+    // directly; UIAutomator/Espresso would only add a brittle UI layer.
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
 }

--- a/examples/android-native/app/src/androidTest/kotlin/network/greeting/barnard/example/devicelab/BarnardDeviceLabTest.kt
+++ b/examples/android-native/app/src/androidTest/kotlin/network/greeting/barnard/example/devicelab/BarnardDeviceLabTest.kt
@@ -1,0 +1,222 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+package network.greeting.barnard.example.devicelab
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import network.greeting.barnard.BarnardDebugEvent
+import network.greeting.barnard.BarnardEngine
+import network.greeting.barnard.BarnardEvent
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Collections
+import java.util.LinkedHashSet
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+private const val LOG_TAG = "BarnardDeviceLab"
+private const val DEFAULT_EVENT_CODE = "BND"
+
+private fun marker(message: String) {
+    Log.i(LOG_TAG, message)
+    println(message)
+}
+
+private fun stringArgument(name: String, defaultValue: String? = null): String {
+    val value = InstrumentationRegistry.getArguments().getString(name) ?: defaultValue
+    require(!value.isNullOrBlank()) { "pass -e $name <value> to AndroidJUnitRunner" }
+    return value
+}
+
+private fun boundedIntArgument(name: String, defaultValue: Int, range: IntRange): Int {
+    val raw = InstrumentationRegistry.getArguments().getString(name)
+    val value = if (raw == null) {
+        defaultValue
+    } else {
+        requireNotNull(raw.toIntOrNull()) { "$name must be an integer, got $raw" }
+    }
+    require(value in range) { "$name must be in ${range.first}..${range.last}, got $value" }
+    return value
+}
+
+private fun targetContext(): Context =
+    InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
+private fun BarnardEngine.attachDebugMarkers() {
+    onDebugEvent = { event: BarnardDebugEvent ->
+        marker("BARNARD_DBG ${event.level} ${event.name} ${event.data ?: emptyMap<String, Any?>()}")
+    }
+}
+
+private fun awaitCondition(timeoutMs: Long, condition: () -> Boolean): Boolean {
+    val deadline = SystemClock.elapsedRealtime() + timeoutMs
+    while (SystemClock.elapsedRealtime() < deadline) {
+        if (condition()) return true
+        SystemClock.sleep(100)
+    }
+    return condition()
+}
+
+@RunWith(AndroidJUnit4::class)
+class BarnardAdvertiserDeviceLabTest {
+    private lateinit var engine: BarnardEngine
+
+    @After
+    fun tearDown() {
+        if (::engine.isInitialized) engine.dispose()
+    }
+
+    @Test
+    fun advertisesAndHolds() {
+        val eventCode = stringArgument("eventCode", DEFAULT_EVENT_CODE)
+        val holdSeconds = boundedIntArgument("holdSeconds", 120, 1..900)
+
+        engine = BarnardEngine(targetContext()).apply {
+            attachDebugMarkers()
+            onEvent = { event ->
+                when (event) {
+                    is BarnardEvent.State -> marker(
+                        "BARNARD_EVT state scanning=${event.state.isScanning} " +
+                            "advertising=${event.state.isAdvertising}",
+                    )
+                    is BarnardEvent.Constraint -> marker(
+                        "BARNARD_EVT constraint code=${event.constraint.code} " +
+                            "message=${event.constraint.message ?: ""}",
+                    )
+                    is BarnardEvent.Error -> marker(
+                        "BARNARD_EVT error code=${event.error.code} message=${event.error.message}",
+                    )
+                    else -> Unit
+                }
+            }
+        }
+
+        engine.joinEvent(eventCode)
+        marker("BARNARD_JOINED_EVENT=$eventCode")
+        marker("BARNARD_SELF_DISPLAY_ID=${engine.getMyDisplayId()}")
+
+        val permission = engine.getPermissionStatus()
+        marker(
+            "BARNARD_PERM canAdvertise=${permission.canAdvertise} " +
+                "canScan=${permission.canScan}",
+        )
+        assertTrue(
+            "Advertise unavailable; check Bluetooth and runtime permissions",
+            permission.canAdvertise,
+        )
+
+        engine.startAdvertise()
+        val advertising = awaitCondition(timeoutMs = 10_000) {
+            engine.getState().isAdvertising
+        }
+        marker("BARNARD_ADVERTISING=$advertising")
+        assertTrue("Advertise did not start within 10 seconds", advertising)
+
+        SystemClock.sleep(holdSeconds * 1_000L)
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class BarnardScannerDeviceLabTest {
+    private lateinit var engine: BarnardEngine
+
+    @After
+    fun tearDown() {
+        if (::engine.isInitialized) engine.dispose()
+    }
+
+    @Test
+    fun discoversAdvertiserByDisplayId() {
+        val expectedDisplayId = stringArgument("expectedDisplayId")
+        val eventCode = stringArgument("eventCode", DEFAULT_EVENT_CODE)
+        val scanTimeoutSeconds = boundedIntArgument("scanTimeoutSeconds", 60, 1..180)
+        val permissionWaitSeconds = boundedIntArgument("permissionWaitSeconds", 30, 0..60)
+
+        assertTrue(
+            "expectedDisplayId must be 8 lowercase hex characters",
+            expectedDisplayId.matches(Regex("[0-9a-f]{8}")),
+        )
+        marker("BARNARD_SCAN_EXPECTED=$expectedDisplayId")
+
+        val found = CountDownLatch(1)
+        val detections = AtomicInteger(0)
+        val rssiUpdates = AtomicInteger(0)
+        val seen = Collections.synchronizedSet(LinkedHashSet<String>())
+
+        engine = BarnardEngine(targetContext()).apply {
+            attachDebugMarkers()
+            onEvent = { event ->
+                when (event) {
+                    is BarnardEvent.Detection -> {
+                        detections.incrementAndGet()
+                        val displayId = event.detection.detectedDisplayId
+                        marker(
+                            "BARNARD_EVT detection displayId=$displayId " +
+                                "rssi=${event.detection.rssi}",
+                        )
+                        if (displayId != null) seen.add(displayId)
+                        if (displayId == expectedDisplayId) found.countDown()
+                    }
+                    is BarnardEvent.RssiUpdate -> {
+                        rssiUpdates.incrementAndGet()
+                        val displayId = event.update.detectedDisplayId
+                        marker(
+                            "BARNARD_EVT rssi_update displayId=$displayId " +
+                                "rssi=${event.update.rssi}",
+                        )
+                        if (displayId != null) seen.add(displayId)
+                        if (displayId == expectedDisplayId) found.countDown()
+                    }
+                    is BarnardEvent.State -> marker(
+                        "BARNARD_EVT state scanning=${event.state.isScanning} " +
+                            "advertising=${event.state.isAdvertising}",
+                    )
+                    is BarnardEvent.Constraint -> marker(
+                        "BARNARD_EVT constraint code=${event.constraint.code} " +
+                            "message=${event.constraint.message ?: ""}",
+                    )
+                    is BarnardEvent.Error -> marker(
+                        "BARNARD_EVT error code=${event.error.code} message=${event.error.message}",
+                    )
+                }
+            }
+        }
+
+        engine.joinEvent(eventCode)
+        marker("BARNARD_JOINED_EVENT=$eventCode")
+
+        val canScan = awaitCondition(timeoutMs = permissionWaitSeconds * 1_000L) {
+            engine.getPermissionStatus().canScan
+        }
+        val permission = engine.getPermissionStatus()
+        marker(
+            "BARNARD_PERM canScan=${permission.canScan} " +
+                "canAdvertise=${permission.canAdvertise}",
+        )
+        assertTrue(
+            "Scan unavailable; check Bluetooth, Location services, and runtime permissions",
+            canScan,
+        )
+
+        engine.startScan(allowDuplicates = true)
+        val matched = found.await(scanTimeoutSeconds.toLong(), TimeUnit.SECONDS)
+        val seenSnapshot = synchronized(seen) { seen.toList() }
+        marker(
+            "BARNARD_SCAN_FOUND=$matched detections=${detections.get()} " +
+                "rssiUpdates=${rssiUpdates.get()} seen=$seenSnapshot",
+        )
+
+        assertTrue(
+            "Did not detect expected displayId $expectedDisplayId within " +
+                "$scanTimeoutSeconds seconds (seen=$seenSnapshot)",
+            matched,
+        )
+    }
+}

--- a/examples/android-native/device-lab/README.md
+++ b/examples/android-native/device-lab/README.md
@@ -1,0 +1,57 @@
+# Native Android device-lab target
+
+This target drives `examples/android-native` on two real Android devices and
+exercises the Flutter-free `packages/android/barnard` library through
+`BarnardEngine`.
+
+It mirrors the existing Flutter device-lab rendezvous:
+
+1. The Advertiser joins `EVENT_CODE`, starts Advertise, and reports its
+   event-scoped `displayId`.
+2. The Scanner joins the same event and starts Scan.
+3. The run passes only when the Scanner receives a `Detection` or `RssiUpdate`
+   carrying that exact `displayId`, and its instrumentation test exits cleanly.
+
+## Run on the device-lab host
+
+From the Barnard checkout:
+
+```bash
+cd examples/android-native
+./device-lab/run_two_device_loop.sh
+```
+
+The defaults match the current emi lab:
+
+- Advertiser: Galaxy S7 edge, adb serial `45732079`
+- Scanner: Nexus 5X, adb serial `00b8316e85a2a456`
+- Event code: `BND`
+- Application ID: `network.greeting.barnard.example.native`
+
+Override them with `ADV_SERIAL`, `SCAN_SERIAL`, `EVENT_CODE`, `HOLD_SECONDS`,
+`SCAN_TIMEOUT_SECONDS`, or `OUTPUT_DIR`. The existing pull-based watcher can
+invoke this repository-owned script after checking out the Barnard commit; the
+watcher and its credentials remain outside this public repository.
+
+The script builds the app and instrumentation APKs, installs clean copies,
+grants the applicable Android runtime permissions, enables Location services
+for the legacy Android Scanner, runs both roles, and force-stops both app
+processes during cleanup. Filtered logs overwrite four fixed files under
+`/tmp/barnard-android-native-device-lab` by default.
+
+## What can run without two BLE devices
+
+```bash
+./gradlew :app:assembleDebug :app:assembleDebugAndroidTest
+bash -n device-lab/run_two_device_loop.sh
+shellcheck device-lab/run_two_device_loop.sh
+```
+
+Those checks prove that the native app, test APK, and host harness compile or
+parse. They do **not** prove a BLE rendezvous. Only a run ending with
+`RESULT=PASS ... transport=android-native` on the two real devices supplies
+that evidence.
+
+This harness changes no public schema or on-wire payload and adds no
+device-unique persistent identifier on-wire. The iOS twin remains out of scope
+until iOS devices join the lab.

--- a/examples/android-native/device-lab/run_two_device_loop.sh
+++ b/examples/android-native/device-lab/run_two_device_loop.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Copyright 2024-2026 The Greeting Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license.
+#
+# Native Android two-device rendezvous for the Barnard device lab (issue #72).
+# It mirrors the Flutter loop's contract while exercising BarnardEngine:
+# advertiser joins an event and reports its displayId; scanner joins the same
+# event and must receive that displayId through the Scan -> Central GATT path.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="${APP_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+ADB="${ADB:-adb}"
+GRADLEW="${GRADLEW:-$APP_DIR/gradlew}"
+
+ADV_SERIAL="${ADV_SERIAL:-45732079}"
+SCAN_SERIAL="${SCAN_SERIAL:-00b8316e85a2a456}"
+APP_ID="${APP_ID:-network.greeting.barnard.example.native}"
+TEST_APP_ID="${TEST_APP_ID:-$APP_ID.test}"
+RUNNER="${RUNNER:-androidx.test.runner.AndroidJUnitRunner}"
+EVENT_CODE="${EVENT_CODE:-BND}"
+HOLD_SECONDS="${HOLD_SECONDS:-450}"
+SCAN_TIMEOUT_SECONDS="${SCAN_TIMEOUT_SECONDS:-60}"
+PERMISSION_WAIT_SECONDS="${PERMISSION_WAIT_SECONDS:-30}"
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/barnard-android-native-device-lab}"
+
+ADV_TEST_CLASS="network.greeting.barnard.example.devicelab.BarnardAdvertiserDeviceLabTest#advertisesAndHolds"
+SCAN_TEST_CLASS="network.greeting.barnard.example.devicelab.BarnardScannerDeviceLabTest#discoversAdvertiserByDisplayId"
+APP_APK="${APP_APK:-$APP_DIR/app/build/outputs/apk/debug/app-debug.apk}"
+TEST_APK="${TEST_APK:-$APP_DIR/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk}"
+
+ADV_INSTRUMENTATION_LOG="$OUTPUT_DIR/advertiser-instrumentation.log"
+ADV_LOGCAT="$OUTPUT_DIR/advertiser-logcat.log"
+SCAN_INSTRUMENTATION_LOG="$OUTPUT_DIR/scanner-instrumentation.log"
+SCAN_LOGCAT="$OUTPUT_DIR/scanner-logcat.log"
+
+ADV_PID=""
+ADV_LOGCAT_PID=""
+SCAN_LOGCAT_PID=""
+
+fail() {
+  echo "RESULT=ERROR $*"
+  exit 2
+}
+
+validate_bounded_integer() {
+  name="$1"
+  value="$2"
+  minimum="$3"
+  maximum="$4"
+  case "$value" in
+    ''|*[!0-9]*) fail "$name must be an integer in $minimum..$maximum" ;;
+  esac
+  if [ "$value" -lt "$minimum" ] || [ "$value" -gt "$maximum" ]; then
+    fail "$name must be in $minimum..$maximum (got $value)"
+  fi
+}
+
+validate_bounded_integer HOLD_SECONDS "$HOLD_SECONDS" 1 900
+validate_bounded_integer SCAN_TIMEOUT_SECONDS "$SCAN_TIMEOUT_SECONDS" 1 180
+validate_bounded_integer PERMISSION_WAIT_SECONDS "$PERMISSION_WAIT_SECONDS" 0 60
+[ "$ADV_SERIAL" != "$SCAN_SERIAL" ] || fail "ADV_SERIAL and SCAN_SERIAL must name different devices"
+command -v "$ADB" >/dev/null 2>&1 || fail "adb is not available: $ADB"
+[ -x "$GRADLEW" ] || fail "Gradle wrapper is not executable: $GRADLEW"
+
+mkdir -p "$OUTPUT_DIR"
+: > "$ADV_INSTRUMENTATION_LOG"
+: > "$ADV_LOGCAT"
+: > "$SCAN_INSTRUMENTATION_LOG"
+: > "$SCAN_LOGCAT"
+
+# shellcheck disable=SC2329  # Invoked indirectly by the trap below.
+cleanup() {
+  set +e
+  [ -z "$ADV_PID" ] || kill "$ADV_PID" 2>/dev/null
+  [ -z "$ADV_LOGCAT_PID" ] || kill "$ADV_LOGCAT_PID" 2>/dev/null
+  [ -z "$SCAN_LOGCAT_PID" ] || kill "$SCAN_LOGCAT_PID" 2>/dev/null
+  "$ADB" -s "$ADV_SERIAL" shell am force-stop "$APP_ID" >/dev/null 2>&1
+  "$ADB" -s "$SCAN_SERIAL" shell am force-stop "$APP_ID" >/dev/null 2>&1
+}
+trap cleanup EXIT INT TERM
+
+device_ready() {
+  serial="$1"
+  "$ADB" devices | awk -v target="$serial" '$1 == target && $2 == "device" { found = 1 } END { exit(found ? 0 : 1) }'
+}
+
+echo "[android-native] build app and instrumentation APKs"
+"$GRADLEW" -p "$APP_DIR" :app:assembleDebug :app:assembleDebugAndroidTest
+[ -f "$APP_APK" ] || fail "app APK missing after build: $APP_APK"
+[ -f "$TEST_APK" ] || fail "test APK missing after build: $TEST_APK"
+
+echo "[android-native] ensure both devices are connected"
+"$ADB" reconnect >/dev/null 2>&1 || true
+ready=false
+for _ in $(seq 1 30); do
+  if device_ready "$ADV_SERIAL" && device_ready "$SCAN_SERIAL"; then
+    ready=true
+    break
+  fi
+  "$ADB" reconnect >/dev/null 2>&1 || true
+  sleep 2
+done
+[ "$ready" = true ] || fail "both Android devices are not ready over adb"
+
+install_role() {
+  serial="$1"
+  role="$2"
+  echo "[android-native] install clean APKs on $serial ($role)"
+  "$ADB" -s "$serial" uninstall "$TEST_APP_ID" >/dev/null 2>&1 || true
+  "$ADB" -s "$serial" uninstall "$APP_ID" >/dev/null 2>&1 || true
+  "$ADB" -s "$serial" install -g "$APP_APK" >/dev/null
+  "$ADB" -s "$serial" install -g -t "$TEST_APK" >/dev/null
+  "$ADB" -s "$serial" shell svc bluetooth enable >/dev/null 2>&1 || true
+
+  # Android 8 needs Location; Android 12+ needs the Bluetooth runtime group.
+  # `install -g` grants applicable permissions, while these explicit grants
+  # make the intent clear and harmlessly no-op on other API levels.
+  for permission in \
+    android.permission.ACCESS_FINE_LOCATION \
+    android.permission.BLUETOOTH_SCAN \
+    android.permission.BLUETOOTH_ADVERTISE \
+    android.permission.BLUETOOTH_CONNECT; do
+    "$ADB" -s "$serial" shell pm grant "$APP_ID" "$permission" >/dev/null 2>&1 || true
+  done
+}
+
+install_role "$ADV_SERIAL" advertiser
+install_role "$SCAN_SERIAL" scanner
+"$ADB" -s "$SCAN_SERIAL" shell settings put secure location_mode 3 >/dev/null 2>&1 || true
+
+"$ADB" -s "$ADV_SERIAL" logcat -c
+"$ADB" -s "$SCAN_SERIAL" logcat -c
+"$ADB" -s "$ADV_SERIAL" logcat -v time BarnardDeviceLab:I '*:S' > "$ADV_LOGCAT" 2>&1 &
+ADV_LOGCAT_PID=$!
+"$ADB" -s "$SCAN_SERIAL" logcat -v time BarnardDeviceLab:I '*:S' > "$SCAN_LOGCAT" 2>&1 &
+SCAN_LOGCAT_PID=$!
+
+echo "[android-native] start Advertise role on $ADV_SERIAL"
+"$ADB" -s "$ADV_SERIAL" shell am instrument -w -r \
+  -e class "$ADV_TEST_CLASS" \
+  -e eventCode "$EVENT_CODE" \
+  -e holdSeconds "$HOLD_SECONDS" \
+  "$TEST_APP_ID/$RUNNER" > "$ADV_INSTRUMENTATION_LOG" 2>&1 &
+ADV_PID=$!
+
+display_id=""
+advertising=false
+for _ in $(seq 1 90); do
+  display_id="$(sed -n 's/.*BARNARD_SELF_DISPLAY_ID=\([0-9a-f]\{8\}\).*/\1/p' "$ADV_LOGCAT" | head -1 || true)"
+  if grep -q 'BARNARD_ADVERTISING=true' "$ADV_LOGCAT"; then
+    advertising=true
+  fi
+  if [ -n "$display_id" ] && [ "$advertising" = true ]; then
+    break
+  fi
+  if ! kill -0 "$ADV_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if [ -z "$display_id" ] || [ "$advertising" != true ]; then
+  echo "[android-native] Advertise role did not become ready"
+  tail -n 40 "$ADV_INSTRUMENTATION_LOG" || true
+  tail -n 40 "$ADV_LOGCAT" || true
+  echo "RESULT=FAIL advertiser_ready=no"
+  exit 1
+fi
+echo "[android-native] advertiser displayId=$display_id and advertising=true"
+
+echo "[android-native] run Scan role on $SCAN_SERIAL expecting $display_id"
+set +e
+"$ADB" -s "$SCAN_SERIAL" shell am instrument -w -r \
+  -e class "$SCAN_TEST_CLASS" \
+  -e expectedDisplayId "$display_id" \
+  -e eventCode "$EVENT_CODE" \
+  -e scanTimeoutSeconds "$SCAN_TIMEOUT_SECONDS" \
+  -e permissionWaitSeconds "$PERMISSION_WAIT_SECONDS" \
+  "$TEST_APP_ID/$RUNNER" > "$SCAN_INSTRUMENTATION_LOG" 2>&1
+scan_rc=$?
+set -e
+
+echo "[android-native] --- scanner markers ---"
+grep -E 'BARNARD_SCAN_|BARNARD_PERM|BARNARD_EVT (detection|rssi_update|constraint|error)' "$SCAN_LOGCAT" | tail -n 40 || true
+echo "[android-native] scanner adb exit_code=$scan_rc"
+
+scan_found=false
+if grep -q 'BARNARD_SCAN_FOUND=true' "$SCAN_LOGCAT"; then
+  scan_found=true
+fi
+runner_ok=false
+if [ "$scan_rc" -eq 0 ] && grep -q 'OK (1 test)' "$SCAN_INSTRUMENTATION_LOG"; then
+  runner_ok=true
+fi
+
+if [ "$scan_found" = true ] && [ "$runner_ok" = true ]; then
+  echo "RESULT=PASS advertiser=$display_id scanner_found=yes transport=android-native"
+  exit 0
+fi
+
+tail -n 60 "$SCAN_INSTRUMENTATION_LOG" || true
+tail -n 60 "$SCAN_LOGCAT" || true
+echo "RESULT=FAIL advertiser=$display_id scanner_found=$scan_found runner_ok=$runner_ok"
+exit 1

--- a/specs/001-barnard-core-sdk/spec.md
+++ b/specs/001-barnard-core-sdk/spec.md
@@ -101,6 +101,33 @@ As a maintainer, I want a core SDK structure that can be distributed as iOS (SPM
 
 ---
 
+### Native Android device-lab conformance (Issue #72)
+
+The native Android surface MUST have a real-device two-role harness that drives
+`examples/android-native` and `packages/android/barnard` directly, without a
+Flutter or React Native runtime.
+
+- The Advertiser role joins a configured event, starts Advertise through
+  `BarnardEngine`, confirms the advertising state, and reports its
+  event-scoped `displayId` to the host harness.
+- The Scanner role joins the same event, starts Scan through `BarnardEngine`,
+  and waits for a `Detection` or `RssiUpdate` event whose `detectedDisplayId`
+  matches the Advertiser's reported value.
+- PASS requires both Android instrumentation roles to start successfully and
+  the Scanner to find that exact `displayId` within a bounded timeout. Building
+  the APKs or compiling the instrumentation tests is not a substitute for this
+  real two-device result.
+- The host harness MUST use bounded waits and bounded, overwritten diagnostic
+  logs, grant the runtime permissions required by each connected Android
+  version, and clean up both app processes after the run.
+- This harness does not change any public schema or on-wire payload. The
+  transmitted values remain event-scoped, and no device-unique persistent
+  identifier is added on-wire.
+
+The iOS native twin remains out of scope until iOS devices join the lab.
+
+---
+
 ### Edge Cases
 
 - Repeated `startScan()` calls (idempotent vs error vs restart)
@@ -147,6 +174,7 @@ As a maintainer, I want a core SDK structure that can be distributed as iOS (SPM
 - **FR-IOS-004**: iOS wrappers MUST defer `CBCentralManager` / `CBPeripheralManager` construction until an explicit host-app action to avoid Bluetooth permission prompts during app launch
 - **FR-ANDROID-001**: Android packages MUST ship manifest declarations for BLE Scan, Advertise, Connect, legacy Bluetooth, legacy location, and BLE feature support so host apps receive them through manifest merge
 - **FR-ANDROID-002**: Android 12+ `BLUETOOTH_SCAN` MUST use `neverForLocation` by default so BLE Scan does not require location permission on API 31+
+- **FR-ANDROID-003**: The native Android example MUST provide a bounded two-device lab harness that proves Advertise-to-Scan rendezvous through `BarnardEngine` on real hardware before the first external consumer adopts the package
 
 ### Prototype API Sketch (minimal config)
 


### PR DESCRIPTION
## Summary

- add AndroidJUnitRunner Advertiser and Scanner roles under `examples/android-native`
- drive `BarnardEngine` directly with the same event-scoped rendezvous contract as the existing Flutter device-lab loop
- add a repository-owned two-device host script using the current emi Android device defaults
- compile the native device-lab test APK in Native SDK CI
- document the real-device PASS contract and the unchanged schema/on-wire privacy boundary

## Verified in this sandbox

- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' examples/android-native/gradlew -p examples/android-native :app:assembleDebug :app:assembleDebugAndroidTest`
  - app APK and instrumentation APK both built successfully
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew test` from `packages/android/barnard`
  - all 60 debug and 60 release JVM/Robolectric test cases passed
- `./scripts/check-android-mirror.sh`
  - the Android mirror guard passed
- `bash -n examples/android-native/device-lab/run_two_device_loop.sh`
- `shellcheck examples/android-native/device-lab/run_two_device_loop.sh`
- host-side validation rejects using the same adb serial for both roles

## Not verified here: real device-lab hardware

No Android device or access to the emi device-lab host was available in this sandbox (`adb devices -l` reported no attached devices). I therefore did **not** run or claim a real two-device BLE PASS.

Before this work is considered actually validated, the emi Barnard target must invoke `examples/android-native/device-lab/run_two_device_loop.sh` for this PR head on the Galaxy S7 edge and Nexus 5X (or equivalent two real Android devices), and the run must finish with:

```text
RESULT=PASS advertiser=<8-hex-displayId> scanner_found=yes transport=android-native
```

That run is still required to validate real GATT timing, runtime-permission behavior, Bluetooth adapter races, and the complete Advertise-to-Scan rendezvous through `BarnardEngine`. The external pull-based watcher configuration/credentials remain outside this public repository and were not changed from this sandbox.

## Compatibility and privacy

- no public API or JSON Schema changes
- no on-wire payload changes
- no device-unique persistent identifier added on-wire; the compared `displayId` remains event-scoped
- iOS device-lab coverage remains out of scope until iOS devices join the lab

Refs #72
