### PR TITLE
feat(swift): add root SwiftPM package

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -42,6 +42,42 @@ jobs:
           fi
       - name: swift test (Barnard compatibility + BarnardCore unit tests)
         run: xcodebuild -scheme Barnard-Package -destination "id=${{ steps.destination.outputs.udid }}" test
+      - name: Root and inner Swift package manifest drift guard
+        working-directory: .
+        run: ./scripts/check-swift-package-manifest-mirror.sh
+      - name: Scratch consumer builds for iOS Simulator and imports Barnard
+        working-directory: .
+        run: |
+          consumer_dir="$(mktemp -d)"
+          mkdir -p "$consumer_dir/Sources/BarnardConsumer"
+          cat > "$consumer_dir/Package.swift" <<EOF
+          // swift-tools-version: 5.9
+          import PackageDescription
+
+          let package = Package(
+              name: "BarnardConsumer",
+              dependencies: [
+                  .package(name: "barnard", path: "$GITHUB_WORKSPACE")
+              ],
+              targets: [
+                  .executableTarget(
+                      name: "BarnardConsumer",
+                      dependencies: [
+                          .product(name: "Barnard", package: "barnard")
+                      ]
+                  )
+              ]
+          )
+          EOF
+          cat > "$consumer_dir/Sources/BarnardConsumer/main.swift" <<'EOF'
+          import Barnard
+
+          print("Barnard import succeeded")
+          EOF
+          swift build \
+            --package-path "$consumer_dir" \
+            --triple arm64-apple-ios15.0-simulator \
+            --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)"
 
   swift-mirror-sync-check:
     # packages/swift/barnard mirrors the Flutter-free platform adapters and

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -56,6 +56,7 @@ jobs:
 
           let package = Package(
               name: "BarnardConsumer",
+              platforms: [.iOS("14.0")],
               dependencies: [
                   .package(name: "barnard", path: "$GITHUB_WORKSPACE")
               ],

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -18,11 +18,13 @@ name: Swift Android Cross-Compile
 on:
   pull_request:
     paths:
+      - "Package.swift"
       - "packages/swift/**"
       - ".github/workflows/swift-android.yml"
   push:
     branches: [ main ]
     paths:
+      - "Package.swift"
       - "packages/swift/**"
       - ".github/workflows/swift-android.yml"
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ When the user asks to create a PR and verify CI, prefer GitHub MCP operations ov
 
 Repository defaults:
 
-- Repo: `thegreeting/barnard`
+- Repo: `levarac/barnard`
 - Base branch: `main`
 
 Recommended flow:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025-2026 Levarac
+Copyright (c) 2024-2026 Levarac
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,54 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Barnard",
+    platforms: [
+        .iOS("14.0")
+    ],
+    products: [
+        .library(name: "Barnard", targets: ["Barnard"]),
+        .library(name: "BarnardCore", targets: ["BarnardCore"]),
+        // Dynamic on purpose: this is the .so/.dylib consumed over the C ABI
+        // by non-Swift hosts (Kotlin/JNI on Android, C, ...). See issue #78.
+        .library(name: "BarnardCoreC", type: .dynamic, targets: ["BarnardCoreC"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Barnard",
+            dependencies: ["BarnardCore"],
+            path: "packages/swift/barnard/Sources/Barnard",
+            resources: [
+                .process("PrivacyInfo.xcprivacy")
+            ]
+        ),
+        .target(
+            name: "BarnardCore",
+            dependencies: [],
+            path: "packages/swift/barnard/Sources/BarnardCore"
+        ),
+        .target(
+            name: "BarnardCoreC",
+            dependencies: ["BarnardCore"],
+            path: "packages/swift/barnard/Sources/BarnardCoreC"
+        ),
+        .testTarget(
+            name: "BarnardTests",
+            dependencies: ["Barnard"],
+            path: "packages/swift/barnard/Tests/BarnardTests"
+        ),
+        .testTarget(
+            name: "BarnardCoreTests",
+            dependencies: ["BarnardCore"],
+            path: "packages/swift/barnard/Tests/BarnardCoreTests"
+        ),
+        .testTarget(
+            name: "BarnardCoreCTests",
+            dependencies: ["BarnardCoreC"],
+            path: "packages/swift/barnard/Tests/BarnardCoreCTests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ installation and usage details, plus platform-specific setup where required.
 - [Flutter / Dart](packages/dart/barnard/README.md)
 - [React Native](packages/react-native/barnard/README.md)
 
+### Swift Package Manager installation
+
+Add Barnard to the `dependencies` in your package manifest:
+
+```swift
+.package(url: "https://github.com/levarac/barnard.git", from: "0.1.0")
+```
+
+The repository-root `Package.swift` supports remote consumption. The inner
+manifest at `packages/swift/barnard/Package.swift` remains available for
+in-repository development, and CI checks that their declarations stay aligned.
+
 ## Protocol and privacy references
 
 The [resolvable-ID v2 specification](specs/004-resolvable-id/spec.md) defines

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,18 @@
+# Releasing Barnard
+
+Barnard uses whole-monorepo semantic versions. A `vX.Y.Z` tag identifies the
+same protocol semantics across the Swift, Kotlin, Dart, and React Native
+packages.
+
+After the release commit is merged into `main`, create and push the release tag:
+
+```sh
+git tag vX.Y.Z && git push origin vX.Y.Z
+```
+
+The first `v0.1.0` tag will be cut by the project lead after the root Swift
+package manifest is merged.
+
+Revisit whole-monorepo versioning if repository size grows enough to hurt
+consumer fetches or if platforms genuinely need divergent versioning. At that
+point, evaluate a CI-published distribution repository.

--- a/packages/dart/barnard/README.md
+++ b/packages/dart/barnard/README.md
@@ -39,7 +39,7 @@ For a Git dependency:
 dependencies:
   barnard:
     git:
-      url: https://github.com/thegreeting/barnard.git
+      url: https://github.com/levarac/barnard.git
       path: packages/dart/barnard
 ```
 

--- a/packages/dart/barnard/ios/barnard.podspec
+++ b/packages/dart/barnard/ios/barnard.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 Barnard BLE Transport for Flutter (GATT-first RPID).
                        DESC
-  s.homepage         = 'https://github.com/thegreeting/barnard'
+  s.homepage         = 'https://github.com/levarac/barnard'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }

--- a/packages/dart/barnard/pubspec.yaml
+++ b/packages/dart/barnard/pubspec.yaml
@@ -1,7 +1,7 @@
 name: barnard
 description: Barnard SDK for Flutter/Dart (public API + mock implementation + real BLE Transport).
 version: 0.0.1-alpha.1
-repository: https://github.com/thegreeting/barnard
+repository: https://github.com/levarac/barnard
 
 environment:
   sdk: ^3.11.0

--- a/packages/react-native/barnard/package.json
+++ b/packages/react-native/barnard/package.json
@@ -34,15 +34,15 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/thegreeting/barnard.git",
+    "url": "git+https://github.com/levarac/barnard.git",
     "directory": "packages/react-native/barnard"
   },
   "author": "Levarac",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/thegreeting/barnard/issues"
+    "url": "https://github.com/levarac/barnard/issues"
   },
-  "homepage": "https://github.com/thegreeting/barnard#readme",
+  "homepage": "https://github.com/levarac/barnard#readme",
   "devDependencies": {
     "@react-native-community/eslint-config": "^3.2.0",
     "@types/jest": "^29.5.14",

--- a/scripts/check-android-mirror.sh
+++ b/scripts/check-android-mirror.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Use of this source code is governed by a BSD-style license.
+# Use of this source code is governed by the MIT license in /LICENSE.
 #
 # barnard#56: packages/android/barnard mirrors the Flutter-free crypto/RPID
 # sources from packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard

--- a/scripts/check-swift-mirror.sh
+++ b/scripts/check-swift-mirror.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Use of this source code is governed by a BSD-style license.
+# Use of this source code is governed by the MIT license in /LICENSE.
 #
 # barnard#56 and #80: packages/swift/barnard mirrors the Flutter-free
 # platform adapters and deterministic BarnardCore sources from

--- a/scripts/check-swift-package-manifest-mirror.sh
+++ b/scripts/check-swift-package-manifest-mirror.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Use of this source code is governed by a BSD-style license.
+# Use of this source code is governed by the MIT license in /LICENSE.
 #
 # barnard#85: the repository-root Package.swift exposes the Swift package for
 # remote consumption while packages/swift/barnard/Package.swift remains the

--- a/scripts/check-swift-package-manifest-mirror.sh
+++ b/scripts/check-swift-package-manifest-mirror.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Use of this source code is governed by a BSD-style license.
+#
+# barnard#85: the repository-root Package.swift exposes the Swift package for
+# remote consumption while packages/swift/barnard/Package.swift remains the
+# in-repository development manifest. This check prevents their declared
+# products, targets, platforms, and Swift tools version from silently drifting.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+root_manifest="$repo_root/Package.swift"
+inner_package="$repo_root/packages/swift/barnard"
+
+if [[ ! -f "$root_manifest" ]]; then
+  echo "MISSING root Swift package manifest: $root_manifest"
+  exit 1
+fi
+
+root_dump="$(mktemp)"
+inner_dump="$(mktemp)"
+root_declarations="$(mktemp)"
+inner_declarations="$(mktemp)"
+trap 'rm -f "$root_dump" "$inner_dump" "$root_declarations" "$inner_declarations"' EXIT
+
+swift package dump-package --package-path "$repo_root" >"$root_dump"
+swift package dump-package --package-path "$inner_package" >"$inner_dump"
+
+extract_declarations() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    package = json.load(source)
+
+targets = package["targets"]
+for target in targets:
+    # The root manifest must point into the nested package; the inner manifest
+    # uses SwiftPM's default Sources/ and Tests/ locations.
+    target.pop("path", None)
+
+declarations = {
+    "platforms": package["platforms"],
+    "products": package["products"],
+    "targets": targets,
+    "toolsVersion": package["toolsVersion"],
+}
+json.dump(declarations, sys.stdout, indent=2, sort_keys=True)
+sys.stdout.write("\n")
+PY
+}
+
+extract_declarations "$root_dump" >"$root_declarations"
+extract_declarations "$inner_dump" >"$inner_declarations"
+
+if ! diff -u "$inner_declarations" "$root_declarations"; then
+  echo "DRIFT: root and inner Swift package declarations differ."
+  exit 1
+fi
+
+echo "OK: root and inner Swift package products, targets, platforms, and tools version match."


### PR DESCRIPTION
## Summary

- add a repository-root `Package.swift` so Barnard can be consumed through a remote SwiftPM git dependency while retaining the inner manifest for in-repository development
- add a manifest drift guard and a scratch-consumer iOS Simulator build to Native SDK CI
- document SwiftPM installation and whole-monorepo semantic-version release tagging
- correct the LICENSE start year and update package metadata from `thegreeting/barnard` to `levarac/barnard`

Closes #85

## Compatibility, security, and privacy

- No Swift files under `Sources/` or `Tests/` changed.
- No public on-wire payload shape or schema changed.
- No device-unique persistent identifier was added to any on-wire payload.
- The inner `packages/swift/barnard/Package.swift` remains intact. Its existing `swift-package` CI job is the regression evidence for in-repository development; no separate local inner-package test run is required.
- The first `v0.1.0` tag will be cut by the project lead after merge. This PR does not create or push a tag.

## Local evidence

### Root SwiftPM iOS Simulator build

```sh
swift build \
  --triple arm64-apple-ios15.0-simulator \
  --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)"
```

```text
[147 / 156] Barnard
[153 / 156] Barnard
Build complete! (4.43 sec)
```

### Root-manifest tests on iOS Simulator

```sh
xcodebuild -scheme Barnard-Package -destination 'id=LOCAL_SIMULATOR_UDID' test
```

```text
Test Suite 'BarnardTests.xctest' passed.
    Executed 33 tests, with 0 failures (0 unexpected)
Test Suite 'BarnardCoreTests.xctest' passed.
    Executed 5 tests, with 0 failures (0 unexpected)
Test Suite 'BarnardCoreCTests.xctest' passed.
    Executed 3 tests, with 0 failures (0 unexpected)
** TEST SUCCEEDED **
```

### Manifest drift guard: matching manifests

```sh
./scripts/check-swift-package-manifest-mirror.sh
```

```text
OK: root and inner Swift package products, targets, platforms, and tools version match.
```

### Manifest drift guard: intentional mismatch in a scratch copy

The scratch root manifest's iOS platform was changed from `14.0` to `15.0` without changing the inner manifest.

```text
-      "version": "14.0"
+      "version": "15.0"
DRIFT: root and inner Swift package declarations differ.
expected_failure_exit=1
```

### Scratch consumer importing Barnard

A scratch executable package used `.package(name: "barnard", path: REPOSITORY_ROOT)`, declared iOS 14.0, imported `Barnard`, and was built with the iOS Simulator SDK and triple used by CI.

```text
[141 / 156] BarnardConsumer
[154 / 160] BarnardConsumer-product
[154 / 160] Barnard
[158 / 160] BarnardConsumer-product
Build complete! (5.33 sec)
```

### Stale repository URL scope

```sh
git grep -n "thegreeting/barnard"
```

```text
specs/004-resolvable-id/spec.md:3:**Issue:** [#42](https://github.com/thegreeting/barnard/issues/42)
specs/004-resolvable-id/spec.md:4:**Ancestor:** [#31](https://github.com/thegreeting/barnard/issues/31), [spec 003](../003-flutter-poc-real-ble/spec.md)
specs/004-resolvable-id/spec.md:368:- Barnard issue #42 (this spec's primary source) — https://github.com/thegreeting/barnard/issues/42
```

Only the explicitly excluded historical `specs/**` references remain; `schema/**` was not modified.

## CI

- [x] All 9 GitHub Actions checks passed on head `49026341e1e9bc87769af639115476fd7ec79c6f`.
- [x] `swift-package` passed, including the inner-package iOS Simulator tests, root/inner drift guard, and scratch consumer iOS Simulator build.
- [x] `android-cross-compile` passed.

Native SDK CI run: https://github.com/levarac/barnard/actions/runs/30016603540