### PR TITLE
ci: run push CI on release/** branches

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -3,7 +3,7 @@ name: Dart CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ main, "release/**" ]
 
 jobs:
   flutter:

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -3,7 +3,7 @@ name: Native SDK CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ main, "release/**" ]
 
 jobs:
   swift-package:

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -22,7 +22,7 @@ on:
       - "packages/swift/**"
       - ".github/workflows/swift-android.yml"
   push:
-    branches: [ main ]
+    branches: [ main, "release/**" ]
     paths:
       - "Package.swift"
       - "packages/swift/**"


### PR DESCRIPTION
Adds `release/**` to the push triggers of all three workflows (dart, native-sdk, swift-android).

**Why**: `release/0.2.0` has had two squash merges (#91, #93) with zero post-merge CI runs — every workflow triggered on `push: branches: [main]` only. PR checks validate against the base at PR time, so the merged combined state of a release branch is never exercised until the main-integration PR. With the large owner-key PR (#92) heading to this branch, the gap grows.

**Verification**: the merge of this PR is itself the test — it should produce the first push-triggered runs on `release/0.2.0`.

Found by routine repo sweep. Milestone 0.2.0.