### PR TITLE
feat(swift): C ABI surface for BarnardCore + aarch64-android cross-compile CI

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -33,9 +33,10 @@ jobs:
       - name: BarnardCore stdlib-only build and purity check
         run: |
           swift build --target BarnardCore
+          swift build --target BarnardCoreC
           if grep -RnwE \
-            'Foundation|CryptoKit|CoreBluetooth|Security|UIKit|CommonCrypto|SecRandom|UserDefaults|Data|Date|CCCrypt' \
-            Sources/BarnardCore; then
+            'Foundation|FoundationEssentials|CryptoKit|CoreBluetooth|Security|UIKit|CommonCrypto|SecRandom|UserDefaults|Data|Date|CCCrypt' \
+            Sources/BarnardCore Sources/BarnardCoreC; then
             echo "BarnardCore contains a forbidden platform dependency"
             exit 1
           fi

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -1,0 +1,137 @@
+name: Swift Android Cross-Compile
+
+# Locks in what the issue #78 spike proved manually: BarnardCore (and its C ABI
+# surface, BarnardCoreC) cross-compiles for aarch64-android with the official
+# Swift Android SDK, and the exported C symbols stay present in the .so.
+#
+# Toolchain pin tradeoff (documented decision, issue #78):
+# - Swift 6.4 has no stable release with Android SDK support yet, so this pins
+#   one exact 6.4.x development snapshot (host + Android SDK are a matched
+#   pair). Bump both lines of the pin together.
+# - The host toolchain (~1.3 GB) and Android SDK bundle (~340 MB) downloads are
+#   cached via actions/cache (~1.6 GB of the repo's 10 GB budget); a cold run
+#   downloads them once. This keeps the job on every PR touching
+#   packages/swift instead of a scheduled job, at roughly 2-4 min warm.
+# - Only aarch64 is cross-compiled here (the spike proved armv7/x86_64 build
+#   identically); the goal is a drift guard, not a release pipeline.
+
+on:
+  pull_request:
+    paths:
+      - "packages/swift/**"
+      - ".github/workflows/swift-android.yml"
+  push:
+    branches: [ main ]
+    paths:
+      - "packages/swift/**"
+      - ".github/workflows/swift-android.yml"
+  workflow_dispatch:
+
+env:
+  SWIFT_SNAPSHOT: swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-17-a
+  SWIFT_HOST_URL: https://download.swift.org/swift-6.4.x-branch/ubuntu2404/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-17-a/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-17-a-ubuntu24.04.tar.gz
+  SWIFT_HOST_SHA256: 58f4717c54c4fd87084647b947bf509c51c317313b7f50cbd30ed6f43814c47a
+  SWIFT_ANDROID_SDK_URL: https://download.swift.org/swift-6.4.x-branch/android-sdk/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-17-a/swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-17-a_android.artifactbundle.tar.gz
+  SWIFT_ANDROID_SDK_SHA256: 54a9c6b9491ea531cd3f5696f1071c2ca055cad89b89a2f408633b73f373c601
+  ANDROID_TRIPLE: aarch64-unknown-linux-android28
+
+jobs:
+  android-cross-compile:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Swift toolchain downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/swift-downloads
+          key: swift-android-${{ env.SWIFT_SNAPSHOT }}-v1
+
+      - name: Download pinned toolchain artifacts (cache miss only)
+        run: |
+          mkdir -p ~/swift-downloads
+          cd ~/swift-downloads
+          if [ ! -f host.tar.gz ]; then
+            curl -fsSL -o host.tar.gz "$SWIFT_HOST_URL"
+          fi
+          if [ ! -f android-sdk.tar.gz ]; then
+            curl -fsSL -o android-sdk.tar.gz "$SWIFT_ANDROID_SDK_URL"
+          fi
+          echo "$SWIFT_HOST_SHA256  host.tar.gz" | sha256sum -c -
+          echo "$SWIFT_ANDROID_SDK_SHA256  android-sdk.tar.gz" | sha256sum -c -
+
+      - name: Install host toolchain
+        run: |
+          mkdir -p "$RUNNER_TEMP/swift-host"
+          tar -xzf ~/swift-downloads/host.tar.gz -C "$RUNNER_TEMP/swift-host" --strip-components=1
+          echo "$RUNNER_TEMP/swift-host/usr/bin" >> "$GITHUB_PATH"
+
+      - name: Install Android Swift SDK
+        run: |
+          swift --version
+          swift sdk install ~/swift-downloads/android-sdk.tar.gz
+          swift sdk list
+
+      - name: Link Android SDK sysroot to the runner's NDK
+        run: |
+          echo "NDK: $ANDROID_NDK_LATEST_HOME"
+          setup_script=$(find "$HOME/.swiftpm/swift-sdks" "$HOME/.config/swiftpm/swift-sdks" \
+            -name setup-android-sdk.sh 2>/dev/null | head -1)
+          if [ -z "$setup_script" ]; then
+            echo "setup-android-sdk.sh not found in installed SDK bundle" >&2
+            find "$HOME/.swiftpm" "$HOME/.config/swiftpm" -maxdepth 4 -type d 2>/dev/null >&2
+            exit 1
+          fi
+          ANDROID_NDK_HOME="$ANDROID_NDK_LATEST_HOME" SWIFT_ANDROID_NDK_LINK=1 \
+            bash "$setup_script"
+
+      - name: Cross-compile BarnardCoreC for aarch64-android
+        run: |
+          swift build --package-path packages/swift/barnard \
+            --product BarnardCoreC \
+            --swift-sdk "$ANDROID_TRIPLE" \
+            -c release
+      - name: Verify exported C ABI symbols in the Android .so
+        run: |
+          so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so -path "*release*" | head -1)
+          echo "shared library: $so"
+          file "$so"
+          nm_tool=$(find "$ANDROID_NDK_LATEST_HOME" -name llvm-nm | head -1)
+          "$nm_tool" -D --defined-only "$so" | tee /tmp/exported-symbols.txt
+          for symbol in \
+            barnard_core_derive_tek_for_event \
+            barnard_core_derive_tek_for_anonymous \
+            barnard_core_derive_rpik \
+            barnard_core_generate_rpi \
+            barnard_core_calculate_enin \
+            barnard_core_stable_read_enin \
+            barnard_core_compute_event_code_hash \
+            barnard_core_display_id4 \
+            barnard_core_sha256 \
+            barnard_core_derive_signing_keypair \
+            barnard_core_sign_recoverable \
+            barnard_core_should_emit_rssi_update \
+            barnard_core_should_serve_gatt_display_id; do
+            if ! grep -qw "$symbol" /tmp/exported-symbols.txt; then
+              echo "MISSING exported symbol: $symbol" >&2
+              exit 1
+            fi
+          done
+          echo "OK: all 13 C ABI symbols exported for $ANDROID_TRIPLE"
+
+      - name: C host consumption proof (Linux native, same C ABI)
+        # The Android .so cannot execute on the runner; this builds the same
+        # BarnardCoreC product for the Linux host with the same toolchain and
+        # replays the issue #80 golden vector through dlopen + the C ABI.
+        run: |
+          swift build --package-path packages/swift/barnard \
+            --product BarnardCoreC \
+            -c release \
+            --scratch-path packages/swift/barnard/.build-host
+          lib=$(find packages/swift/barnard/.build-host -name libBarnardCoreC.so -path "*release*" | head -1)
+          echo "host library: $lib"
+          cc -o /tmp/barnard_core_c_host_proof \
+            packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
+          LD_LIBRARY_PATH="$RUNNER_TEMP/swift-host/usr/lib/swift/linux" \
+            /tmp/barnard_core_c_host_proof "$lib"

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -94,7 +94,12 @@ jobs:
             -c release
       - name: Verify exported C ABI symbols in the Android .so
         run: |
