### PR TITLE
refactor(scripts): make native packages mirror origins

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -81,9 +81,9 @@ jobs:
             --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)"
 
   swift-mirror-sync-check:
-    # packages/swift/barnard mirrors the Flutter-free platform adapters and
-    # BarnardCore sources under packages/dart/barnard/ios; this guards against
-    # drift (see scripts/check-swift-mirror.sh).
+    # packages/swift/barnard is the origin for Flutter-free platform adapters
+    # and BarnardCore sources mirrored under packages/dart/barnard/ios; this
+    # guards against drift (see scripts/check-swift-mirror.sh).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -139,9 +139,9 @@ jobs:
         run: ./gradlew test
 
   android-mirror-sync-check:
-    # packages/android/barnard mirrors the Flutter-free crypto/signing/RPID
-    # sources under packages/dart/barnard/android; this guards against drift
-    # (see scripts/check-android-mirror.sh).
+    # packages/android/barnard is the origin for Flutter-free
+    # crypto/signing/RPID sources mirrored under packages/dart/barnard/android;
+    # this guards against drift (see scripts/check-android-mirror.sh).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The repository is organized around a few design principles:
 - The Flutter/Dart and React Native packages expose BLE Scan and Advertise APIs,
   including a GATT-based RPID exchange on iOS and Android.
 - The native Swift and Android packages expose first-class platform APIs and are
-  built and tested directly in CI. Mirror checks make the relationship between
-  their shared crypto, signing, and RPID sources and the Flutter plugin's
-  Flutter-free platform sources verifiable.
+  built and tested directly in CI. They are the canonical origins for shared
+  crypto, signing, and RPID sources; mirror checks verify the Flutter plugin's
+  referencing copies byte-for-byte.
 - Examples cover mock-driven Dart use, real Flutter BLE use, and minimal native
   iOS and Android integrations. The native Android example also contains a
   two-device test-loop script for a device lab.
@@ -53,7 +53,7 @@ and the reason it is kept in the repository.
 ├── examples/     # Runnable integrations; prove each SDK surface in a minimal host application.
 ├── packages/     # Distributable SDK packages; provide native and framework-specific adoption paths.
 ├── schema/       # Versioned JSON Schema; define language-agnostic public shapes before implementation details.
