### PR TITLE
perf: memoize reporterRpid per-ENIN in BarnardRpidGenerator / computePayload

### DIFF
--- a/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/dart/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -117,7 +117,16 @@ internal class BarnardController(
     // MARK: - Event Mode
 
     private var eventCode: String? = null
+    @Volatile
     private var currentTek: ByteArray = ByteArray(16)
+
+    private data class CachedReporterPayload(
+        val enin: UInt,
+        val tekHash: Int,
+        val payload: ByteArray,
+    )
+
+    private var cachedReporterPayload: CachedReporterPayload? = null
 
     // MARK: - Discovery State
 
@@ -724,14 +733,23 @@ internal class BarnardController(
      * Build the 17-byte RPID wire form at [nowMs], atomically deriving ENIN
      * and RPI from the same timestamp.
      */
+    @Synchronized
     private fun computePayload(nowMs: Long): ByteArray {
         val enin = currentEnin(nowMs)
-        val rpik = BarnardCrypto.deriveRpik(currentTek)
+        val tek = currentTek
+        val tekHash = tek.contentHashCode()
+        val cached = cachedReporterPayload
+        if (cached != null && cached.enin == enin && cached.tekHash == tekHash) {
+            return cached.payload
+        }
+
+        val rpik = BarnardCrypto.deriveRpik(tek)
         val rpi = BarnardCrypto.generateRpi(rpik, enin)
 
         val payload = ByteArray(17)
         payload[0] = (formatVersion and 0xFF).toByte()
         System.arraycopy(rpi, 0, payload, 1, 16)
+        cachedReporterPayload = CachedReporterPayload(enin, tekHash, payload)
         return payload
     }
 

--- a/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardControllerPayloadCacheTest.kt
+++ b/packages/dart/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardControllerPayloadCacheTest.kt
@@ -1,0 +1,116 @@
+package network.greeting.barnard
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.flutter.plugin.common.BinaryMessenger
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.nio.ByteBuffer
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class BarnardControllerPayloadCacheTest {
+    private lateinit var context: Context
+    private lateinit var computePayload: Method
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        computePayload = BarnardController::class.java
+            .getDeclaredMethod("computePayload", Long::class.javaPrimitiveType)
+            .apply { isAccessible = true }
+    }
+
+    @Test
+    fun computePayload_reusesExactByteArrayWithinSameEninAndTek() {
+        val controller = BarnardController(context, RecordingBinaryMessenger())
+
+        val first = controller.computePayloadAt(1_000L)
+        val second = controller.computePayloadAt(2_000L)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun computePayload_recomputesAcrossEninBoundary() {
+        val controller = BarnardController(context, RecordingBinaryMessenger())
+
+        val beforeBoundary = controller.computePayloadAt(299_999L)
+        val afterBoundary = controller.computePayloadAt(300_000L)
+
+        assertNotSame(beforeBoundary, afterBoundary)
+        assertFalse(beforeBoundary.contentEquals(afterBoundary))
+    }
+
+    @Test
+    fun computePayload_recomputesWhenTekChangesWithinSameEnin() {
+        val controller = BarnardController(context, RecordingBinaryMessenger())
+        val anonymous = controller.computePayloadAt(1_000L)
+
+        controller.joinEventForTest("payload-cache-test")
+        val joined = controller.computePayloadAt(1_000L)
+        controller.leaveEventForTest()
+        val left = controller.computePayloadAt(1_000L)
+
+        assertNotSame(anonymous, joined)
+        assertFalse(anonymous.contentEquals(joined))
+        assertNotSame(joined, left)
+        assertFalse(joined.contentEquals(left))
+        assertNotSame(anonymous, left)
+        assertTrue(anonymous.contentEquals(left))
+    }
+
+    @Test
+    fun computePayload_serializesCacheAccessAcrossThreads() {
+        assertTrue(Modifier.isSynchronized(computePayload.modifiers))
+    }
+
+    @Test
+    fun currentTek_publishesChangesAcrossThreads() {
+        val field = BarnardController::class.java.getDeclaredField("currentTek")
+
+        assertTrue(Modifier.isVolatile(field.modifiers))
+    }
+
+    private fun BarnardController.computePayloadAt(nowMs: Long): ByteArray {
+        return computePayload.invoke(this, nowMs) as ByteArray
+    }
+
+    private fun BarnardController.joinEventForTest(code: String) {
+        BarnardController::class.java.getDeclaredMethod("joinEvent", String::class.java)
+            .apply { isAccessible = true }
+            .invoke(this, code)
+    }
+
+    private fun BarnardController.leaveEventForTest() {
+        BarnardController::class.java.getDeclaredMethod("leaveEvent")
+            .apply { isAccessible = true }
+            .invoke(this)
+    }
+
+    private class RecordingBinaryMessenger : BinaryMessenger {
+        override fun send(channel: String, message: ByteBuffer?) = Unit
+
+        override fun send(
+            channel: String,
+            message: ByteBuffer?,
+            callback: BinaryMessenger.BinaryReply?
+        ) = Unit
+
+        override fun setMessageHandler(
+            channel: String,
+            handler: BinaryMessenger.BinaryMessageHandler?
+        ) = Unit
+    }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardRpidGenerator.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardRpidGenerator.swift
@@ -30,6 +30,8 @@ final class BarnardRpidGenerator {
   /// Current TEK (Temporary Exposure Key)
   private var currentTek: Data
 
+  private var cachedReporterPayload: (enin: UInt32, tekHash: Int, payload: Data)?
+
   // MARK: - Initialization
 
   init() {
@@ -116,11 +118,21 @@ final class BarnardRpidGenerator {
       eninSeconds: eninSeconds,
       beaconChain: beaconChain
     )
-    let rpik = BarnardCrypto.deriveRpik(from: currentTek)
+    let tek = currentTek
+    let tekHash = tek.hashValue
+
+    if let cached = cachedReporterPayload,
+       cached.enin == enin,
+       cached.tekHash == tekHash {
+      return cached.payload
+    }
+
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
     let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: enin)
 
     var payload = Data([formatVersion])
     payload.append(rpi)
+    cachedReporterPayload = (enin: enin, tekHash: tekHash, payload: payload)
     return payload
   }
 

--- a/packages/dart/barnard/test/rpid_payload_cache_source_test.dart
+++ b/packages/dart/barnard/test/rpid_payload_cache_source_test.dart
@@ -1,0 +1,97 @@
+import "dart:io";
+
+import "package:test/test.dart";
+
+void main() {
+  group("iOS reporter RPID payload cache source invariants", () {
+    for (final _SwiftSource source in <_SwiftSource>[
+      const _SwiftSource(
+        name: "Flutter iOS",
+        path: "ios/barnard/Sources/barnard/BarnardRpidGenerator.swift",
+        currentPayloadEndMarker: "// MARK: - DeviceSecret Management",
+      ),
+      const _SwiftSource(
+        name: "React Native iOS",
+        path: "../../react-native/barnard/ios/BarnardRpidGenerator.swift",
+        currentPayloadEndMarker: "private func getOrCreateDeviceSecret()",
+      ),
+    ]) {
+      test("${source.name} returns the cached Data on an ENIN and TEK hit", () {
+        final String text = File(source.path).readAsStringSync();
+        final String body = _sliceBetween(
+          text,
+          "func currentPayload(",
+          source.currentPayloadEndMarker,
+        );
+
+        expect(
+          text,
+          contains(
+            "private var cachedReporterPayload: (enin: UInt32, tekHash: Int, payload: Data)?",
+          ),
+        );
+        expect(body, contains("let tek = currentTek"));
+        expect(body, contains("let tekHash = tek.hashValue"));
+
+        final int hitIndex = body.indexOf(
+          "if let cached = cachedReporterPayload",
+        );
+        final int deriveIndex = body.indexOf(
+          "BarnardCrypto.deriveRpik(from: tek)",
+        );
+        expect(hitIndex, isNonNegative);
+        expect(deriveIndex, greaterThan(hitIndex));
+
+        final String hitPath = body.substring(hitIndex, deriveIndex);
+        expect(hitPath, contains("cached.enin == enin"));
+        expect(hitPath, contains("cached.tekHash == tekHash"));
+        expect(hitPath, contains("return cached.payload"));
+      });
+
+      test("${source.name} stores a newly computed Data after an ENIN miss", () {
+        final String text = File(source.path).readAsStringSync();
+        final String body = _sliceBetween(
+          text,
+          "func currentPayload(",
+          source.currentPayloadEndMarker,
+        );
+
+        final int eninIndex = body.indexOf(
+          "let enin = BarnardCrypto.calculateEnin(",
+        );
+        final int deriveIndex = body.indexOf(
+          "BarnardCrypto.deriveRpik(from: tek)",
+        );
+        final int storeIndex = body.indexOf(
+          "cachedReporterPayload = (enin: enin, tekHash: tekHash, payload: payload)",
+        );
+        final int returnIndex = body.indexOf("return payload");
+
+        expect(eninIndex, isNonNegative);
+        expect(deriveIndex, greaterThan(eninIndex));
+        expect(storeIndex, greaterThan(deriveIndex));
+        expect(returnIndex, greaterThan(storeIndex));
+      });
+    }
+  });
+}
+
+String _sliceBetween(String text, String start, String end) {
+  final int startIndex = text.indexOf(start);
+  expect(startIndex, isNonNegative, reason: "missing start marker: $start");
+  final int endIndex = text.indexOf(end, startIndex + start.length);
+  expect(endIndex, isNonNegative, reason: "missing end marker: $end");
+  return text.substring(startIndex, endIndex);
+}
+
+class _SwiftSource {
+  const _SwiftSource({
+    required this.name,
+    required this.path,
+    required this.currentPayloadEndMarker,
+  });
+
+  final String name;
+  final String path;
+  final String currentPayloadEndMarker;
+}

--- a/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
+++ b/packages/react-native/barnard/android/src/main/kotlin/network/greeting/barnard/BarnardController.kt
@@ -108,7 +108,16 @@ internal class BarnardController(
     // MARK: - Event Mode
 
     private var eventCode: String? = null
+    @Volatile
     private var currentTek: ByteArray = ByteArray(16)
+
+    private data class CachedReporterPayload(
+        val enin: UInt,
+        val tekHash: Int,
+        val payload: ByteArray,
+    )
+
+    private var cachedReporterPayload: CachedReporterPayload? = null
 
     // MARK: - Discovery State
 
@@ -589,14 +598,23 @@ internal class BarnardController(
 
     // MARK: - RPID Payload Generation
 
+    @Synchronized
     private fun computePayload(nowMs: Long): ByteArray {
         val enin = currentEnin(nowMs)
-        val rpik = BarnardCrypto.deriveRpik(currentTek)
+        val tek = currentTek
+        val tekHash = tek.contentHashCode()
+        val cached = cachedReporterPayload
+        if (cached != null && cached.enin == enin && cached.tekHash == tekHash) {
+            return cached.payload
+        }
+
+        val rpik = BarnardCrypto.deriveRpik(tek)
         val rpi = BarnardCrypto.generateRpi(rpik, enin)
 
         val payload = ByteArray(17)
         payload[0] = (formatVersion and 0xFF).toByte()
         System.arraycopy(rpi, 0, payload, 1, 16)
+        cachedReporterPayload = CachedReporterPayload(enin, tekHash, payload)
         return payload
     }
 

--- a/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardControllerPayloadCacheTest.kt
+++ b/packages/react-native/barnard/android/src/test/kotlin/network/greeting/barnard/BarnardControllerPayloadCacheTest.kt
@@ -1,0 +1,101 @@
+package network.greeting.barnard
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class BarnardControllerPayloadCacheTest {
+    private lateinit var context: Context
+    private lateinit var computePayload: Method
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        computePayload = BarnardController::class.java
+            .getDeclaredMethod("computePayload", Long::class.javaPrimitiveType)
+            .apply { isAccessible = true }
+    }
+
+    @Test
+    fun computePayload_reusesExactByteArrayWithinSameEninAndTek() {
+        val controller = BarnardController(context)
+
+        val first = controller.computePayloadAt(1_000L)
+        val second = controller.computePayloadAt(2_000L)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun computePayload_recomputesAcrossEninBoundary() {
+        val controller = BarnardController(context)
+
+        val beforeBoundary = controller.computePayloadAt(299_999L)
+        val afterBoundary = controller.computePayloadAt(300_000L)
+
+        assertNotSame(beforeBoundary, afterBoundary)
+        assertFalse(beforeBoundary.contentEquals(afterBoundary))
+    }
+
+    @Test
+    fun computePayload_recomputesWhenTekChangesWithinSameEnin() {
+        val controller = BarnardController(context)
+        val anonymous = controller.computePayloadAt(1_000L)
+
+        context.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+            .edit()
+            .putString("eventCode", "payload-cache-test")
+            .commit()
+        controller.initializeTekForTest()
+        val joined = controller.computePayloadAt(1_000L)
+        context.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+            .edit()
+            .remove("eventCode")
+            .commit()
+        controller.initializeTekForTest()
+        val left = controller.computePayloadAt(1_000L)
+
+        assertNotSame(anonymous, joined)
+        assertFalse(anonymous.contentEquals(joined))
+        assertNotSame(joined, left)
+        assertFalse(joined.contentEquals(left))
+        assertNotSame(anonymous, left)
+        assertTrue(anonymous.contentEquals(left))
+    }
+
+    @Test
+    fun computePayload_serializesCacheAccessAcrossThreads() {
+        assertTrue(Modifier.isSynchronized(computePayload.modifiers))
+    }
+
+    @Test
+    fun currentTek_publishesChangesAcrossThreads() {
+        val field = BarnardController::class.java.getDeclaredField("currentTek")
+
+        assertTrue(Modifier.isVolatile(field.modifiers))
+    }
+
+    private fun BarnardController.computePayloadAt(nowMs: Long): ByteArray {
+        return computePayload.invoke(this, nowMs) as ByteArray
+    }
+
+    private fun BarnardController.initializeTekForTest() {
+        BarnardController::class.java.getDeclaredMethod("initializeTek")
+            .apply { isAccessible = true }
+            .invoke(this)
+    }
+}

--- a/packages/react-native/barnard/ios/BarnardRpidGenerator.swift
+++ b/packages/react-native/barnard/ios/BarnardRpidGenerator.swift
@@ -13,6 +13,7 @@ final class BarnardRpidGenerator {
   }
 
   private var currentTek: Data
+  private var cachedReporterPayload: (enin: UInt32, tekHash: Int, payload: Data)?
 
   init() {
     let defaults = UserDefaults.standard
@@ -70,11 +71,21 @@ final class BarnardRpidGenerator {
       eninSeconds: eninSeconds,
       beaconChain: beaconChain
     )
-    let rpik = BarnardCrypto.deriveRpik(from: currentTek)
+    let tek = currentTek
+    let tekHash = tek.hashValue
+
+    if let cached = cachedReporterPayload,
+       cached.enin == enin,
+       cached.tekHash == tekHash {
+      return cached.payload
+    }
+
+    let rpik = BarnardCrypto.deriveRpik(from: tek)
     let rpi = BarnardCrypto.generateRpi(rpik: rpik, enin: enin)
 
     var payload = Data([formatVersion])
     payload.append(rpi)
+    cachedReporterPayload = (enin: enin, tekHash: tekHash, payload: payload)
     return payload
   }
 


### PR DESCRIPTION
## Summary

Implements #46: memoizes the reporter RPID payload per `(enin, tekHash)` on both iOS and Android, across the Dart-plugin and React Native package copies (4 files). No wire-format or public API change.

- iOS: single-slot `(enin, tekHash, Data)` cache in `BarnardRpidGenerator`.
- Android: same shape, guarded by `@Synchronized` on the whole `computePayload` (read-check-compute-write is one atomic critical section, not just individual `@Volatile` fields), `currentTek` marked `@Volatile`, and `ByteArray` compared via `contentHashCode()` (avoids the reference-identity-hash pitfall plain `.hashCode()` would have on a `ByteArray`).
- Cache invalidates automatically on ENIN boundary crossing or TEK change (join/leaveEvent), verified by unit tests on both platforms.

## Verified in this sandbox

- `cd packages/dart/barnard && flutter test` — `+111` all passed
- `cd packages/dart/barnard/android && ./gradlew testDebugUnitTest` — BUILD SUCCESSFUL
- `cd examples/react-native/barnard_demo/android && ./gradlew :barnard:testDebugUnitTest` — BUILD SUCCESSFUL
- `flutter analyze` — no issues
- Both Swift copies type-checked (`swiftc -typecheck`)
- Flutter iOS app: `xcodebuild` — BUILD SUCCEEDED

## Not verified here: real 3-device cross-platform regression

The issue's own acceptance criteria include: "Cross-platform test: three-device mutual detection unchanged (no regression, same RPID observed by peers)." This needs real BLE hardware spanning **both iOS and Android** simultaneously. Not available in this sandbox (0 Android devices, iOS devices locked/unprovisioned), and — checked against the current device-lab (emi) setup — not currently possible there either, since emi's real-device lab has two Android devices only, no iOS device yet.

This PR is opened as a draft to make the (unit-verified) work visible and reviewable, not as a merge-ready claim. Recommend holding merge until genuine mixed iOS+Android real-device verification is possible, given this touches the RPID generation hot path.

Refs #46