-          so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so -path "*release*" | head -1)
+          so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)
+          if [ -z "$so" ]; then
+            echo "libBarnardCoreC.so not found under .build; layout was:" >&2
+            find packages/swift/barnard/.build -name "*.so" >&2
+            exit 1
+          fi
           echo "shared library: $so"
           file "$so"
           nm_tool=$(find "$ANDROID_NDK_LATEST_HOME" -name llvm-nm | head -1)
@@ -129,7 +134,12 @@ jobs:
             --product BarnardCoreC \
             -c release \
             --scratch-path packages/swift/barnard/.build-host
-          lib=$(find packages/swift/barnard/.build-host -name libBarnardCoreC.so -path "*release*" | head -1)
+          lib=$(find packages/swift/barnard/.build-host -name libBarnardCoreC.so | head -1)
+          if [ -z "$lib" ]; then
+            echo "host libBarnardCoreC.so not found under .build-host; layout was:" >&2
+            find packages/swift/barnard/.build-host -name "*.so" >&2
+            exit 1
+          fi
           echo "host library: $lib"
           cc -o /tmp/barnard_core_c_host_proof \
             packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c

--- a/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
+++ b/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
@@ -1,0 +1,196 @@
+/* Copyright 2024-2026 The Greeting Inc. All rights reserved.
+ * Use of this source code is governed by a BSD-style license.
+ *
+ * C-host consumption proof for the BarnardCoreC shared library (issue #78).
+ *
+ * Loads libBarnardCoreC (.so on Linux/Android, .dylib on macOS) with dlopen,
+ * resolves the exported C ABI symbols, and replays the issue #80 golden
+ * behavior vector (BarnardBehaviorVectorTests). Exits 0 only if every value
+ * matches byte-for-byte.
+ *
+ * Usage: barnard_core_c_host_proof <path-to-libBarnardCoreC>
+ */
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef int32_t (*derive_tek_for_event_fn)(
+    const uint8_t *, int32_t, const uint8_t *, int32_t, uint8_t *);
+typedef int32_t (*derive_tek_for_anonymous_fn)(const uint8_t *, int32_t, uint8_t *);
+typedef int32_t (*derive_rpik_fn)(const uint8_t *, uint8_t *);
+typedef int32_t (*generate_rpi_fn)(const uint8_t *, uint32_t, uint8_t *);
+typedef uint32_t (*calculate_enin_fn)(int64_t, int32_t, int64_t, int64_t, int64_t);
+typedef int32_t (*stable_read_enin_fn)(
+    int64_t, int64_t, int32_t, int64_t, int64_t, int64_t, uint32_t *);
+typedef int32_t (*event_code_hash_fn)(const uint8_t *, int32_t, uint8_t *);
+typedef int32_t (*display_id4_fn)(const uint8_t *, uint8_t *);
+typedef int32_t (*sha256_fn)(const uint8_t *, int32_t, uint8_t *);
+typedef int32_t (*derive_signing_keypair_fn)(
+    const uint8_t *, int32_t, const uint8_t *, int32_t, uint8_t *, uint8_t *);
+typedef int32_t (*sign_recoverable_fn)(
+    const uint8_t *, const uint8_t *, uint8_t *, uint8_t *, int32_t *);
+typedef uint8_t (*should_emit_rssi_update_fn)(uint32_t, uint32_t);
+typedef uint8_t (*should_serve_gatt_display_id_fn)(const uint8_t *, int32_t);
+
+static int failures = 0;
+
+static void expect_hex(const char *name, const uint8_t *bytes, size_t count,
+                       const char *expected) {
+  char actual[2 * 64 + 1];
+  for (size_t i = 0; i < count; i++) {
+    snprintf(actual + 2 * i, 3, "%02x", bytes[i]);
+  }
+  actual[2 * count] = '\0';
+  int ok = strcmp(actual, expected) == 0;
+  printf("%s=%s%s\n", name, actual, ok ? "" : " MISMATCH");
+  if (!ok) {
+    printf("  expected %s=%s\n", name, expected);
+    failures++;
+  }
+}
+
+static void expect_u32(const char *name, uint32_t actual, uint32_t expected) {
+  int ok = actual == expected;
+  printf("%s=%u%s\n", name, actual, ok ? "" : " MISMATCH");
+  if (!ok) {
+    printf("  expected %s=%u\n", name, expected);
+    failures++;
+  }
+}
+
+static void expect_i32(const char *name, int32_t actual, int32_t expected) {
+  int ok = actual == expected;
+  printf("%s=%d%s\n", name, actual, ok ? "" : " MISMATCH");
+  if (!ok) {
+    printf("  expected %s=%d\n", name, expected);
+    failures++;
+  }
+}
+
+static void *must_sym(void *handle, const char *name) {
+  void *sym = dlsym(handle, name);
+  if (!sym) {
+    fprintf(stderr, "missing symbol %s: %s\n", name, dlerror());
+    exit(2);
+  }
+  return sym;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    fprintf(stderr, "usage: %s <path-to-libBarnardCoreC>\n", argv[0]);
+    return 2;
+  }
+  void *handle = dlopen(argv[1], RTLD_NOW);
+  if (!handle) {
+    fprintf(stderr, "dlopen failed: %s\n", dlerror());
+    return 2;
+  }
+
+  derive_tek_for_event_fn derive_tek_for_event =
+      (derive_tek_for_event_fn)must_sym(handle, "barnard_core_derive_tek_for_event");
+  derive_tek_for_anonymous_fn derive_tek_for_anonymous =
+      (derive_tek_for_anonymous_fn)must_sym(handle, "barnard_core_derive_tek_for_anonymous");
+  derive_rpik_fn derive_rpik = (derive_rpik_fn)must_sym(handle, "barnard_core_derive_rpik");
+  generate_rpi_fn generate_rpi =
+      (generate_rpi_fn)must_sym(handle, "barnard_core_generate_rpi");
+  calculate_enin_fn calculate_enin =
+      (calculate_enin_fn)must_sym(handle, "barnard_core_calculate_enin");
+  stable_read_enin_fn stable_read_enin =
+      (stable_read_enin_fn)must_sym(handle, "barnard_core_stable_read_enin");
+  event_code_hash_fn event_code_hash =
+      (event_code_hash_fn)must_sym(handle, "barnard_core_compute_event_code_hash");
+  display_id4_fn display_id4 = (display_id4_fn)must_sym(handle, "barnard_core_display_id4");
+  sha256_fn sha256 = (sha256_fn)must_sym(handle, "barnard_core_sha256");
+  derive_signing_keypair_fn derive_signing_keypair =
+      (derive_signing_keypair_fn)must_sym(handle, "barnard_core_derive_signing_keypair");
+  sign_recoverable_fn sign_recoverable =
+      (sign_recoverable_fn)must_sym(handle, "barnard_core_sign_recoverable");
+  should_emit_rssi_update_fn should_emit_rssi_update =
+      (should_emit_rssi_update_fn)must_sym(handle, "barnard_core_should_emit_rssi_update");
+  should_serve_gatt_display_id_fn should_serve_gatt_display_id =
+      (should_serve_gatt_display_id_fn)must_sym(
+          handle, "barnard_core_should_serve_gatt_display_id");
+
+  uint8_t device_secret[32];
+  for (int i = 0; i < 32; i++) device_secret[i] = (uint8_t)i;
+  const char *event_code = "CORE-SPLIT-80";
+  int32_t event_code_len = (int32_t)strlen(event_code);
+  const uint32_t enin = 123456u;
+
+  uint8_t event_tek[16], anonymous_tek[16], rpik[16], rpi[16];
+  uint8_t display_id[4], code_hash[8];
+
+  if (derive_tek_for_event(device_secret, 32, (const uint8_t *)event_code,
+                           event_code_len, event_tek) != 0 ||
+      derive_tek_for_anonymous(device_secret, 32, anonymous_tek) != 0 ||
+      derive_rpik(event_tek, rpik) != 0 || generate_rpi(rpik, enin, rpi) != 0 ||
+      display_id4(event_tek, display_id) != 0 ||
+      event_code_hash((const uint8_t *)event_code, event_code_len, code_hash) != 0) {
+    fprintf(stderr, "a derivation call returned an error\n");
+    return 2;
+  }
+
+  expect_hex("anonymous_tek", anonymous_tek, 16, "1fc47c788289a03f2fbc8382f80b060c");
+  expect_u32("beacon_enin", calculate_enin(1700000123, 1, 300, 1600000000, 12), 8333343u);
+
+  uint32_t stable = 0;
+  expect_i32("crossed_enin_status", stable_read_enin(899, 900, 0, 300, 0, 0, &stable), 0);
+  expect_hex("display_id", display_id, 4, "c0fab611");
+  expect_hex("event_code_hash", code_hash, 8, "0b9f14789f13968f");
+  expect_hex("event_tek", event_tek, 16, "51c9263c4fbfc28fb28a76ab0d5d83d6");
+  expect_u32("fixed_enin", calculate_enin(1700000123, 0, 300, 0, 0), 5666667u);
+
+  uint8_t payload[17];
+  payload[0] = 1;
+  memcpy(payload + 1, rpi, 16);
+  expect_hex("payload", payload, 17, "01be601a7b45035ec4c85f8e203679d5ae");
+
+  expect_i32("policy_display_empty",
+             should_serve_gatt_display_id((const uint8_t *)event_code, 0), 0);
+  expect_i32("policy_display_joined",
+             should_serve_gatt_display_id((const uint8_t *)event_code, event_code_len), 1);
+  expect_i32("policy_rssi_rotated", should_emit_rssi_update(enin, enin + 1), 0);
+  expect_i32("policy_rssi_same", should_emit_rssi_update(enin, enin), 1);
+  expect_hex("rpi", rpi, 16, "be601a7b45035ec4c85f8e203679d5ae");
+  expect_hex("rpik", rpik, 16, "9c20d41985cc258c21e11f10f764b954");
+
+  uint8_t private_key[32], public_key[33];
+  if (derive_signing_keypair(device_secret, 32, (const uint8_t *)event_code,
+                             event_code_len, private_key, public_key) != 0) {
+    fprintf(stderr, "derive_signing_keypair returned an error\n");
+    return 2;
+  }
+  expect_hex("signing_private_key", private_key, 32,
+             "054e89de8696ef821cd60963bf0d2980ce1392241a1606ed3bed32983448f404");
+  expect_hex("signing_public_key", public_key, 33,
+             "036548e454f2b65bf3dc9676d64f8f22517caf0a07af7f33e0710fda7b8efd9e0c");
+
+  const char *message = "issue-80-signing";
+  uint8_t message_hash[32], r[32], s[32];
+  int32_t v = -1;
+  if (sha256((const uint8_t *)message, (int32_t)strlen(message), message_hash) != 0 ||
+      sign_recoverable(private_key, message_hash, r, s, &v) != 0) {
+    fprintf(stderr, "signing call returned an error\n");
+    return 2;
+  }
+  expect_hex("signing_r", r, 32,
+             "e7df5948c76c2c0c3397dcdbf72fed1cf87e5d2379cb0831e4d2f1f2b3f262f5");
+  expect_hex("signing_s", s, 32,
+             "51760b12ac9be31472f61ca68574e7d1c950ca68504d7dd37bff1bba97e3e7d8");
+  expect_i32("signing_v", v, 0);
+
+  stable = 0;
+  expect_i32("stable_enin_status", stable_read_enin(899, 899, 0, 300, 0, 0, &stable), 1);
+  expect_u32("stable_enin", stable, 2u);
+
+  if (failures != 0) {
+    printf("FAILED: %d mismatch(es)\n", failures);
+    return 1;
+  }
+  printf("OK: C host reproduced the issue #80 golden vector via libBarnardCoreC\n");
+  return 0;
+}