-├── scripts/      # Repository checks; detect drift between native mirrors and their source files.
+├── scripts/      # Repository checks and sync; keep Dart mirrors aligned with native origins.
 ├── specs/        # Feature specifications; record behavior, boundaries, and privacy decisions independently of code.
 └── tools/        # Focused developer utilities; keep one-off protocol and scanner tooling outside SDK packages.
 ```
@@ -74,14 +74,15 @@ packages/
 
 - `packages/swift/barnard/` is a Swift Package Manager library for iOS 14 and
   later. It exists so native iOS apps can use Barnard without a Flutter runtime;
-  its mirrored Flutter-free sources are checked for byte-for-byte drift.
+  its shared Flutter-free sources are the canonical Swift origins.
 - `packages/android/barnard/` is a Gradle library for Android API 24 and later.
   It exists so native Android apps can use typed Kotlin APIs without a Flutter
-  or React Native runtime; its mirrored Flutter-free sources are likewise
-  checked for drift.
+  or React Native runtime; its shared Flutter-free sources are the canonical
+  Kotlin origins.
 - `packages/dart/barnard/` is the Flutter/Dart SDK. It exists for Flutter apps
   that need the shared domain API, a hardware-free `MockBarnard` integration
-  path, or the platform BLE Transport.
+  path, or the platform BLE Transport. Its referencing Swift and Kotlin copies
+  are synchronized from the native origins and checked for byte-for-byte drift.
 - `packages/react-native/barnard/` is the React Native SDK. It exists for React
   Native apps that need a TypeScript API over native iOS and Android BLE
   implementations.
@@ -101,9 +102,10 @@ packages/
 - `tools/` currently contains `barnard-scan`, a small scanner utility. Keeping
   it outside `packages/` prevents a focused developer tool from becoming a
   required SDK dependency.
-- `scripts/` contains the Swift and Android mirror checks. They make the
-  deliberate shared-source relationship between native SDKs and the Flutter
-  plugin verifiable in CI.
+- `scripts/` contains the Swift and Android mirror checks and the native-to-Dart
+  sync helper. They make the deliberate shared-source relationship between
+  native SDK origins and the Flutter plugin's referencing copies verifiable in
+  CI.
 - `.github/` contains the Dart and native SDK workflows. It keeps package
   verification in the repository where changes are reviewed.
 - `.specify/` contains Spec Kit templates, helper scripts, and the project

--- a/packages/android/barnard/README.md
+++ b/packages/android/barnard/README.md
@@ -68,31 +68,32 @@ See `examples/android-native` for a runnable minimal app.
 
 ## Relationship to the Flutter plugin
 
-This package is currently a **mirror**, not a move, of
-`packages/dart/barnard/android`:
+This package is the **canonical origin** for the shared Kotlin sources also
+shipped inside `packages/dart/barnard/android`. The Flutter plugin keeps a
+referencing mirror copy because pub.dev packages must be self-contained:
 
 - `BarnardCrypto.kt`, `BarnardSigning.kt`, `BarnardV2Policy.kt`, and
-  `BarnardIso8601.kt` are byte-for-byte copies of the Flutter plugin's
-  Flutter-free sources (pure JVM, no Android-framework or Flutter-embedding
-  dependency). `scripts/check-android-mirror.sh` (repo root) fails CI if
-  they drift.
+  `BarnardIso8601.kt` are the native origins for byte-for-byte copies in the
+  Flutter plugin (pure JVM, no Android-framework or Flutter-embedding
+  dependency). `scripts/sync-mirrors.sh` regenerates the copies, and
+  `scripts/check-android-mirror.sh` fails CI if they drift.
 - `BarnardEngine.kt` (Flutter-free port of `BarnardController`) and
   `BarnardIdentity.kt` (Flutter-free port of `BarnardIdentityController`)
-  are new files, not mirrors — the originals are woven into Flutter's
-  method-channel API (`MethodChannel`, `EventChannel`,
+  are native-only files, not mirrored sources. Their Flutter counterparts are
+  woven into the method-channel API (`MethodChannel`, `EventChannel`,
   `PluginRegistry.RequestPermissionsResultListener`) and cannot be copied
-  verbatim. They re-implement the same behavior with a Kotlin-first public
-  API (typed sealed events/callbacks instead of a method-channel
+  verbatim. The native files expose the same behavior through a Kotlin-first
+  public API (typed sealed events/callbacks instead of a method-channel
   dispatcher).
 
-**Why mirror instead of making the Flutter plugin depend on this
+**Why keep a mirror copy instead of making the Flutter plugin depend on this
 package**: the Flutter plugin's Android module resolves its Flutter
 embedding classpath dynamically from the Flutter SDK
 (`packages/dart/barnard/android/build.gradle`); making it depend on a
 sibling standalone Gradle library is possible but nontrivial to wire up
 safely across Flutter's own Gradle plugin, and this repo's CI/tooling here
-has no Flutter toolchain to validate that path end-to-end. Mirroring the
-pure, dependency-free sources with a byte-identical sync check is
-lower-risk for this first slice. Follow-up: evaluate making
-`packages/dart/barnard/android` depend on this package directly (true
-move) once that path is validated against a real Flutter build.
+has no Flutter toolchain to validate that path end-to-end. Synchronizing the
+pure, dependency-free sources from this native origin into the Flutter
+package, with a byte-identical drift check, is lower-risk for this first slice.
+Follow-up: evaluate making `packages/dart/barnard/android` depend on this
+package directly once that path is validated against a real Flutter build.

--- a/packages/swift/barnard/README.md
+++ b/packages/swift/barnard/README.md
@@ -47,33 +47,34 @@ See `examples/ios-native` for a runnable minimal app.
 
 ## Relationship to the Flutter plugin
 
-This package is currently a **mirror**, not a move, of
-`packages/dart/barnard/ios/barnard`:
+This package is the **canonical origin** for the shared Swift sources also
+shipped inside `packages/dart/barnard/ios/barnard`. The Flutter plugin keeps a
+referencing mirror copy because pub.dev packages must be self-contained:
 
 - The platform adapters (`BarnardCrypto.swift`, `Secp256k1.swift`,
   `BarnardSigning.swift`, `BarnardRpidGenerator.swift`,
   `BarnardV2Policy.swift`, `BarnardPlatformDependencies.swift`, and
-  `PrivacyInfo.xcprivacy`) are byte-for-byte copies of the Flutter plugin's
-  Flutter-free sources.
-- Every source under `Sources/BarnardCore` is also a byte-for-byte copy of the
-  corresponding Flutter plugin source under `Sources/barnard/BarnardCore`.
-  `scripts/check-swift-mirror.sh` (repo root) checks both groups and fails CI
-  if they drift.
+  `PrivacyInfo.xcprivacy`) are the native origins for byte-for-byte copies in
+  the Flutter plugin.
+- Every source under `Sources/BarnardCore` is likewise the native origin for
+  the corresponding Flutter plugin copy under `Sources/barnard/BarnardCore`.
+  `scripts/sync-mirrors.sh` regenerates both groups, and
+  `scripts/check-swift-mirror.sh` fails CI if they drift.
 - `BarnardEngine.swift` (Flutter-free port of `BarnardBleController`) and
   `BarnardIdentity.swift` (Flutter-free port of `BarnardIdentityController`)
-  are new files, not mirrors — the originals are woven into Flutter's
-  method-channel API (`FlutterEventSink`, `FlutterMethodCall`) and cannot be
-  copied verbatim. They re-implement the same behavior with a Swift-first
-  public API (closures/return values instead of a method-channel
-  dispatcher).
+  are native-only files, not mirrored sources. Their Flutter counterparts are
+  woven into the method-channel API (`FlutterEventSink`, `FlutterMethodCall`)
+  and cannot be copied verbatim. The native files expose the same behavior
+  through a Swift-first public API (closures/return values instead of a
+  method-channel dispatcher).
 
-**Why mirror instead of making the Flutter plugin depend on this package**:
-the Flutter plugin ships via a CocoaPods podspec
+**Why keep a mirror copy instead of making the Flutter plugin depend on this
+package**: the Flutter plugin ships via a CocoaPods podspec
 (`packages/dart/barnard/ios/barnard.podspec`); making a CocoaPods pod depend
 on a sibling local SwiftPM package is possible but nontrivial to wire up
 safely, and this repo's CI/tooling here has no Flutter/CocoaPods toolchain
-to validate that path end-to-end. Mirroring the pure, dependency-free
-sources with a byte-identical sync check is lower-risk for this first
-slice. Follow-up: evaluate making `packages/dart/barnard/ios` depend on
-this package directly (true move) once that path is validated against a
-real Flutter build.
+to validate that path end-to-end. Synchronizing the pure, dependency-free
+sources from this native origin into the Flutter package, with a byte-identical
+drift check, is lower-risk for this first slice. Follow-up: evaluate making
+`packages/dart/barnard/ios` depend on this package directly once that path is
+validated against a real Flutter build.

--- a/scripts/check-android-mirror.sh
+++ b/scripts/check-android-mirror.sh
@@ -1,45 +1,41 @@
 #!/usr/bin/env bash
 # Use of this source code is governed by the MIT license in /LICENSE.
 #
-# barnard#56: packages/android/barnard mirrors the Flutter-free crypto/RPID
-# sources from packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard
-# (byte-for-byte, not re-implemented) so the two packages cannot silently drift.
-# Fails with a diff if any mirrored file no longer matches its origin.
+# barnard#56 and #81: packages/android/barnard is the native origin for shared
+# Flutter-free crypto/RPID sources. The Flutter plugin keeps byte-for-byte
+# Dart-package mirrors so pub.dev releases remain self-contained. Fails with a
+# diff if any Dart mirror no longer matches its native origin.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-origin_dir="$repo_root/packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard"
-mirror_dir="$repo_root/packages/android/barnard/src/main/kotlin/org/levarac/barnard"
-
-mirrored_files=(
-  "BarnardCrypto.kt"
-  "BarnardSigning.kt"
-  "BarnardV2Policy.kt"
-  "BarnardIso8601.kt"
-)
+origin_dir="$repo_root/packages/android/barnard/src/main/kotlin/org/levarac/barnard"
+mirror_dir="$repo_root/packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard"
+source "$repo_root/scripts/mirror-manifest.sh"
 
 status=0
-for f in "${mirrored_files[@]}"; do
+for f in "${android_mirrored_files[@]}"; do
   origin_file="$origin_dir/$f"
   mirror_file="$mirror_dir/$f"
   if [[ ! -f "$origin_file" ]]; then
-    echo "MISSING origin: $origin_file"
+    echo "MISSING native origin: $origin_file"
     status=1
     continue
   fi
   if [[ ! -f "$mirror_file" ]]; then
-    echo "MISSING mirror: $mirror_file"
+    echo "MISSING Dart mirror: $mirror_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
     status=1
     continue
   fi
   if ! diff -q "$origin_file" "$mirror_file" >/dev/null 2>&1; then
-    echo "DRIFT: $origin_file != $mirror_file"
+    echo "DRIFT: Dart mirror $mirror_file differs from native origin $origin_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
     diff -u "$origin_file" "$mirror_file" || true
     status=1
   fi
 done
 
 if [[ $status -eq 0 ]]; then
-  echo "OK: packages/android/barnard mirrors match their origin byte-for-byte."
+  echo "OK: Dart Android mirrors match their native origins byte-for-byte."
 fi
-exit $status
+exit "$status"

--- a/scripts/check-swift-mirror.sh
+++ b/scripts/check-swift-mirror.sh
@@ -1,56 +1,44 @@
 #!/usr/bin/env bash
 # Use of this source code is governed by the MIT license in /LICENSE.
 #
-# barnard#56 and #80: packages/swift/barnard mirrors the Flutter-free
-# platform adapters and deterministic BarnardCore sources from
-# packages/dart/barnard/ios/barnard/Sources/barnard (byte-for-byte, not
-# re-implemented) so the two packages cannot silently drift.
-# Fails with a diff if any mirrored file no longer matches its origin.
+# barnard#56, #80, and #81: packages/swift/barnard is the native origin for
+# shared platform adapters and deterministic BarnardCore sources. The Flutter
+# plugin keeps byte-for-byte Dart-package mirrors so pub.dev releases remain
+# self-contained. Fails with a diff if any Dart mirror no longer matches its
+# native origin.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-plugin_dir="$repo_root/packages/dart/barnard/ios/barnard/Sources/barnard"
-package_dir="$repo_root/packages/swift/barnard/Sources"
-
-mirrored_pairs=(
-  "BarnardCrypto.swift|Barnard/BarnardCrypto.swift"
-  "Secp256k1.swift|Barnard/Secp256k1.swift"
-  "BarnardSigning.swift|Barnard/BarnardSigning.swift"
-  "BarnardRpidGenerator.swift|Barnard/BarnardRpidGenerator.swift"
-  "BarnardV2Policy.swift|Barnard/BarnardV2Policy.swift"
-  "BarnardPlatformDependencies.swift|Barnard/BarnardPlatformDependencies.swift"
-  "PrivacyInfo.xcprivacy|Barnard/PrivacyInfo.xcprivacy"
-  "BarnardCore/BarnardCoreCrypto.swift|BarnardCore/BarnardCoreCrypto.swift"
-  "BarnardCore/BarnardCorePolicy.swift|BarnardCore/BarnardCorePolicy.swift"
-  "BarnardCore/BarnardCorePrimitives.swift|BarnardCore/BarnardCorePrimitives.swift"
-  "BarnardCore/BarnardCoreSigning.swift|BarnardCore/BarnardCoreSigning.swift"
-  "BarnardCore/Secp256k1.swift|BarnardCore/Secp256k1.swift"
-)
+origin_dir="$repo_root/packages/swift/barnard/Sources"
+mirror_dir="$repo_root/packages/dart/barnard/ios/barnard/Sources/barnard"
+source "$repo_root/scripts/mirror-manifest.sh"
 
 status=0
-for pair in "${mirrored_pairs[@]}"; do
-  plugin_relative="${pair%%|*}"
-  package_relative="${pair#*|}"
-  plugin_file="$plugin_dir/$plugin_relative"
-  package_file="$package_dir/$package_relative"
-  if [[ ! -f "$plugin_file" ]]; then
-    echo "MISSING plugin source: $plugin_file"
+for pair in "${swift_mirrored_pairs[@]}"; do
+  origin_relative="${pair%%|*}"
+  mirror_relative="${pair#*|}"
+  origin_file="$origin_dir/$origin_relative"
+  mirror_file="$mirror_dir/$mirror_relative"
+  if [[ ! -f "$origin_file" ]]; then
+    echo "MISSING native origin: $origin_file"
     status=1
     continue
   fi
-  if [[ ! -f "$package_file" ]]; then
-    echo "MISSING package source: $package_file"
+  if [[ ! -f "$mirror_file" ]]; then
+    echo "MISSING Dart mirror: $mirror_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
     status=1
     continue
   fi
-  if ! diff -q "$plugin_file" "$package_file" >/dev/null 2>&1; then
-    echo "DRIFT: $plugin_file != $package_file"
-    diff -u "$plugin_file" "$package_file" || true
+  if ! diff -q "$origin_file" "$mirror_file" >/dev/null 2>&1; then
+    echo "DRIFT: Dart mirror $mirror_file differs from native origin $origin_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
+    diff -u "$origin_file" "$mirror_file" || true
     status=1
   fi
 done
 
 if [[ $status -eq 0 ]]; then
-  echo "OK: packages/swift/barnard mirrors match their origin byte-for-byte."
+  echo "OK: Dart Swift mirrors match their native origins byte-for-byte."
 fi
-exit $status
+exit "$status"

--- a/scripts/mirror-manifest.sh
+++ b/scripts/mirror-manifest.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Use of this source code is governed by the MIT license in /LICENSE.
+#
+# Explicit allowlists shared by the mirror checks and sync helper. Each Swift
+# pair is ordered native-origin-relative|Dart-mirror-relative.
+
+# shellcheck disable=SC2034  # This file is sourced by the check and sync scripts.
+swift_mirrored_pairs=(
+  "Barnard/BarnardCrypto.swift|BarnardCrypto.swift"
+  "Barnard/Secp256k1.swift|Secp256k1.swift"
+  "Barnard/BarnardSigning.swift|BarnardSigning.swift"
+  "Barnard/BarnardRpidGenerator.swift|BarnardRpidGenerator.swift"
+  "Barnard/BarnardV2Policy.swift|BarnardV2Policy.swift"
+  "Barnard/BarnardPlatformDependencies.swift|BarnardPlatformDependencies.swift"
+  "Barnard/PrivacyInfo.xcprivacy|PrivacyInfo.xcprivacy"
+  "BarnardCore/BarnardCoreCrypto.swift|BarnardCore/BarnardCoreCrypto.swift"
+  "BarnardCore/BarnardCorePolicy.swift|BarnardCore/BarnardCorePolicy.swift"
+  "BarnardCore/BarnardCorePrimitives.swift|BarnardCore/BarnardCorePrimitives.swift"
+  "BarnardCore/BarnardCoreSigning.swift|BarnardCore/BarnardCoreSigning.swift"
+  "BarnardCore/Secp256k1.swift|BarnardCore/Secp256k1.swift"
+)
+
+android_mirrored_files=(
+  "BarnardCrypto.kt"
+  "BarnardSigning.kt"
+  "BarnardV2Policy.kt"
+  "BarnardIso8601.kt"
+)

--- a/scripts/sync-mirrors.sh
+++ b/scripts/sync-mirrors.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Use of this source code is governed by the MIT license in /LICENSE.
+#
+# Regenerates the Flutter plugin's referencing mirror copies from the canonical
+# native Swift and Android packages.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+# shellcheck source=scripts/mirror-manifest.sh
+source "$script_dir/mirror-manifest.sh"
+
+swift_origin_dir="$repo_root/packages/swift/barnard/Sources"
+swift_mirror_dir="$repo_root/packages/dart/barnard/ios/barnard/Sources/barnard"
+android_origin_dir="$repo_root/packages/android/barnard/src/main/kotlin/org/levarac/barnard"
+android_mirror_dir="$repo_root/packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard"
+
+require_origin() {
+  local origin_file="$1"
+  if [[ ! -f "$origin_file" ]]; then
+    echo "MISSING native origin: $origin_file" >&2
+    return 1
+  fi
+}
+
+# Validate the complete source set before copying so a missing later origin
+# cannot leave the Dart mirrors partially synchronized.
+for pair in "${swift_mirrored_pairs[@]}"; do
+  require_origin "$swift_origin_dir/${pair%%|*}"
+done
+for relative_path in "${android_mirrored_files[@]}"; do
+  require_origin "$android_origin_dir/$relative_path"
+done
+
+synced_count=0
+
+sync_file() {
+  local origin_file="$1"
+  local mirror_file="$2"
+
+  if cmp -s "$origin_file" "$mirror_file"; then
+    return
+  fi
+
+  mkdir -p "$(dirname "$mirror_file")"
+  cp "$origin_file" "$mirror_file"
+  echo "SYNCED: $origin_file -> $mirror_file"
+  synced_count=$((synced_count + 1))
+}
+
+for pair in "${swift_mirrored_pairs[@]}"; do
+  origin_relative="${pair%%|*}"
+  mirror_relative="${pair#*|}"
+  sync_file \
+    "$swift_origin_dir/$origin_relative" \
+    "$swift_mirror_dir/$mirror_relative"
+done
+
+for relative_path in "${android_mirrored_files[@]}"; do
+  sync_file \
+    "$android_origin_dir/$relative_path" \
+    "$android_mirror_dir/$relative_path"
+done
+
+if [[ $synced_count -eq 0 ]]; then
+  echo "OK: Dart mirrors already match their native origins."
+else
+  echo "OK: synchronized $synced_count Dart mirror file(s) from native origins."
+fi


### PR DESCRIPTION
## Summary

- make `packages/swift/barnard` and `packages/android/barnard` the canonical origins for the existing shared-source mirror sets
- keep the exact existing allowlists (12 Swift pairs and 4 Android files) in one manifest shared by checks and synchronization
- add `scripts/sync-mirrors.sh` to regenerate the Flutter plugin's referencing copies from native origins, with a complete origin preflight before any copy
- update the root/package documentation and native CI comments to describe the new direction consistently

## Validation

```text
$ ./scripts/check-swift-mirror.sh
OK: Dart Swift mirrors match their native origins byte-for-byte.

