### PR TITLE
fix(android): memoize RPID payload derivation

### DIFF
--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -118,7 +118,16 @@ public class BarnardEngine(private val appContext: Context) {
     // MARK: - Event Mode
 
     private var eventCode: String? = null
+    @Volatile
     private var currentTek: ByteArray = ByteArray(16)
+
+    private data class CachedReporterPayload(
+        val enin: UInt,
+        val tek: ByteArray,
+        val payload: ByteArray,
+    )
+
+    private var cachedReporterPayload: CachedReporterPayload? = null
 
     // MARK: - Discovery State
 
@@ -723,15 +732,25 @@ public class BarnardEngine(private val appContext: Context) {
     /**
      * Build the 17-byte RPID wire form at [nowMs], atomically deriving ENIN
      * and RPI from the same timestamp.
+     *
+     * A cache hit returns the same array instance; callers must not mutate it.
      */
+    @Synchronized
     private fun computePayload(nowMs: Long): ByteArray {
         val enin = currentEnin(nowMs)
-        val rpik = BarnardCrypto.deriveRpik(currentTek)
+        val tek = currentTek
+        val cached = cachedReporterPayload
+        if (cached != null && cached.enin == enin && cached.tek.contentEquals(tek)) {
+            return cached.payload
+        }
+
+        val rpik = BarnardCrypto.deriveRpik(tek)
         val rpi = BarnardCrypto.generateRpi(rpik, enin)
 
         val payload = ByteArray(17)
         payload[0] = (formatVersion and 0xFF).toByte()
         System.arraycopy(rpi, 0, payload, 1, 16)
+        cachedReporterPayload = CachedReporterPayload(enin, tek.copyOf(), payload)
         return payload
     }
 

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEnginePayloadCacheTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEnginePayloadCacheTest.kt
@@ -1,0 +1,88 @@
+// Use of this source code is governed by a BSD-style license.
+
+package org.levarac.barnard
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BarnardEnginePayloadCacheTest {
+    private lateinit var context: Context
+    private lateinit var computePayload: Method
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        computePayload = BarnardEngine::class.java
+            .getDeclaredMethod("computePayload", Long::class.javaPrimitiveType)
+            .apply { isAccessible = true }
+    }
+
+    @Test
+    fun computePayloadReusesExactByteArrayWithinSameEninAndTek() {
+        val engine = BarnardEngine(context)
+
+        val first = engine.computePayloadAt(1_000L)
+        val second = engine.computePayloadAt(2_000L)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun computePayloadRecomputesAcrossEninBoundary() {
+        val engine = BarnardEngine(context)
+
+        val beforeBoundary = engine.computePayloadAt(299_999L)
+        val afterBoundary = engine.computePayloadAt(300_000L)
+
+        assertNotSame(beforeBoundary, afterBoundary)
+        assertFalse(beforeBoundary.contentEquals(afterBoundary))
+    }
+
+    @Test
+    fun computePayloadRecomputesWhenTekChangesAndReturnsAfterLeave() {
+        val engine = BarnardEngine(context)
+        val anonymous = engine.computePayloadAt(1_000L)
+
+        engine.joinEvent("payload-cache-test")
+        val joined = engine.computePayloadAt(1_000L)
+        engine.leaveEvent()
+        val left = engine.computePayloadAt(1_000L)
+
+        assertNotSame(anonymous, joined)
+        assertFalse(anonymous.contentEquals(joined))
+        assertNotSame(joined, left)
+        assertFalse(joined.contentEquals(left))
+        assertNotSame(anonymous, left)
+        assertTrue(anonymous.contentEquals(left))
+    }
+
+    @Test
+    fun computePayloadSerializesCacheAccessAcrossThreads() {
+        assertTrue(Modifier.isSynchronized(computePayload.modifiers))
+    }
+
+    @Test
+    fun currentTekPublishesChangesAcrossThreads() {
+        val field = BarnardEngine::class.java.getDeclaredField("currentTek")
+
+        assertTrue(Modifier.isVolatile(field.modifiers))
+    }
+
+    private fun BarnardEngine.computePayloadAt(nowMs: Long): ByteArray =
+        computePayload.invoke(this, nowMs) as ByteArray
+}


### PR DESCRIPTION
## Summary

Adds single-slot memoization for `BarnardEngine.computePayload` keyed by ENIN and the contents of a copied TEK. This ports the payload-derivation optimization from PR #75 to the standalone Android package.

- Returns the cached 17-byte payload only when both ENIN and TEK contents match.
- Recomputes at ENIN boundaries and across event TEK rotations; leaving an event restores the original anonymous payload.
- Uses `@Synchronized` cache access and a `@Volatile` TEK reference.
- Stores a 16-byte TEK copy and uses `contentEquals`, avoiding hash-collision-based cache hits.

## Compatibility and privacy

No public API, schema, or on-wire payload format changes. The existing privacy invariant remains unchanged: no device-unique persistent identifier is added to BLE payloads.

## Verification

`cd packages/android/barnard && JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ./gradlew testDebugUnitTest` — BUILD SUCCESSFUL.

Refs #76