--- a/packages/swift/barnard/Package.swift
+++ b/packages/swift/barnard/Package.swift
@@ -10,7 +10,10 @@ let package = Package(
     ],
     products: [
         .library(name: "Barnard", targets: ["Barnard"]),
-        .library(name: "BarnardCore", targets: ["BarnardCore"])
+        .library(name: "BarnardCore", targets: ["BarnardCore"]),
+        // Dynamic on purpose: this is the .so/.dylib consumed over the C ABI
+        // by non-Swift hosts (Kotlin/JNI on Android, C, ...). See issue #78.
+        .library(name: "BarnardCoreC", type: .dynamic, targets: ["BarnardCoreC"])
     ],
     dependencies: [],
     targets: [
@@ -25,6 +28,10 @@ let package = Package(
             name: "BarnardCore",
             dependencies: []
         ),
+        .target(
+            name: "BarnardCoreC",
+            dependencies: ["BarnardCore"]
+        ),
         .testTarget(
             name: "BarnardTests",
             dependencies: ["Barnard"]
@@ -32,6 +39,10 @@ let package = Package(
         .testTarget(
             name: "BarnardCoreTests",
             dependencies: ["BarnardCore"]
+        ),
+        .testTarget(
+            name: "BarnardCoreCTests",
+            dependencies: ["BarnardCoreC"]
         )
     ]
 )

--- a/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
+++ b/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
@@ -1,0 +1,262 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+//
+// C ABI surface for BarnardCore (issue #78 follow-through).
+//
+// Every function here is a thin, allocation-free-at-the-boundary wrapper over
+// the deterministic BarnardCore API so that non-Swift hosts (Kotlin/JNI, C,
+// Rust, ...) can call the exact same implementation that iOS ships. The same
+// purity contract as BarnardCore applies: Swift stdlib only. Callers own all
+// buffers; fixed-size outputs are documented per function. Functions return 0
+// on success and a negative value on invalid arguments.
+
+import BarnardCore
+
+private func bytes(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> [UInt8]? {
+  guard count >= 0 else { return nil }
+  if count == 0 { return [] }
+  guard let pointer else { return nil }
+  return Array(UnsafeBufferPointer(start: pointer, count: Int(count)))
+}
+
+private func utf8String(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> String? {
+  guard let raw = bytes(pointer, count) else { return nil }
+  return String(decoding: raw, as: UTF8.self)
+}
+
+private func write(_ output: [UInt8], to pointer: UnsafeMutablePointer<UInt8>) {
+  pointer.update(from: output, count: output.count)
+}
+
+/// out_tek16: 16 bytes.
+@_cdecl("barnard_core_derive_tek_for_event")
+public func barnard_core_derive_tek_for_event(
+  _ deviceSecret: UnsafePointer<UInt8>?,
+  _ deviceSecretLength: Int32,
+  _ eventCodeUtf8: UnsafePointer<UInt8>?,
+  _ eventCodeLength: Int32,
+  _ outTek16: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard
+    let secret = bytes(deviceSecret, deviceSecretLength),
+    let eventCode = utf8String(eventCodeUtf8, eventCodeLength),
+    let outTek16
+  else { return -1 }
+  write(
+    BarnardCoreCrypto.deriveTekForEvent(deviceSecret: secret, eventCode: eventCode),
+    to: outTek16
+  )
+  return 0
+}
+
+/// out_tek16: 16 bytes.
+@_cdecl("barnard_core_derive_tek_for_anonymous")
+public func barnard_core_derive_tek_for_anonymous(
+  _ deviceSecret: UnsafePointer<UInt8>?,
+  _ deviceSecretLength: Int32,
+  _ outTek16: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let secret = bytes(deviceSecret, deviceSecretLength), let outTek16 else {
+    return -1
+  }
+  write(BarnardCoreCrypto.deriveTekForAnonymous(deviceSecret: secret), to: outTek16)
+  return 0
+}
+
+/// tek16: 16 bytes in. out_rpik16: 16 bytes out.
+@_cdecl("barnard_core_derive_rpik")
+public func barnard_core_derive_rpik(
+  _ tek16: UnsafePointer<UInt8>?,
+  _ outRpik16: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let tek = bytes(tek16, 16), let outRpik16 else { return -1 }
+  write(BarnardCoreCrypto.deriveRpik(from: tek), to: outRpik16)
+  return 0
+}
+
+/// rpik16: 16 bytes in. out_rpi16: 16 bytes out.
+@_cdecl("barnard_core_generate_rpi")
+public func barnard_core_generate_rpi(
+  _ rpik16: UnsafePointer<UInt8>?,
+  _ enin: UInt32,
+  _ outRpi16: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let rpik = bytes(rpik16, 16), let outRpi16 else { return -1 }
+  write(BarnardCoreCrypto.generateRpi(rpik: rpik, enin: enin), to: outRpi16)
+  return 0
+}
+
+/// mode: 0 = fixed-length window, 1 = beacon slot. Beacon parameters are
+/// ignored for mode 0; enin_seconds is ignored for mode 1.
+@_cdecl("barnard_core_calculate_enin")
+public func barnard_core_calculate_enin(
+  _ unixSeconds: Int64,
+  _ mode: Int32,
+  _ eninSeconds: Int64,
+  _ beaconGenesisUnixSeconds: Int64,
+  _ beaconSlotSeconds: Int64
+) -> UInt32 {
+  switch mode {
+  case 1:
+    return BarnardCoreCrypto.calculateEnin(
+      unixSeconds: unixSeconds,
+      mode: .beaconSlot,
+      beaconChain: BarnardCoreBeaconChain(
+        chainId: "c-abi",
+        genesisUnixSeconds: beaconGenesisUnixSeconds,
+        slotSeconds: beaconSlotSeconds
+      )
+    )
+  default:
+    return BarnardCoreCrypto.calculateEnin(
+      unixSeconds: unixSeconds,
+      mode: .fixedLength,
+      eninSeconds: eninSeconds
+    )
+  }
+}
+
+/// Returns 1 and writes out_enin when the window is stable across both reads,
+/// 0 (out_enin untouched) when the window boundary was crossed, negative on
+/// invalid arguments.
+@_cdecl("barnard_core_stable_read_enin")
+public func barnard_core_stable_read_enin(
+  _ startedAtUnixSeconds: Int64,
+  _ completedAtUnixSeconds: Int64,
+  _ mode: Int32,
+  _ eninSeconds: Int64,
+  _ beaconGenesisUnixSeconds: Int64,
+  _ beaconSlotSeconds: Int64,
+  _ outEnin: UnsafeMutablePointer<UInt32>?
+) -> Int32 {
+  guard let outEnin else { return -1 }
+  let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
+  let chain = BarnardCoreBeaconChain(
+    chainId: "c-abi",
+    genesisUnixSeconds: beaconGenesisUnixSeconds,
+    slotSeconds: beaconSlotSeconds
+  )
+  guard
+    let enin = BarnardCoreCrypto.stableReadEnin(
+      startedAtUnixSeconds: startedAtUnixSeconds,
+      completedAtUnixSeconds: completedAtUnixSeconds,
+      mode: coreMode,
+      eninSeconds: eninSeconds,
+      beaconChain: chain
+    )
+  else { return 0 }
+  outEnin.pointee = enin
+  return 1
+}
+
+/// out_hash8: 8 bytes.
+@_cdecl("barnard_core_compute_event_code_hash")
+public func barnard_core_compute_event_code_hash(
+  _ eventCodeUtf8: UnsafePointer<UInt8>?,
+  _ eventCodeLength: Int32,
+  _ outHash8: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let eventCode = utf8String(eventCodeUtf8, eventCodeLength), let outHash8 else {
+    return -1
+  }
+  write(BarnardCoreCrypto.computeEventCodeHash(eventCode), to: outHash8)
+  return 0
+}
+
+/// tek16: 16 bytes in. out_display_id4: 4 bytes out.
+@_cdecl("barnard_core_display_id4")
+public func barnard_core_display_id4(
+  _ tek16: UnsafePointer<UInt8>?,
+  _ outDisplayId4: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let tek = bytes(tek16, 16), let outDisplayId4 else { return -1 }
+  write(BarnardCoreCrypto.displayId4(from: tek), to: outDisplayId4)
+  return 0
+}
+
+/// out_digest32: 32 bytes.
+@_cdecl("barnard_core_sha256")
+public func barnard_core_sha256(
+  _ input: UnsafePointer<UInt8>?,
+  _ inputLength: Int32,
+  _ outDigest32: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let raw = bytes(input, inputLength), let outDigest32 else { return -1 }
+  write(BarnardCoreCrypto.sha256(raw), to: outDigest32)
+  return 0
+}
+
+/// out_private_key32: 32 bytes. out_public_key_compressed33: 33 bytes.
+@_cdecl("barnard_core_derive_signing_keypair")
+public func barnard_core_derive_signing_keypair(
+  _ deviceSecret: UnsafePointer<UInt8>?,
+  _ deviceSecretLength: Int32,
+  _ eventCodeUtf8: UnsafePointer<UInt8>?,
+  _ eventCodeLength: Int32,
+  _ outPrivateKey32: UnsafeMutablePointer<UInt8>?,
+  _ outPublicKeyCompressed33: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard
+    let secret = bytes(deviceSecret, deviceSecretLength),
+    let eventCode = utf8String(eventCodeUtf8, eventCodeLength),
+    let outPrivateKey32,
+    let outPublicKeyCompressed33
+  else { return -1 }
+  let keyPair = BarnardCoreSigning.deriveSigningKeyPair(
+    deviceSecret: secret,
+    eventCode: eventCode
+  )
+  write(keyPair.privateKey, to: outPrivateKey32)
+  write(keyPair.publicKeyCompressed, to: outPublicKeyCompressed33)
+  return 0
+}
+
+/// private_key32 and message_hash32: 32 bytes in. out_r32/out_s32: 32 bytes
+/// out; out_v: recovery id 0-3.
+@_cdecl("barnard_core_sign_recoverable")
+public func barnard_core_sign_recoverable(
+  _ privateKey32: UnsafePointer<UInt8>?,
+  _ messageHash32: UnsafePointer<UInt8>?,
+  _ outR32: UnsafeMutablePointer<UInt8>?,
+  _ outS32: UnsafeMutablePointer<UInt8>?,
+  _ outV: UnsafeMutablePointer<Int32>?
+) -> Int32 {
+  guard
+    let privateKey = bytes(privateKey32, 32),
+    let messageHash = bytes(messageHash32, 32),
+    let outR32,
+    let outS32,
+    let outV
+  else { return -1 }
+  let signature = BarnardCoreSigning.signRecoverable(
+    privateKey: privateKey,
+    messageHash32: messageHash
+  )
+  write(signature.r, to: outR32)
+  write(signature.s, to: outS32)
+  outV.pointee = Int32(signature.v)
+  return 0
+}
+
+/// Returns 1 when the RSSI update should be emitted, else 0.
+@_cdecl("barnard_core_should_emit_rssi_update")
+public func barnard_core_should_emit_rssi_update(
+  _ cachedPeerEnin: UInt32,
+  _ currentEnin: UInt32
+) -> UInt8 {
+  BarnardCoreV2Policy.shouldEmitRssiUpdate(
+    cachedPeerEnin: cachedPeerEnin,
+    currentEnin: currentEnin
+  ) ? 1 : 0
+}
+
+/// Returns 1 when the GATT display id should be served, else 0. A NULL
+/// event code is treated as absent.
+@_cdecl("barnard_core_should_serve_gatt_display_id")
+public func barnard_core_should_serve_gatt_display_id(
+  _ eventCodeUtf8: UnsafePointer<UInt8>?,
+  _ eventCodeLength: Int32
+) -> UInt8 {
+  let eventCode = utf8String(eventCodeUtf8, eventCodeLength)
+  return BarnardCoreV2Policy.shouldServeGattDisplayId(eventCode: eventCode) ? 1 : 0
+}

--- a/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
+++ b/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
@@ -24,8 +24,38 @@ private func utf8String(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> Str
   return String(decoding: raw, as: UTF8.self)
 }
 
-private func write(_ output: [UInt8], to pointer: UnsafeMutablePointer<UInt8>) {
+private func write(_ output: [UInt8], _ expectedCount: Int, to pointer: UnsafeMutablePointer<UInt8>) {
+  precondition(
+    output.count == expectedCount,
+    "core output length drifted from the documented C ABI buffer size"
+  )
   pointer.update(from: output, count: output.count)
+}
+
+/// The C boundary must be total: BarnardCore converts the derived window
+/// index with a trapping UInt32 cast, and a Swift trap is an uncatchable
+/// process abort for a JNI/C host. These guards mirror the core's own input
+/// clamps (see BarnardCoreCrypto.calculateEnin) purely to decide whether the
+/// core call is safe; in-domain results come from the core unchanged.
+private func eninDomain(
+  unixSeconds: Int64,
+  mode: Int32,
+  eninSeconds: Int64,
+  beaconGenesisUnixSeconds: Int64,
+  beaconSlotSeconds: Int64
+) -> (inDomain: Bool, saturated: UInt32) {
+  if mode == 1 {
+    let genesis = max(0, beaconGenesisUnixSeconds)
+    let slot = max(1, beaconSlotSeconds)
+    let elapsed = unixSeconds - genesis
+    if elapsed <= 0 { return (true, 0) }
+    if elapsed / slot > Int64(UInt32.max) { return (false, UInt32.max) }
+    return (true, 0)
+  }
+  if unixSeconds < 0 { return (false, 0) }
+  let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
+  if unixSeconds / effectiveSeconds > Int64(UInt32.max) { return (false, UInt32.max) }
+  return (true, 0)
 }
 
 /// out_tek16: 16 bytes.
@@ -44,6 +74,7 @@ public func barnard_core_derive_tek_for_event(
   else { return -1 }
   write(
     BarnardCoreCrypto.deriveTekForEvent(deviceSecret: secret, eventCode: eventCode),
+    16,
     to: outTek16
   )
   return 0
@@ -59,7 +90,7 @@ public func barnard_core_derive_tek_for_anonymous(
   guard let secret = bytes(deviceSecret, deviceSecretLength), let outTek16 else {
     return -1
   }
-  write(BarnardCoreCrypto.deriveTekForAnonymous(deviceSecret: secret), to: outTek16)
+  write(BarnardCoreCrypto.deriveTekForAnonymous(deviceSecret: secret), 16, to: outTek16)
   return 0
 }
 
@@ -70,7 +101,7 @@ public func barnard_core_derive_rpik(
   _ outRpik16: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
   guard let tek = bytes(tek16, 16), let outRpik16 else { return -1 }
-  write(BarnardCoreCrypto.deriveRpik(from: tek), to: outRpik16)
+  write(BarnardCoreCrypto.deriveRpik(from: tek), 16, to: outRpik16)
   return 0
 }
 
@@ -82,12 +113,16 @@ public func barnard_core_generate_rpi(
   _ outRpi16: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
   guard let rpik = bytes(rpik16, 16), let outRpi16 else { return -1 }
-  write(BarnardCoreCrypto.generateRpi(rpik: rpik, enin: enin), to: outRpi16)
+  write(BarnardCoreCrypto.generateRpi(rpik: rpik, enin: enin), 16, to: outRpi16)
   return 0
 }
 
-/// mode: 0 = fixed-length window, 1 = beacon slot. Beacon parameters are
-/// ignored for mode 0; enin_seconds is ignored for mode 1.
+/// mode: 1 = beacon slot; any other value is treated as the fixed-length
+/// window. Beacon parameters are ignored for the fixed-length mode;
+/// enin_seconds is ignored for the beacon-slot mode. This function has no
+/// error channel, so out-of-domain timestamps saturate instead of trapping:
+/// a negative fixed-length timestamp yields 0 and a window index beyond
+/// UINT32_MAX yields UINT32_MAX.
 @_cdecl("barnard_core_calculate_enin")
 public func barnard_core_calculate_enin(
   _ unixSeconds: Int64,
@@ -96,8 +131,15 @@ public func barnard_core_calculate_enin(
   _ beaconGenesisUnixSeconds: Int64,
   _ beaconSlotSeconds: Int64
 ) -> UInt32 {
-  switch mode {
-  case 1:
+  let domain = eninDomain(
+    unixSeconds: unixSeconds,
+    mode: mode,
+    eninSeconds: eninSeconds,
+    beaconGenesisUnixSeconds: beaconGenesisUnixSeconds,
+    beaconSlotSeconds: beaconSlotSeconds
+  )
+  guard domain.inDomain else { return domain.saturated }
+  if mode == 1 {
     return BarnardCoreCrypto.calculateEnin(
       unixSeconds: unixSeconds,
       mode: .beaconSlot,
@@ -107,18 +149,20 @@ public func barnard_core_calculate_enin(
         slotSeconds: beaconSlotSeconds
       )
     )
-  default:
-    return BarnardCoreCrypto.calculateEnin(
-      unixSeconds: unixSeconds,
-      mode: .fixedLength,
-      eninSeconds: eninSeconds
-    )
   }
+  return BarnardCoreCrypto.calculateEnin(
+    unixSeconds: unixSeconds,
+    mode: .fixedLength,
+    eninSeconds: eninSeconds
+  )
 }
 
 /// Returns 1 and writes out_enin when the window is stable across both reads,
 /// 0 (out_enin untouched) when the window boundary was crossed, negative on
-/// invalid arguments.
+/// invalid arguments — including timestamps outside the representable window
+/// domain (negative fixed-length timestamps or window indices beyond
+/// UINT32_MAX), which would otherwise trap. mode: 1 = beacon slot; any other
+/// value is treated as the fixed-length window.
 @_cdecl("barnard_core_stable_read_enin")
 public func barnard_core_stable_read_enin(
   _ startedAtUnixSeconds: Int64,
@@ -130,6 +174,16 @@ public func barnard_core_stable_read_enin(
   _ outEnin: UnsafeMutablePointer<UInt32>?
 ) -> Int32 {
   guard let outEnin else { return -1 }
+  for unixSeconds in [startedAtUnixSeconds, completedAtUnixSeconds]
+  where !eninDomain(
+    unixSeconds: unixSeconds,
+    mode: mode,
+    eninSeconds: eninSeconds,
+    beaconGenesisUnixSeconds: beaconGenesisUnixSeconds,
+    beaconSlotSeconds: beaconSlotSeconds
+  ).inDomain {
+    return -1
+  }
   let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
   let chain = BarnardCoreBeaconChain(
     chainId: "c-abi",
@@ -159,7 +213,7 @@ public func barnard_core_compute_event_code_hash(
   guard let eventCode = utf8String(eventCodeUtf8, eventCodeLength), let outHash8 else {
     return -1
   }
-  write(BarnardCoreCrypto.computeEventCodeHash(eventCode), to: outHash8)
+  write(BarnardCoreCrypto.computeEventCodeHash(eventCode), 8, to: outHash8)
   return 0
 }
 
@@ -170,7 +224,7 @@ public func barnard_core_display_id4(
   _ outDisplayId4: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
   guard let tek = bytes(tek16, 16), let outDisplayId4 else { return -1 }
-  write(BarnardCoreCrypto.displayId4(from: tek), to: outDisplayId4)
+  write(BarnardCoreCrypto.displayId4(from: tek), 4, to: outDisplayId4)
   return 0
 }
 
@@ -182,7 +236,7 @@ public func barnard_core_sha256(
   _ outDigest32: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
   guard let raw = bytes(input, inputLength), let outDigest32 else { return -1 }
-  write(BarnardCoreCrypto.sha256(raw), to: outDigest32)
+  write(BarnardCoreCrypto.sha256(raw), 32, to: outDigest32)
   return 0
 }
 
@@ -206,8 +260,8 @@ public func barnard_core_derive_signing_keypair(
     deviceSecret: secret,
     eventCode: eventCode
   )
-  write(keyPair.privateKey, to: outPrivateKey32)
-  write(keyPair.publicKeyCompressed, to: outPublicKeyCompressed33)
+  write(keyPair.privateKey, 32, to: outPrivateKey32)
+  write(keyPair.publicKeyCompressed, 33, to: outPublicKeyCompressed33)
   return 0
 }
 
@@ -232,8 +286,8 @@ public func barnard_core_sign_recoverable(
     privateKey: privateKey,
     messageHash32: messageHash
   )
-  write(signature.r, to: outR32)
-  write(signature.s, to: outS32)
+  write(signature.r, 32, to: outR32)
+  write(signature.s, 32, to: outS32)
   outV.pointee = Int32(signature.v)
   return 0
 }

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -1,0 +1,115 @@
+// Copyright 2024-2026 The Greeting Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+import XCTest
+@testable import BarnardCoreC
+
+/// Replays the issue #80 golden behavior vector (BarnardBehaviorVectorTests)
+/// exclusively through the exported C ABI entry points, so any drift between
+/// the C surface and BarnardCore fails byte-identically here.
+final class BarnardCoreCTests: XCTestCase {
+  private func hex(_ bytes: [UInt8]) -> String {
+    bytes.map { String(format: "%02x", $0) }.joined()
+  }
+
+  func testCAbiReproducesIssue80GoldenVector() {
+    let deviceSecret = (0..<32).map(UInt8.init)
+    let eventCode = Array("CORE-SPLIT-80".utf8)
+    let enin: UInt32 = 123_456
+
+    var eventTek = [UInt8](repeating: 0, count: 16)
+    XCTAssertEqual(
+      barnard_core_derive_tek_for_event(
+        deviceSecret, 32, eventCode, Int32(eventCode.count), &eventTek
+      ),
+      0
+    )
+    XCTAssertEqual(hex(eventTek), "51c9263c4fbfc28fb28a76ab0d5d83d6")
+
+    var anonymousTek = [UInt8](repeating: 0, count: 16)
+    XCTAssertEqual(barnard_core_derive_tek_for_anonymous(deviceSecret, 32, &anonymousTek), 0)
+    XCTAssertEqual(hex(anonymousTek), "1fc47c788289a03f2fbc8382f80b060c")
+
+    var rpik = [UInt8](repeating: 0, count: 16)
+    XCTAssertEqual(barnard_core_derive_rpik(eventTek, &rpik), 0)
+    XCTAssertEqual(hex(rpik), "9c20d41985cc258c21e11f10f764b954")
+
+    var rpi = [UInt8](repeating: 0, count: 16)
+    XCTAssertEqual(barnard_core_generate_rpi(rpik, enin, &rpi), 0)
+    XCTAssertEqual(hex(rpi), "be601a7b45035ec4c85f8e203679d5ae")
+    XCTAssertEqual(hex([1] + rpi), "01be601a7b45035ec4c85f8e203679d5ae")
+
+    var displayId = [UInt8](repeating: 0, count: 4)
+    XCTAssertEqual(barnard_core_display_id4(eventTek, &displayId), 0)
+    XCTAssertEqual(hex(displayId), "c0fab611")
+
+    var eventCodeHash = [UInt8](repeating: 0, count: 8)
+    XCTAssertEqual(
+      barnard_core_compute_event_code_hash(eventCode, Int32(eventCode.count), &eventCodeHash),
+      0
+    )
+    XCTAssertEqual(hex(eventCodeHash), "0b9f14789f13968f")
+
+    XCTAssertEqual(
+      barnard_core_calculate_enin(1_700_000_123, 0, 300, 0, 0),
+      5_666_667
+    )
+    XCTAssertEqual(
+      barnard_core_calculate_enin(1_700_000_123, 1, 300, 1_600_000_000, 12),
+      8_333_343
+    )
+
+    var stableEnin: UInt32 = 0
+    XCTAssertEqual(barnard_core_stable_read_enin(899, 899, 0, 300, 0, 0, &stableEnin), 1)
+    XCTAssertEqual(stableEnin, 2)
+    XCTAssertEqual(barnard_core_stable_read_enin(899, 900, 0, 300, 0, 0, &stableEnin), 0)
+
+    XCTAssertEqual(barnard_core_should_serve_gatt_display_id(eventCode, 0), 0)
+    XCTAssertEqual(
+      barnard_core_should_serve_gatt_display_id(eventCode, Int32(eventCode.count)),
+      1
+    )
+    XCTAssertEqual(barnard_core_should_emit_rssi_update(enin, enin + 1), 0)
+    XCTAssertEqual(barnard_core_should_emit_rssi_update(enin, enin), 1)
+
+    var privateKey = [UInt8](repeating: 0, count: 32)
+    var publicKey = [UInt8](repeating: 0, count: 33)
+    XCTAssertEqual(
+      barnard_core_derive_signing_keypair(
+        deviceSecret, 32, eventCode, Int32(eventCode.count), &privateKey, &publicKey
+      ),
+      0
+    )
+    XCTAssertEqual(
+      hex(privateKey),
+      "054e89de8696ef821cd60963bf0d2980ce1392241a1606ed3bed32983448f404"
+    )
+    XCTAssertEqual(
+      hex(publicKey),
+      "036548e454f2b65bf3dc9676d64f8f22517caf0a07af7f33e0710fda7b8efd9e0c"
+    )
+
+    let message = Array("issue-80-signing".utf8)
+    var messageHash = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(barnard_core_sha256(message, Int32(message.count), &messageHash), 0)
+
+    var r = [UInt8](repeating: 0, count: 32)
+    var s = [UInt8](repeating: 0, count: 32)
+    var v: Int32 = -1
+    XCTAssertEqual(barnard_core_sign_recoverable(privateKey, messageHash, &r, &s, &v), 0)
+    XCTAssertEqual(hex(r), "e7df5948c76c2c0c3397dcdbf72fed1cf87e5d2379cb0831e4d2f1f2b3f262f5")
+    XCTAssertEqual(hex(s), "51760b12ac9be31472f61ca68574e7d1c950ca68504d7dd37bff1bba97e3e7d8")
+    XCTAssertEqual(v, 0)
+  }
+
+  func testInvalidArgumentsAreRejected() {
+    var out = [UInt8](repeating: 0, count: 16)
+    XCTAssertEqual(barnard_core_derive_tek_for_event(nil, 32, nil, 0, &out), -1)
+    XCTAssertEqual(barnard_core_derive_tek_for_anonymous(nil, 1, &out), -1)
+    XCTAssertEqual(barnard_core_derive_rpik(nil, &out), -1)
+    XCTAssertEqual(barnard_core_sha256(nil, 4, &out), -1)
+    XCTAssertEqual(barnard_core_stable_read_enin(0, 0, 0, 300, 0, 0, nil), -1)
+    XCTAssertEqual(barnard_core_should_serve_gatt_display_id(nil, 5), 0)
+  }
+}

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -103,6 +103,21 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(v, 0)
   }
 
+  func testOutOfDomainTimestampsDoNotTrap() {
+    // calculate_enin has no error channel: out-of-domain saturates.
+    XCTAssertEqual(barnard_core_calculate_enin(-400, 0, 300, 0, 0), 0)
+    XCTAssertEqual(barnard_core_calculate_enin(.max, 0, 300, 0, 0), .max)
+    XCTAssertEqual(barnard_core_calculate_enin(.max, 1, 300, 0, 1), .max)
+    XCTAssertEqual(barnard_core_calculate_enin(-400, 1, 300, 0, 12), 0)
+
+    // stable_read_enin has an error channel: out-of-domain is rejected.
+    var enin: UInt32 = 0
+    XCTAssertEqual(barnard_core_stable_read_enin(-1, 899, 0, 300, 0, 0, &enin), -1)
+    XCTAssertEqual(barnard_core_stable_read_enin(899, .max, 0, 300, 0, 0, &enin), -1)
+    XCTAssertEqual(barnard_core_stable_read_enin(-1, -1, 1, 300, 0, 12, &enin), 1)
+    XCTAssertEqual(enin, 0)
+  }
+
   func testInvalidArgumentsAreRejected() {
     var out = [UInt8](repeating: 0, count: 16)
     XCTAssertEqual(barnard_core_derive_tek_for_event(nil, 32, nil, 0, &out), -1)


### PR DESCRIPTION
Refs #78 (follow-through after the #80/#83 BarnardCore split).

Makes BarnardCore consumable from non-Swift hosts (Kotlin/JNI on Android, plain C) and locks the Android cross-compile the #78 spike proved manually into CI.

## 1. C ABI surface: new `BarnardCoreC` target

- `Sources/BarnardCoreC/CExports.swift`: 13 `@_cdecl` exports wrapping BarnardCore's deterministic API — TEK (event + anonymous), RPIK, RPI, ENIN (fixed-length + beacon-slot + stable-read), event-code hash, display id, sha256, signing key-pair derivation, recoverable signing, and the v2 policy predicates. Same purity contract as BarnardCore (Swift stdlib only), so it cross-compiles for Android unchanged.
- New dynamic library product `BarnardCoreC` — this is the `.so`/`.dylib` a JNI wrapper loads.
- No existing BarnardCore source is modified; golden vectors stay byte-identical. The mirror contract (`scripts/check-swift-mirror.sh`) is untouched and passes.

## 2. Consumption proof (issue #80 golden vector, byte-identical)

Two independent consumers replay the exact `BarnardBehaviorVectorTests` vector through the C ABI:

**Swift test target** `BarnardCoreCTests` (runs in the existing `Barnard-Package` CI test step):

```
$ xcodebuild -scheme Barnard-Package -destination "id=<simulator>" test -only-testing:BarnardCoreCTests
Test Case '-[BarnardCoreCTests.BarnardCoreCTests testCAbiReproducesIssue80GoldenVector]' passed (32.703 seconds).
Test Case '-[BarnardCoreCTests.BarnardCoreCTests testInvalidArgumentsAreRejected]' passed (0.004 seconds).
** TEST SUCCEEDED **
```

**Plain C host** (`CHostProof/barnard_core_c_host_proof.c`) — dlopens the built library, no Swift in the caller:

```
$ swift build --product BarnardCoreC -c release
$ cc -o proof CHostProof/barnard_core_c_host_proof.c
$ ./proof .build/release/libBarnardCoreC.dylib
anonymous_tek=1fc47c788289a03f2fbc8382f80b060c
beacon_enin=8333343
crossed_enin_status=0
display_id=c0fab611
event_code_hash=0b9f14789f13968f
event_tek=51c9263c4fbfc28fb28a76ab0d5d83d6
fixed_enin=5666667
payload=01be601a7b45035ec4c85f8e203679d5ae
policy_display_empty=0
policy_display_joined=1
policy_rssi_rotated=0
policy_rssi_same=1
rpi=be601a7b45035ec4c85f8e203679d5ae
rpik=9c20d41985cc258c21e11f10f764b954
signing_private_key=054e89de8696ef821cd60963bf0d2980ce1392241a1606ed3bed32983448f404
signing_public_key=036548e454f2b65bf3dc9676d64f8f22517caf0a07af7f33e0710fda7b8efd9e0c
signing_r=e7df5948c76c2c0c3397dcdbf72fed1cf87e5d2379cb0831e4d2f1f2b3f262f5
signing_s=51760b12ac9be31472f61ca68574e7d1c950ca68504d7dd37bff1bba97e3e7d8
signing_v=0
stable_enin_status=1
stable_enin=2
OK: C host reproduced the issue #80 golden vector via libBarnardCoreC
```

Every value matches the `BarnardBehaviorVectorTests` expected block byte-for-byte. The same C harness runs in the new CI workflow against a Linux-native build of the same product.

## 3. CI: `swift-android.yml` (aarch64-android cross-compile on every packages/swift PR)

- ubuntu-24.04, pinned `swift-6.4.x-DEVELOPMENT-SNAPSHOT-2026-07-17-a` host toolchain + matching Android SDK bundle, both sha256-verified; runner NDK linked via the SDK's official `setup-android-sdk.sh`.
- Builds `libBarnardCoreC.so` for `aarch64-unknown-linux-android28` and fails if any of the 13 exported symbols disappears (`llvm-nm -D`).
- Then builds the same product for the Linux host and runs the C harness above — the Android `.so` cannot execute on the runner, so the executable proof runs on the host with the identical toolchain, and the Android artifact is guarded at build + symbol level.

**Tradeoffs, stated honestly:**
- The 6.4 Android toolchain has no stable release; this pins one development snapshot (matched host/SDK pair). Bumping is a two-line change.
- ~1.6 GB of downloads are cached via `actions/cache` (repo budget 10 GB); a cold run adds a one-time download (a few minutes). That keeps this a per-PR guard rather than a scheduled job.
- Only aarch64 is cross-compiled; the spike showed armv7/x86_64 build identically, and this job is a drift guard, not a release pipeline.

## 4. Purity grep strengthened (audit note from #83)

`FoundationEssentials` added to the forbidden alternation, and the grep + stdlib-only build now also cover `Sources/BarnardCoreC`. Nothing was removed from the check.

## Out of scope

- Maintainer decision from the #78 spike stands: no Kotlin logic-core replacement yet. This PR only makes the shared core linkable/consumable and CI-guarded.
- `packages/dart` mirror direction is untouched (#81 handles that separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019veX4SbjiyQ8pMjvwx8mF8