$ ./scripts/check-android-mirror.sh
OK: Dart Android mirrors match their native origins byte-for-byte.

$ ./scripts/sync-mirrors.sh
OK: Dart mirrors already match their native origins.
$ ./scripts/sync-mirrors.sh
OK: Dart mirrors already match their native origins.
$ git status --short
# no output

$ bash -n scripts/check-swift-mirror.sh scripts/check-android-mirror.sh scripts/mirror-manifest.sh scripts/sync-mirrors.sh
$ shellcheck scripts/check-swift-mirror.sh scripts/check-android-mirror.sh scripts/mirror-manifest.sh scripts/sync-mirrors.sh
# both exit 0
```

A scratch edit to one Dart-side Swift mirror and one Dart-side Kotlin mirror made both checks exit 1 with:

```text
Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly.
```

Running the sync helper restored both Dart files from the native origins. An isolated missing-origin regression fixture also verified that preflight failure leaves earlier mirrors untouched.

The targeted old-direction wording search exits 0 with no matches.

## Compatibility, security, and privacy

- no public API, schema, spec, signing, crypto, or on-wire payload changes
- no device-unique persistent identifiers added on-wire
- no source files changed after the scratch probes were mechanically restored
- React Native was not part of the existing byte-for-byte checks, so its current behavioral coverage remains unchanged

Closes #81
Refs #80