### PR TITLE
feat(core): implement owner-key identity proofs

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -10,6 +10,15 @@ on:
     branches: [ main, "release/**" ]
 
 jobs:
+  schema-privacy-invariant:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enforce schema privacy invariant
+        run: |
+          python3 scripts/check-schema-privacy-invariant.py --self-test
+          python3 scripts/check-wallet-binding-schema.py
+
   swift-package:
     # Flutter-free: builds/tests packages/swift/barnard directly. No Flutter
     # toolchain is installed in this job (barnard#56 acceptance criterion:

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -120,8 +120,15 @@ jobs:
             barnard_core_compute_event_code_hash \
             barnard_core_display_id4 \
             barnard_core_sha256 \
+            barnard_core_keccak256 \
+            barnard_core_eip191_digest \
             barnard_core_derive_signing_keypair \
+            barnard_core_derive_owner_keypair \
             barnard_core_sign_recoverable \
+            barnard_core_build_self_proof_message \
+            barnard_core_verify_self_proof \
+            barnard_core_classify_wallet_signature \
+            barnard_core_verify_wallet_binding \
             barnard_core_should_emit_rssi_update \
             barnard_core_should_serve_gatt_display_id; do
             if ! grep -qw "$symbol" /tmp/exported-symbols.txt; then
@@ -129,7 +136,7 @@ jobs:
               exit 1
             fi
           done
-          echo "OK: all 13 C ABI symbols exported for $ANDROID_TRIPLE"
+          echo "OK: all 20 C ABI symbols exported for $ANDROID_TRIPLE"
 
       - name: C host consumption proof (Linux native, same C ABI)
         # The Android .so cannot execute on the runner; this builds the same

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -174,4 +174,9 @@ public enum BarnardCoreCrypto {
   public static func sha256(_ bytes: [UInt8]) -> [UInt8] {
     BarnardCorePrimitives.sha256(bytes)
   }
+
+  /// Ethereum Keccak-256 (legacy Keccak padding, not NIST SHA3-256).
+  public static func keccak256(_ bytes: [UInt8]) -> [UInt8] {
+    BarnardCorePrimitives.keccak256(bytes)
+  }
 }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -1,0 +1,691 @@
+// Use of this source code is governed by a BSD-style license.
+
+public enum BarnardCoreWalletSignatureClassification: Int32 {
+  case invalid = 0
+  case validEoaShape = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreWalletBindingVerification: Int32 {
+  case invalid = 0
+  case valid = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreAccountUnbindingSigner: Int32 {
+  case owner = 0
+  case wallet = 1
+}
+
+public enum BarnardCoreWalletVerifierVerdict: Equatable {
+  case valid(verifiedAtUnixSeconds: Int64)
+  case invalid(verifiedAtUnixSeconds: Int64)
+  case unverified
+}
+
+/// Host-defined smart-wallet verification port.
+///
+/// Contract signature validity can change with contract state. Implementations
+/// therefore attach their observation time to every valid or invalid verdict.
+/// BarnardCore intentionally provides no RPC implementation.
+public protocol BarnardCoreWalletVerifier {
+  func verify(
+    address: [UInt8],
+    digest: [UInt8],
+    signature: [UInt8]
+  ) -> BarnardCoreWalletVerifierVerdict
+}
+
+public extension BarnardCoreSigning {
+  static func buildAccountBindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to bind this wallet to a Levarac owner key.",
+      "",
+      "This signature authorizes no transaction and moves no assets.",
+      "",
+      "Domain-Tag: \(accountBindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
+  static func buildSelfProofMessage(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      eventIdHash.count == 32,
+      isValidCompressedPublicKey(eventSigningPublicKey),
+      eninStart <= eninEnd,
+      isValidCompressedPublicKey(ownerPublicKey)
+    else {
+      return nil
+    }
+
+    return Array(selfProofDomainTag.utf8)
+      + eventIdHash
+      + eventSigningPublicKey
+      + uint64BigEndian(eninStart)
+      + uint64BigEndian(eninEnd)
+      + ownerPublicKey
+  }
+
+  static func signSelfProof(
+    ownerPrivateKey: [UInt8],
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifySelfProof(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildWalletAcknowledgementMessage(
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard walletAddress.count == 20, !walletSignature.isEmpty else {
+      return nil
+    }
+    return Array(walletAcknowledgementDomainTag.utf8)
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signWalletAcknowledgement(
+    ownerPrivateKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(ownerPrivateKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyWalletAcknowledgement(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildAccountRotationMessage(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(previousOwnerPublicKey),
+      isValidCompressedPublicKey(successorOwnerPublicKey),
+      previousOwnerPublicKey != successorOwnerPublicKey
+    else {
+      return nil
+    }
+    return Array(accountRotationDomainTag.utf8)
+      + previousOwnerPublicKey
+      + successorOwnerPublicKey
+  }
+
+  static func signAccountRotation(
+    previousOwnerPrivateKey: [UInt8],
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: previousOwnerPrivateKey) == previousOwnerPublicKey,
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: previousOwnerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountRotation(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: previousOwnerPublicKey
+    )
+  }
+
+  static func buildAccountUnbindingMessage(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      walletAddress.count == 20,
+      !walletSignature.isEmpty
+    else {
+      return nil
+    }
+    return Array(accountUnbindingDomainTag.utf8)
+      + ownerPublicKey
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signAccountUnbinding(
+    signerPrivateKey: [UInt8],
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(signerPrivateKey),
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: signerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountUnbinding(
+    signer: BarnardCoreAccountUnbindingSigner,
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      ),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        signature,
+        messageHash32: BarnardCorePrimitives.sha256(message)
+      )
+    else {
+      return false
+    }
+
+    switch signer {
+    case .owner:
+      return recoveredPublicKey == ownerPublicKey
+    case .wallet:
+      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == walletAddress
+    }
+  }
+
+  static func classifyWalletSignature(
+    _ signature: [UInt8]
+  ) -> BarnardCoreWalletSignatureClassification {
+    let erc6492Magic = Array(
+      repeating: [UInt8(0x64), UInt8(0x92)],
+      count: 16
+    )
+      .flatMap { $0 }
+    if signature.count >= erc6492Magic.count,
+      signature.suffix(erc6492Magic.count).elementsEqual(erc6492Magic)
+    {
+      return .smartWalletUnsupported
+    }
+    return signature.count == 65 ? .validEoaShape : .invalid
+  }
+
+  static func verifyWalletBinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8],
+    acknowledgement: BarnardCoreRecoverableSignature
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountBindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress,
+      verifyWalletAcknowledgement(
+        ownerPublicKey: expectedOwnerPublicKey,
+        walletAddress: expectedWalletAddress,
+        walletSignature: walletSignature,
+        signature: acknowledgement
+      )
+    else {
+      return .invalid
+    }
+    return .valid
+  }
+
+  private static func isCanonicalAccountBindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 10,
+      lines[1].isEmpty,
+      lines[2] == "This signature authorizes no transaction and moves no assets.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountBindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))"
+    else {
+      return false
+    }
+
+    let headerSuffix = " wants to bind this wallet to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[8].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[8].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[9].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[9].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func verifyNativeSignature(
+    _ signature: BarnardCoreRecoverableSignature,
+    message: [UInt8],
+    expectedPublicKey: [UInt8]
+  ) -> Bool {
+    strictRecoveredPublicKey(
+      signature,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    ) == expectedPublicKey
+  }
+
+  private static func strictRecoveredPublicKey(
+    _ signature: BarnardCoreRecoverableSignature,
+    messageHash32: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      signature.r.count == 32,
+      signature.s.count == 32,
+      messageHash32.count == 32,
+      signature.v == 0 || signature.v == 1
+    else {
+      return nil
+    }
+
+    let r = BarnardCoreSecp256k1.UInt256(bytes: signature.r)
+    let s = BarnardCoreSecp256k1.UInt256(bytes: signature.s)
+    guard
+      !r.isZero,
+      r < BarnardCoreSecp256k1.curveOrder,
+      !s.isZero,
+      s < BarnardCoreSecp256k1.curveOrder,
+      s <= BarnardCoreSecp256k1.curveOrder.shiftedRight1()
+    else {
+      return nil
+    }
+
+    return recoverPublicKey(
+      recoveryId: signature.v,
+      r: signature.r,
+      s: signature.s,
+      messageHash32: messageHash32
+    )
+  }
+
+  private static func normalizedEthereumRecoveryId(_ v: UInt8) -> Int? {
+    switch v {
+    case 0, 1:
+      return Int(v)
+    case 27, 28:
+      return Int(v - 27)
+    default:
+      return nil
+    }
+  }
+
+  private static func isValidPrivateKey(_ privateKey: [UInt8]) -> Bool {
+    guard privateKey.count == 32 else {
+      return false
+    }
+    let scalar = BarnardCoreSecp256k1.UInt256(bytes: privateKey)
+    return !scalar.isZero && scalar < BarnardCoreSecp256k1.curveOrder
+  }
+
+  private static func publicKey(forPrivateKey privateKey: [UInt8]) -> [UInt8]? {
+    guard isValidPrivateKey(privateKey) else {
+      return nil
+    }
+    let point = BarnardCoreSecp256k1.multiply(
+      BarnardCoreSecp256k1.UInt256(bytes: privateKey),
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSecp256k1.compress(point)
+  }
+
+  private static func isValidCompressedPublicKey(_ publicKey: [UInt8]) -> Bool {
+    serializeUncompressedPublicKey(publicKey) != nil
+  }
+
+  private static func uint64BigEndian(_ value: UInt64) -> [UInt8] {
+    stride(from: 56, through: 0, by: -8).map {
+      UInt8((value >> UInt64($0)) & 0xff)
+    }
+  }
+
+  private static func lowercaseHex(_ bytes: [UInt8]) -> String {
+    bytes.map {
+      let value = String($0, radix: 16)
+      return value.count == 1 ? "0" + value : value
+    }.joined()
+  }
+
+  private static func decodeLowercaseHex(_ value: String) -> [UInt8]? {
+    let bytes = Array(value.utf8)
+    guard bytes.count.isMultiple(of: 2) else {
+      return nil
+    }
+    var output: [UInt8] = []
+    output.reserveCapacity(bytes.count / 2)
+    for index in stride(from: 0, to: bytes.count, by: 2) {
+      func nibble(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 0x30...0x39:
+          return byte - 0x30
+        case 0x61...0x66:
+          return byte - 0x61 + 10
+        default:
+          return nil
+        }
+      }
+      guard let high = nibble(bytes[index]), let low = nibble(bytes[index + 1])
+      else {
+        return nil
+      }
+      output.append((high << 4) | low)
+    }
+    return output
+  }
+
+  private static func isCanonicalDomain(_ domain: String) -> Bool {
+    let bytes = Array(domain.utf8)
+    guard
+      !bytes.isEmpty,
+      isLowercaseAsciiLetterOrDigit(bytes[0])
+    else {
+      return false
+    }
+
+    var colonIndex: Int?
+    for (index, byte) in bytes.enumerated() {
+      if colonIndex != nil {
+        if !(0x30...0x39).contains(byte) {
+          return false
+        }
+        continue
+      }
+      switch byte {
+      case 0x61...0x7a, 0x30...0x39, 0x2d, 0x2e:
+        break
+      case 0x3a:
+        if index == 0 {
+          return false
+        }
+        colonIndex = index
+      default:
+        return false
+      }
+    }
+
+    let hostEnd = colonIndex ?? bytes.count
+    guard
+      hostEnd > 0,
+      isLowercaseAsciiLetterOrDigit(bytes[hostEnd - 1])
+    else {
+      return false
+    }
+    guard let colonIndex else {
+      return true
+    }
+
+    let portBytes = bytes.dropFirst(colonIndex + 1)
+    guard
+      !portBytes.isEmpty,
+      portBytes.count <= 5,
+      portBytes.allSatisfy({ (0x30...0x39).contains($0) }),
+      (portBytes.count == 1 || portBytes.first != 0x30),
+      let port = UInt32(String(decoding: portBytes, as: UTF8.self)),
+      port <= 65_535
+    else {
+      return false
+    }
+    return true
+  }
+
+  private static func isLowercaseAsciiLetterOrDigit(_ byte: UInt8) -> Bool {
+    (0x61...0x7a).contains(byte) || (0x30...0x39).contains(byte)
+  }
+
+  private static func isCanonicalIssuedAt(_ value: String) -> Bool {
+    let bytes = Array(value.utf8)
+    guard
+      bytes.count == 20,
+      bytes[4] == 0x2d,
+      bytes[7] == 0x2d,
+      bytes[10] == 0x54,
+      bytes[13] == 0x3a,
+      bytes[16] == 0x3a,
+      bytes[19] == 0x5a
+    else {
+      return false
+    }
+    let digitPositions = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18]
+    guard digitPositions.allSatisfy({
+      (0x30...0x39).contains(bytes[$0])
+    }) else {
+      return false
+    }
+
+    func decimal(_ first: Int, _ second: Int) -> Int {
+      Int(bytes[first] - 0x30) * 10 + Int(bytes[second] - 0x30)
+    }
+    let year = decimal(0, 1) * 100 + decimal(2, 3)
+    let month = decimal(5, 6)
+    let day = decimal(8, 9)
+    let hour = decimal(11, 12)
+    let minute = decimal(14, 15)
+    let second = decimal(17, 18)
+    guard
+      (1...12).contains(month),
+      (0...23).contains(hour),
+      (0...59).contains(minute),
+      (0...59).contains(second)
+    else {
+      return false
+    }
+
+    var daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    let isLeapYear = year.isMultiple(of: 4)
+      && (!year.isMultiple(of: 100) || year.isMultiple(of: 400))
+    if isLeapYear {
+      daysInMonth[1] = 29
+    }
+    return (1...daysInMonth[month - 1]).contains(day)
+  }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -64,6 +64,7 @@ public extension BarnardCoreSigning {
       "Wallet: 0x\(lowercaseHex(walletAddress))",
       "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
       "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
       "Nonce: 0x\(lowercaseHex(nonce))",
       "Issued-At: \(issuedAt)",
     ].joined(separator: "\n")
@@ -404,13 +405,14 @@ public extension BarnardCoreSigning {
       omittingEmptySubsequences: false
     ).map(String.init)
     guard
-      lines.count == 10,
+      lines.count == 11,
       lines[1].isEmpty,
       lines[2] == "This signature authorizes no transaction and moves no assets.",
       lines[3].isEmpty,
       lines[4] == "Domain-Tag: \(accountBindingDomainTag)",
       lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
-      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))"
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
     else {
       return false
     }
@@ -437,9 +439,9 @@ public extension BarnardCoreSigning {
 
     let noncePrefix = "Nonce: 0x"
     guard
-      lines[8].hasPrefix(noncePrefix),
+      lines[9].hasPrefix(noncePrefix),
       let nonce = decodeLowercaseHex(
-        String(lines[8].dropFirst(noncePrefix.count))
+        String(lines[9].dropFirst(noncePrefix.count))
       ),
       nonce.count == 16
     else {
@@ -447,10 +449,10 @@ public extension BarnardCoreSigning {
     }
 
     let issuedAtPrefix = "Issued-At: "
-    guard lines[9].hasPrefix(issuedAtPrefix) else {
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
       return false
     }
-    let issuedAt = String(lines[9].dropFirst(issuedAtPrefix.count))
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
 
     guard let reconstructed = buildAccountBindingText(
       domain: domain,

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCorePrimitives.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCorePrimitives.swift
@@ -1,6 +1,43 @@
 // Use of this source code is governed by a BSD-style license.
 
 enum BarnardCorePrimitives {
+  static func keccak256(_ input: [UInt8]) -> [UInt8] {
+    let rate = 136
+    var state = [UInt64](repeating: 0, count: 25)
+    var offset = 0
+
+    while input.count - offset >= rate {
+      absorbKeccakBlock(
+        Array(input[offset..<(offset + rate)]),
+        into: &state
+      )
+      keccakF1600(&state)
+      offset += rate
+    }
+
+    var finalBlock = [UInt8](repeating: 0, count: rate)
+    let remaining = input.count - offset
+    if remaining > 0 {
+      for index in 0..<remaining {
+        finalBlock[index] = input[offset + index]
+      }
+    }
+    finalBlock[remaining] ^= 0x01
+    finalBlock[rate - 1] ^= 0x80
+    absorbKeccakBlock(finalBlock, into: &state)
+    keccakF1600(&state)
+
+    var output: [UInt8] = []
+    output.reserveCapacity(32)
+    for byteIndex in 0..<32 {
+      let lane = state[byteIndex / 8]
+      output.append(
+        UInt8((lane >> UInt64(8 * (byteIndex % 8))) & 0xff)
+      )
+    }
+    return output
+  }
+
   static func sha256(_ input: [UInt8]) -> [UInt8] {
     let constants: [UInt32] = [
       0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
@@ -155,6 +192,88 @@ enum BarnardCorePrimitives {
 
   private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {
     (value >> count) | (value << (32 - count))
+  }
+
+  private static func absorbKeccakBlock(
+    _ block: [UInt8],
+    into state: inout [UInt64]
+  ) {
+    for index in block.indices {
+      state[index / 8] ^=
+        UInt64(block[index]) << UInt64(8 * (index % 8))
+    }
+  }
+
+  private static func keccakF1600(_ state: inout [UInt64]) {
+    let roundConstants: [UInt64] = [
+      0x0000000000000001, 0x0000000000008082,
+      0x800000000000808a, 0x8000000080008000,
+      0x000000000000808b, 0x0000000080000001,
+      0x8000000080008081, 0x8000000000008009,
+      0x000000000000008a, 0x0000000000000088,
+      0x0000000080008009, 0x000000008000000a,
+      0x000000008000808b, 0x800000000000008b,
+      0x8000000000008089, 0x8000000000008003,
+      0x8000000000008002, 0x8000000000000080,
+      0x000000000000800a, 0x800000008000000a,
+      0x8000000080008081, 0x8000000000008080,
+      0x0000000080000001, 0x8000000080008008,
+    ]
+    let rotationOffsets: [Int] = [
+      0, 1, 62, 28, 27,
+      36, 44, 6, 55, 20,
+      3, 10, 43, 25, 39,
+      41, 45, 15, 21, 8,
+      18, 2, 61, 56, 14,
+    ]
+
+    for roundConstant in roundConstants {
+      var columns = [UInt64](repeating: 0, count: 5)
+      for x in 0..<5 {
+        columns[x] =
+          state[x]
+          ^ state[x + 5]
+          ^ state[x + 10]
+          ^ state[x + 15]
+          ^ state[x + 20]
+      }
+      for x in 0..<5 {
+        let delta =
+          columns[(x + 4) % 5]
+          ^ rotateLeft(columns[(x + 1) % 5], by: 1)
+        for y in 0..<5 {
+          state[x + 5 * y] ^= delta
+        }
+      }
+
+      var permuted = [UInt64](repeating: 0, count: 25)
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let source = x + 5 * y
+          let destination = y + 5 * ((2 * x + 3 * y) % 5)
+          permuted[destination] = rotateLeft(
+            state[source],
+            by: rotationOffsets[source]
+          )
+        }
+      }
+
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let row = 5 * y
+          state[x + row] =
+            permuted[x + row]
+            ^ ((~permuted[(x + 1) % 5 + row])
+              & permuted[(x + 2) % 5 + row])
+        }
+      }
+      state[0] ^= roundConstant
+    }
+  }
+
+  private static func rotateLeft(_ value: UInt64, by count: Int) -> UInt64 {
+    guard count != 0 else { return value }
+    return (value << UInt64(count)) | (value >> UInt64(64 - count))
   }
 
   private static let aesSBox: [UInt8] = [

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreSigning.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreSigning.swift
@@ -3,12 +3,23 @@
 public struct BarnardCoreSigningKeyPair {
   public let privateKey: [UInt8]
   public let publicKeyCompressed: [UInt8]
+
+  public init(privateKey: [UInt8], publicKeyCompressed: [UInt8]) {
+    self.privateKey = privateKey
+    self.publicKeyCompressed = publicKeyCompressed
+  }
 }
 
 public struct BarnardCoreRecoverableSignature {
   public let r: [UInt8]
   public let s: [UInt8]
   public let v: Int
+
+  public init(r: [UInt8], s: [UInt8], v: Int) {
+    self.r = r
+    self.s = s
+    self.v = v
+  }
 }
 
 public struct BarnardCoreRpidOwnershipProof {
@@ -21,8 +32,14 @@ public struct BarnardCoreRpidOwnershipProof {
 
 public enum BarnardCoreSigning {
   public static let signingKeyInfo = "barnard-sign"
+  public static let ownerKeyInfo = "barnard-owner"
   public static let rpidProofDomainTag = "barnard-rpid-proof:v1"
   public static let keyBindingDomainTag = "barnard-key-binding:v1"
+  public static let selfProofDomainTag = "barnard-self-proof:v1"
+  public static let walletAcknowledgementDomainTag = "barnard-wallet-ack:v1"
+  public static let accountRotationDomainTag = "barnard-account-rotation:v1"
+  public static let accountUnbindingDomainTag = "barnard-account-unbinding:v1"
+  public static let accountBindingDomainTag = "barnard-account-binding:v1"
 
   public static func deriveSigningKeyPair(
     deviceSecret: [UInt8],
@@ -52,6 +69,86 @@ public enum BarnardCoreSigning {
       privateKey: privateKey.bytes,
       publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
     )
+  }
+
+  public static func deriveOwnerKeyPair(
+    accountSecret: [UInt8]
+  ) -> BarnardCoreSigningKeyPair {
+    precondition(accountSecret.count == 32, "accountSecret must be 32 bytes")
+    var seed = BarnardCorePrimitives.hkdfSha256(
+      inputKeyMaterial: accountSecret,
+      info: Array(ownerKeyInfo.utf8),
+      outputByteCount: 32
+    )
+    var privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+      BarnardCoreSecp256k1.UInt256(bytes: seed),
+      BarnardCoreSecp256k1.curveOrder
+    )
+    while privateKey.isZero {
+      seed = BarnardCorePrimitives.sha256(seed)
+      privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+        BarnardCoreSecp256k1.UInt256(bytes: seed),
+        BarnardCoreSecp256k1.curveOrder
+      )
+    }
+    let publicPoint = BarnardCoreSecp256k1.multiply(
+      privateKey,
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSigningKeyPair(
+      privateKey: privateKey.bytes,
+      publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
+    )
+  }
+
+  public static func serializeUncompressedPublicKey(
+    _ compressedPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      compressedPublicKey.count == 33,
+      compressedPublicKey[0] == 0x02 || compressedPublicKey[0] == 0x03
+    else {
+      return nil
+    }
+    let x = BarnardCoreSecp256k1.UInt256(
+      bytes: Array(compressedPublicKey.dropFirst())
+    )
+    guard
+      x < BarnardCoreSecp256k1.fieldPrime,
+      let point = BarnardCoreSecp256k1.decompress(
+        x: x,
+        yIsOdd: compressedPublicKey[0] == 0x03
+      )
+    else {
+      return nil
+    }
+    return BarnardCoreSecp256k1.serializeUncompressed(point)
+  }
+
+  public static func ethereumAddress(
+    publicKeyCompressed: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      let uncompressed = serializeUncompressedPublicKey(publicKeyCompressed),
+      uncompressed.count == 65
+    else {
+      return nil
+    }
+    return Array(
+      BarnardCorePrimitives.keccak256(Array(uncompressed.dropFirst())).suffix(20)
+    )
+  }
+
+  public static func computeEip191Digest(text: String) -> [UInt8] {
+    computeEip191Digest(messageBytes: Array(text.utf8))
+  }
+
+  public static func computeEip191Digest(messageBytes: [UInt8]) -> [UInt8] {
+    let prefix =
+      [UInt8(0x19)]
+      + Array("Ethereum Signed Message:\n".utf8)
+      + Array(String(messageBytes.count).utf8)
+    return BarnardCorePrimitives.keccak256(prefix + messageBytes)
   }
 
   public static func signRecoverable(

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/Secp256k1.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/Secp256k1.swift
@@ -300,6 +300,13 @@ enum BarnardCoreSecp256k1 {
     return [y.testBit(0) ? 0x03 : 0x02] + x.bytes
   }
 
+  static func serializeUncompressed(_ point: Point) -> [UInt8] {
+    guard let x = point.x, let y = point.y else {
+      return []
+    }
+    return [0x04] + x.bytes + y.bytes
+  }
+
   static func decompress(x: UInt256, yIsOdd: Bool) -> Point? {
     let xCubed = Field.multiplyMod(
       Field.multiplyMod(x, x, fieldPrime),

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -174,4 +174,9 @@ public enum BarnardCoreCrypto {
   public static func sha256(_ bytes: [UInt8]) -> [UInt8] {
     BarnardCorePrimitives.sha256(bytes)
   }
+
+  /// Ethereum Keccak-256 (legacy Keccak padding, not NIST SHA3-256).
+  public static func keccak256(_ bytes: [UInt8]) -> [UInt8] {
+    BarnardCorePrimitives.keccak256(bytes)
+  }
 }

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -1,0 +1,691 @@
+// Use of this source code is governed by a BSD-style license.
+
+public enum BarnardCoreWalletSignatureClassification: Int32 {
+  case invalid = 0
+  case validEoaShape = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreWalletBindingVerification: Int32 {
+  case invalid = 0
+  case valid = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreAccountUnbindingSigner: Int32 {
+  case owner = 0
+  case wallet = 1
+}
+
+public enum BarnardCoreWalletVerifierVerdict: Equatable {
+  case valid(verifiedAtUnixSeconds: Int64)
+  case invalid(verifiedAtUnixSeconds: Int64)
+  case unverified
+}
+
+/// Host-defined smart-wallet verification port.
+///
+/// Contract signature validity can change with contract state. Implementations
+/// therefore attach their observation time to every valid or invalid verdict.
+/// BarnardCore intentionally provides no RPC implementation.
+public protocol BarnardCoreWalletVerifier {
+  func verify(
+    address: [UInt8],
+    digest: [UInt8],
+    signature: [UInt8]
+  ) -> BarnardCoreWalletVerifierVerdict
+}
+
+public extension BarnardCoreSigning {
+  static func buildAccountBindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to bind this wallet to a Levarac owner key.",
+      "",
+      "This signature authorizes no transaction and moves no assets.",
+      "",
+      "Domain-Tag: \(accountBindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
+  static func buildSelfProofMessage(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      eventIdHash.count == 32,
+      isValidCompressedPublicKey(eventSigningPublicKey),
+      eninStart <= eninEnd,
+      isValidCompressedPublicKey(ownerPublicKey)
+    else {
+      return nil
+    }
+
+    return Array(selfProofDomainTag.utf8)
+      + eventIdHash
+      + eventSigningPublicKey
+      + uint64BigEndian(eninStart)
+      + uint64BigEndian(eninEnd)
+      + ownerPublicKey
+  }
+
+  static func signSelfProof(
+    ownerPrivateKey: [UInt8],
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifySelfProof(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildWalletAcknowledgementMessage(
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard walletAddress.count == 20, !walletSignature.isEmpty else {
+      return nil
+    }
+    return Array(walletAcknowledgementDomainTag.utf8)
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signWalletAcknowledgement(
+    ownerPrivateKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(ownerPrivateKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyWalletAcknowledgement(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildAccountRotationMessage(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(previousOwnerPublicKey),
+      isValidCompressedPublicKey(successorOwnerPublicKey),
+      previousOwnerPublicKey != successorOwnerPublicKey
+    else {
+      return nil
+    }
+    return Array(accountRotationDomainTag.utf8)
+      + previousOwnerPublicKey
+      + successorOwnerPublicKey
+  }
+
+  static func signAccountRotation(
+    previousOwnerPrivateKey: [UInt8],
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: previousOwnerPrivateKey) == previousOwnerPublicKey,
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: previousOwnerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountRotation(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: previousOwnerPublicKey
+    )
+  }
+
+  static func buildAccountUnbindingMessage(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      walletAddress.count == 20,
+      !walletSignature.isEmpty
+    else {
+      return nil
+    }
+    return Array(accountUnbindingDomainTag.utf8)
+      + ownerPublicKey
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signAccountUnbinding(
+    signerPrivateKey: [UInt8],
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(signerPrivateKey),
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: signerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountUnbinding(
+    signer: BarnardCoreAccountUnbindingSigner,
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      ),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        signature,
+        messageHash32: BarnardCorePrimitives.sha256(message)
+      )
+    else {
+      return false
+    }
+
+    switch signer {
+    case .owner:
+      return recoveredPublicKey == ownerPublicKey
+    case .wallet:
+      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == walletAddress
+    }
+  }
+
+  static func classifyWalletSignature(
+    _ signature: [UInt8]
+  ) -> BarnardCoreWalletSignatureClassification {
+    let erc6492Magic = Array(
+      repeating: [UInt8(0x64), UInt8(0x92)],
+      count: 16
+    )
+      .flatMap { $0 }
+    if signature.count >= erc6492Magic.count,
+      signature.suffix(erc6492Magic.count).elementsEqual(erc6492Magic)
+    {
+      return .smartWalletUnsupported
+    }
+    return signature.count == 65 ? .validEoaShape : .invalid
+  }
+
+  static func verifyWalletBinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8],
+    acknowledgement: BarnardCoreRecoverableSignature
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountBindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress,
+      verifyWalletAcknowledgement(
+        ownerPublicKey: expectedOwnerPublicKey,
+        walletAddress: expectedWalletAddress,
+        walletSignature: walletSignature,
+        signature: acknowledgement
+      )
+    else {
+      return .invalid
+    }
+    return .valid
+  }
+
+  private static func isCanonicalAccountBindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 10,
+      lines[1].isEmpty,
+      lines[2] == "This signature authorizes no transaction and moves no assets.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountBindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))"
+    else {
+      return false
+    }
+
+    let headerSuffix = " wants to bind this wallet to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[8].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[8].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[9].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[9].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func verifyNativeSignature(
+    _ signature: BarnardCoreRecoverableSignature,
+    message: [UInt8],
+    expectedPublicKey: [UInt8]
+  ) -> Bool {
+    strictRecoveredPublicKey(
+      signature,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    ) == expectedPublicKey
+  }
+
+  private static func strictRecoveredPublicKey(
+    _ signature: BarnardCoreRecoverableSignature,
+    messageHash32: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      signature.r.count == 32,
+      signature.s.count == 32,
+      messageHash32.count == 32,
+      signature.v == 0 || signature.v == 1
+    else {
+      return nil
+    }
+
+    let r = BarnardCoreSecp256k1.UInt256(bytes: signature.r)
+    let s = BarnardCoreSecp256k1.UInt256(bytes: signature.s)
+    guard
+      !r.isZero,
+      r < BarnardCoreSecp256k1.curveOrder,
+      !s.isZero,
+      s < BarnardCoreSecp256k1.curveOrder,
+      s <= BarnardCoreSecp256k1.curveOrder.shiftedRight1()
+    else {
+      return nil
+    }
+
+    return recoverPublicKey(
+      recoveryId: signature.v,
+      r: signature.r,
+      s: signature.s,
+      messageHash32: messageHash32
+    )
+  }
+
+  private static func normalizedEthereumRecoveryId(_ v: UInt8) -> Int? {
+    switch v {
+    case 0, 1:
+      return Int(v)
+    case 27, 28:
+      return Int(v - 27)
+    default:
+      return nil
+    }
+  }
+
+  private static func isValidPrivateKey(_ privateKey: [UInt8]) -> Bool {
+    guard privateKey.count == 32 else {
+      return false
+    }
+    let scalar = BarnardCoreSecp256k1.UInt256(bytes: privateKey)
+    return !scalar.isZero && scalar < BarnardCoreSecp256k1.curveOrder
+  }
+
+  private static func publicKey(forPrivateKey privateKey: [UInt8]) -> [UInt8]? {
+    guard isValidPrivateKey(privateKey) else {
+      return nil
+    }
+    let point = BarnardCoreSecp256k1.multiply(
+      BarnardCoreSecp256k1.UInt256(bytes: privateKey),
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSecp256k1.compress(point)
+  }
+
+  private static func isValidCompressedPublicKey(_ publicKey: [UInt8]) -> Bool {
+    serializeUncompressedPublicKey(publicKey) != nil
+  }
+
+  private static func uint64BigEndian(_ value: UInt64) -> [UInt8] {
+    stride(from: 56, through: 0, by: -8).map {
+      UInt8((value >> UInt64($0)) & 0xff)
+    }
+  }
+
+  private static func lowercaseHex(_ bytes: [UInt8]) -> String {
+    bytes.map {
+      let value = String($0, radix: 16)
+      return value.count == 1 ? "0" + value : value
+    }.joined()
+  }
+
+  private static func decodeLowercaseHex(_ value: String) -> [UInt8]? {
+    let bytes = Array(value.utf8)
+    guard bytes.count.isMultiple(of: 2) else {
+      return nil
+    }
+    var output: [UInt8] = []
+    output.reserveCapacity(bytes.count / 2)
+    for index in stride(from: 0, to: bytes.count, by: 2) {
+      func nibble(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 0x30...0x39:
+          return byte - 0x30
+        case 0x61...0x66:
+          return byte - 0x61 + 10
+        default:
+          return nil
+        }
+      }
+      guard let high = nibble(bytes[index]), let low = nibble(bytes[index + 1])
+      else {
+        return nil
+      }
+      output.append((high << 4) | low)
+    }
+    return output
+  }
+
+  private static func isCanonicalDomain(_ domain: String) -> Bool {
+    let bytes = Array(domain.utf8)
+    guard
+      !bytes.isEmpty,
+      isLowercaseAsciiLetterOrDigit(bytes[0])
+    else {
+      return false
+    }
+
+    var colonIndex: Int?
+    for (index, byte) in bytes.enumerated() {
+      if colonIndex != nil {
+        if !(0x30...0x39).contains(byte) {
+          return false
+        }
+        continue
+      }
+      switch byte {
+      case 0x61...0x7a, 0x30...0x39, 0x2d, 0x2e:
+        break
+      case 0x3a:
+        if index == 0 {
+          return false
+        }
+        colonIndex = index
+      default:
+        return false
+      }
+    }
+
+    let hostEnd = colonIndex ?? bytes.count
+    guard
+      hostEnd > 0,
+      isLowercaseAsciiLetterOrDigit(bytes[hostEnd - 1])
+    else {
+      return false
+    }
+    guard let colonIndex else {
+      return true
+    }
+
+    let portBytes = bytes.dropFirst(colonIndex + 1)
+    guard
+      !portBytes.isEmpty,
+      portBytes.count <= 5,
+      portBytes.allSatisfy({ (0x30...0x39).contains($0) }),
+      (portBytes.count == 1 || portBytes.first != 0x30),
+      let port = UInt32(String(decoding: portBytes, as: UTF8.self)),
+      port <= 65_535
+    else {
+      return false
+    }
+    return true
+  }
+
+  private static func isLowercaseAsciiLetterOrDigit(_ byte: UInt8) -> Bool {
+    (0x61...0x7a).contains(byte) || (0x30...0x39).contains(byte)
+  }
+
+  private static func isCanonicalIssuedAt(_ value: String) -> Bool {
+    let bytes = Array(value.utf8)
+    guard
+      bytes.count == 20,
+      bytes[4] == 0x2d,
+      bytes[7] == 0x2d,
+      bytes[10] == 0x54,
+      bytes[13] == 0x3a,
+      bytes[16] == 0x3a,
+      bytes[19] == 0x5a
+    else {
+      return false
+    }
+    let digitPositions = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18]
+    guard digitPositions.allSatisfy({
+      (0x30...0x39).contains(bytes[$0])
+    }) else {
+      return false
+    }
+
+    func decimal(_ first: Int, _ second: Int) -> Int {
+      Int(bytes[first] - 0x30) * 10 + Int(bytes[second] - 0x30)
+    }
+    let year = decimal(0, 1) * 100 + decimal(2, 3)
+    let month = decimal(5, 6)
+    let day = decimal(8, 9)
+    let hour = decimal(11, 12)
+    let minute = decimal(14, 15)
+    let second = decimal(17, 18)
+    guard
+      (1...12).contains(month),
+      (0...23).contains(hour),
+      (0...59).contains(minute),
+      (0...59).contains(second)
+    else {
+      return false
+    }
+
+    var daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    let isLeapYear = year.isMultiple(of: 4)
+      && (!year.isMultiple(of: 100) || year.isMultiple(of: 400))
+    if isLeapYear {
+      daysInMonth[1] = 29
+    }
+    return (1...daysInMonth[month - 1]).contains(day)
+  }
+}

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -64,6 +64,7 @@ public extension BarnardCoreSigning {
       "Wallet: 0x\(lowercaseHex(walletAddress))",
       "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
       "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
       "Nonce: 0x\(lowercaseHex(nonce))",
       "Issued-At: \(issuedAt)",
     ].joined(separator: "\n")
@@ -404,13 +405,14 @@ public extension BarnardCoreSigning {
       omittingEmptySubsequences: false
     ).map(String.init)
     guard
-      lines.count == 10,
+      lines.count == 11,
       lines[1].isEmpty,
       lines[2] == "This signature authorizes no transaction and moves no assets.",
       lines[3].isEmpty,
       lines[4] == "Domain-Tag: \(accountBindingDomainTag)",
       lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
-      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))"
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
     else {
       return false
     }
@@ -437,9 +439,9 @@ public extension BarnardCoreSigning {
 
     let noncePrefix = "Nonce: 0x"
     guard
-      lines[8].hasPrefix(noncePrefix),
+      lines[9].hasPrefix(noncePrefix),
       let nonce = decodeLowercaseHex(
-        String(lines[8].dropFirst(noncePrefix.count))
+        String(lines[9].dropFirst(noncePrefix.count))
       ),
       nonce.count == 16
     else {
@@ -447,10 +449,10 @@ public extension BarnardCoreSigning {
     }
 
     let issuedAtPrefix = "Issued-At: "
-    guard lines[9].hasPrefix(issuedAtPrefix) else {
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
       return false
     }
-    let issuedAt = String(lines[9].dropFirst(issuedAtPrefix.count))
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
 
     guard let reconstructed = buildAccountBindingText(
       domain: domain,

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCorePrimitives.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCorePrimitives.swift
@@ -1,6 +1,43 @@
 // Use of this source code is governed by a BSD-style license.
 
 enum BarnardCorePrimitives {
+  static func keccak256(_ input: [UInt8]) -> [UInt8] {
+    let rate = 136
+    var state = [UInt64](repeating: 0, count: 25)
+    var offset = 0
+
+    while input.count - offset >= rate {
+      absorbKeccakBlock(
+        Array(input[offset..<(offset + rate)]),
+        into: &state
+      )
+      keccakF1600(&state)
+      offset += rate
+    }
+
+    var finalBlock = [UInt8](repeating: 0, count: rate)
+    let remaining = input.count - offset
+    if remaining > 0 {
+      for index in 0..<remaining {
+        finalBlock[index] = input[offset + index]
+      }
+    }
+    finalBlock[remaining] ^= 0x01
+    finalBlock[rate - 1] ^= 0x80
+    absorbKeccakBlock(finalBlock, into: &state)
+    keccakF1600(&state)
+
+    var output: [UInt8] = []
+    output.reserveCapacity(32)
+    for byteIndex in 0..<32 {
+      let lane = state[byteIndex / 8]
+      output.append(
+        UInt8((lane >> UInt64(8 * (byteIndex % 8))) & 0xff)
+      )
+    }
+    return output
+  }
+
   static func sha256(_ input: [UInt8]) -> [UInt8] {
     let constants: [UInt32] = [
       0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
@@ -155,6 +192,88 @@ enum BarnardCorePrimitives {
 
   private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {
     (value >> count) | (value << (32 - count))
+  }
+
+  private static func absorbKeccakBlock(
+    _ block: [UInt8],
+    into state: inout [UInt64]
+  ) {
+    for index in block.indices {
+      state[index / 8] ^=
+        UInt64(block[index]) << UInt64(8 * (index % 8))
+    }
+  }
+
+  private static func keccakF1600(_ state: inout [UInt64]) {
+    let roundConstants: [UInt64] = [
+      0x0000000000000001, 0x0000000000008082,
+      0x800000000000808a, 0x8000000080008000,
+      0x000000000000808b, 0x0000000080000001,
+      0x8000000080008081, 0x8000000000008009,
+      0x000000000000008a, 0x0000000000000088,
+      0x0000000080008009, 0x000000008000000a,
+      0x000000008000808b, 0x800000000000008b,
+      0x8000000000008089, 0x8000000000008003,
+      0x8000000000008002, 0x8000000000000080,
+      0x000000000000800a, 0x800000008000000a,
+      0x8000000080008081, 0x8000000000008080,
+      0x0000000080000001, 0x8000000080008008,
+    ]
+    let rotationOffsets: [Int] = [
+      0, 1, 62, 28, 27,
+      36, 44, 6, 55, 20,
+      3, 10, 43, 25, 39,
+      41, 45, 15, 21, 8,
+      18, 2, 61, 56, 14,
+    ]
+
+    for roundConstant in roundConstants {
+      var columns = [UInt64](repeating: 0, count: 5)
+      for x in 0..<5 {
+        columns[x] =
+          state[x]
+          ^ state[x + 5]
+          ^ state[x + 10]
+          ^ state[x + 15]
+          ^ state[x + 20]
+      }
+      for x in 0..<5 {
+        let delta =
+          columns[(x + 4) % 5]
+          ^ rotateLeft(columns[(x + 1) % 5], by: 1)
+        for y in 0..<5 {
+          state[x + 5 * y] ^= delta
+        }
+      }
+
+      var permuted = [UInt64](repeating: 0, count: 25)
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let source = x + 5 * y
+          let destination = y + 5 * ((2 * x + 3 * y) % 5)
+          permuted[destination] = rotateLeft(
+            state[source],
+            by: rotationOffsets[source]
+          )
+        }
+      }
+
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let row = 5 * y
+          state[x + row] =
+            permuted[x + row]
+            ^ ((~permuted[(x + 1) % 5 + row])
+              & permuted[(x + 2) % 5 + row])
+        }
+      }
+      state[0] ^= roundConstant
+    }
+  }
+
+  private static func rotateLeft(_ value: UInt64, by count: Int) -> UInt64 {
+    guard count != 0 else { return value }
+    return (value << UInt64(count)) | (value >> UInt64(64 - count))
   }
 
   private static let aesSBox: [UInt8] = [

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreSigning.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreSigning.swift
@@ -3,12 +3,23 @@
 public struct BarnardCoreSigningKeyPair {
   public let privateKey: [UInt8]
   public let publicKeyCompressed: [UInt8]
+
+  public init(privateKey: [UInt8], publicKeyCompressed: [UInt8]) {
+    self.privateKey = privateKey
+    self.publicKeyCompressed = publicKeyCompressed
+  }
 }
 
 public struct BarnardCoreRecoverableSignature {
   public let r: [UInt8]
   public let s: [UInt8]
   public let v: Int
+
+  public init(r: [UInt8], s: [UInt8], v: Int) {
+    self.r = r
+    self.s = s
+    self.v = v
+  }
 }
 
 public struct BarnardCoreRpidOwnershipProof {
@@ -21,8 +32,14 @@ public struct BarnardCoreRpidOwnershipProof {
 
 public enum BarnardCoreSigning {
   public static let signingKeyInfo = "barnard-sign"
+  public static let ownerKeyInfo = "barnard-owner"
   public static let rpidProofDomainTag = "barnard-rpid-proof:v1"
   public static let keyBindingDomainTag = "barnard-key-binding:v1"
+  public static let selfProofDomainTag = "barnard-self-proof:v1"
+  public static let walletAcknowledgementDomainTag = "barnard-wallet-ack:v1"
+  public static let accountRotationDomainTag = "barnard-account-rotation:v1"
+  public static let accountUnbindingDomainTag = "barnard-account-unbinding:v1"
+  public static let accountBindingDomainTag = "barnard-account-binding:v1"
 
   public static func deriveSigningKeyPair(
     deviceSecret: [UInt8],
@@ -52,6 +69,86 @@ public enum BarnardCoreSigning {
       privateKey: privateKey.bytes,
       publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
     )
+  }
+
+  public static func deriveOwnerKeyPair(
+    accountSecret: [UInt8]
+  ) -> BarnardCoreSigningKeyPair {
+    precondition(accountSecret.count == 32, "accountSecret must be 32 bytes")
+    var seed = BarnardCorePrimitives.hkdfSha256(
+      inputKeyMaterial: accountSecret,
+      info: Array(ownerKeyInfo.utf8),
+      outputByteCount: 32
+    )
+    var privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+      BarnardCoreSecp256k1.UInt256(bytes: seed),
+      BarnardCoreSecp256k1.curveOrder
+    )
+    while privateKey.isZero {
+      seed = BarnardCorePrimitives.sha256(seed)
+      privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+        BarnardCoreSecp256k1.UInt256(bytes: seed),
+        BarnardCoreSecp256k1.curveOrder
+      )
+    }
+    let publicPoint = BarnardCoreSecp256k1.multiply(
+      privateKey,
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSigningKeyPair(
+      privateKey: privateKey.bytes,
+      publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
+    )
+  }
+
+  public static func serializeUncompressedPublicKey(
+    _ compressedPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      compressedPublicKey.count == 33,
+      compressedPublicKey[0] == 0x02 || compressedPublicKey[0] == 0x03
+    else {
+      return nil
+    }
+    let x = BarnardCoreSecp256k1.UInt256(
+      bytes: Array(compressedPublicKey.dropFirst())
+    )
+    guard
+      x < BarnardCoreSecp256k1.fieldPrime,
+      let point = BarnardCoreSecp256k1.decompress(
+        x: x,
+        yIsOdd: compressedPublicKey[0] == 0x03
+      )
+    else {
+      return nil
+    }
+    return BarnardCoreSecp256k1.serializeUncompressed(point)
+  }
+
+  public static func ethereumAddress(
+    publicKeyCompressed: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      let uncompressed = serializeUncompressedPublicKey(publicKeyCompressed),
+      uncompressed.count == 65
+    else {
+      return nil
+    }
+    return Array(
+      BarnardCorePrimitives.keccak256(Array(uncompressed.dropFirst())).suffix(20)
+    )
+  }
+
+  public static func computeEip191Digest(text: String) -> [UInt8] {
+    computeEip191Digest(messageBytes: Array(text.utf8))
+  }
+
+  public static func computeEip191Digest(messageBytes: [UInt8]) -> [UInt8] {
+    let prefix =
+      [UInt8(0x19)]
+      + Array("Ethereum Signed Message:\n".utf8)
+      + Array(String(messageBytes.count).utf8)
+    return BarnardCorePrimitives.keccak256(prefix + messageBytes)
   }
 
   public static func signRecoverable(

--- a/packages/swift/barnard/Sources/BarnardCore/Secp256k1.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/Secp256k1.swift
@@ -300,6 +300,13 @@ enum BarnardCoreSecp256k1 {
     return [y.testBit(0) ? 0x03 : 0x02] + x.bytes
   }
 
+  static func serializeUncompressed(_ point: Point) -> [UInt8] {
+    guard let x = point.x, let y = point.y else {
+      return []
+    }
+    return [0x04] + x.bytes + y.bytes
+  }
+
   static func decompress(x: UInt256, yIsOdd: Bool) -> Point? {
     let xCubed = Field.multiplyMod(
       Field.multiplyMod(x, x, fieldPrime),

--- a/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
+++ b/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
@@ -23,6 +23,15 @@ private func utf8String(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> Str
   return String(decoding: raw, as: UTF8.self)
 }
 
+private func strictUtf8String(
+  _ pointer: UnsafePointer<UInt8>?,
+  _ count: Int32
+) -> String? {
+  guard let raw = bytes(pointer, count) else { return nil }
+  let value = String(decoding: raw, as: UTF8.self)
+  return Array(value.utf8) == raw ? value : nil
+}
+
 private func write(_ output: [UInt8], _ expectedCount: Int, to pointer: UnsafeMutablePointer<UInt8>) {
   precondition(
     output.count == expectedCount,
@@ -239,6 +248,38 @@ public func barnard_core_sha256(
   return 0
 }
 
+/// out_digest32: 32 bytes.
+@_cdecl("barnard_core_keccak256")
+public func barnard_core_keccak256(
+  _ input: UnsafePointer<UInt8>?,
+  _ inputLength: Int32,
+  _ outDigest32: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let raw = bytes(input, inputLength), let outDigest32 else { return -1 }
+  write(BarnardCoreCrypto.keccak256(raw), 32, to: outDigest32)
+  return 0
+}
+
+/// Computes the EIP-191 personal_sign digest of message_utf8. out_digest32:
+/// 32 bytes. The caller is responsible for supplying UTF-8 canonical text;
+/// the digest operates on the byte sequence exactly as received.
+@_cdecl("barnard_core_eip191_digest")
+public func barnard_core_eip191_digest(
+  _ messageUtf8: UnsafePointer<UInt8>?,
+  _ messageLength: Int32,
+  _ outDigest32: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let message = bytes(messageUtf8, messageLength), let outDigest32 else {
+    return -1
+  }
+  write(
+    BarnardCoreSigning.computeEip191Digest(messageBytes: message),
+    32,
+    to: outDigest32
+  )
+  return 0
+}
+
 /// out_private_key32: 32 bytes. out_public_key_compressed33: 33 bytes.
 @_cdecl("barnard_core_derive_signing_keypair")
 public func barnard_core_derive_signing_keypair(
@@ -258,6 +299,29 @@ public func barnard_core_derive_signing_keypair(
   let keyPair = BarnardCoreSigning.deriveSigningKeyPair(
     deviceSecret: secret,
     eventCode: eventCode
+  )
+  write(keyPair.privateKey, 32, to: outPrivateKey32)
+  write(keyPair.publicKeyCompressed, 33, to: outPublicKeyCompressed33)
+  return 0
+}
+
+/// account_secret32: 32 bytes in. out_private_key32: 32 bytes.
+/// out_public_key_compressed33: 33 bytes.
+@_cdecl("barnard_core_derive_owner_keypair")
+public func barnard_core_derive_owner_keypair(
+  _ accountSecret32: UnsafePointer<UInt8>?,
+  _ outPrivateKey32: UnsafeMutablePointer<UInt8>?,
+  _ outPublicKeyCompressed33: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard
+    let accountSecret = bytes(accountSecret32, 32),
+    let outPrivateKey32,
+    let outPublicKeyCompressed33
+  else {
+    return -1
+  }
+  let keyPair = BarnardCoreSigning.deriveOwnerKeyPair(
+    accountSecret: accountSecret
   )
   write(keyPair.privateKey, 32, to: outPrivateKey32)
   write(keyPair.publicKeyCompressed, 33, to: outPublicKeyCompressed33)
@@ -289,6 +353,127 @@ public func barnard_core_sign_recoverable(
   write(signature.s, 32, to: outS32)
   outV.pointee = Int32(signature.v)
   return 0
+}
+
+/// Fixed inputs: event_id_hash32 (32), event_signing_public_key33 (33), and
+/// owner_public_key33 (33). out_message135: 135 bytes.
+@_cdecl("barnard_core_build_self_proof_message")
+public func barnard_core_build_self_proof_message(
+  _ eventIdHash32: UnsafePointer<UInt8>?,
+  _ eventSigningPublicKey33: UnsafePointer<UInt8>?,
+  _ eninStart: UInt64,
+  _ eninEnd: UInt64,
+  _ ownerPublicKey33: UnsafePointer<UInt8>?,
+  _ outMessage135: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard
+    let eventIdHash = bytes(eventIdHash32, 32),
+    let eventSigningPublicKey = bytes(eventSigningPublicKey33, 33),
+    let ownerPublicKey = bytes(ownerPublicKey33, 33),
+    let outMessage135,
+    let message = BarnardCoreSigning.buildSelfProofMessage(
+      eventIdHash: eventIdHash,
+      eventSigningPublicKey: eventSigningPublicKey,
+      eninStart: eninStart,
+      eninEnd: eninEnd,
+      ownerPublicKey: ownerPublicKey
+    )
+  else {
+    return -1
+  }
+  write(message, 135, to: outMessage135)
+  return 0
+}
+
+/// Fixed key/hash/scalar inputs follow build_self_proof_message. Returns 1
+/// when valid, 0 when cryptographically invalid, and -1 for missing pointers.
+@_cdecl("barnard_core_verify_self_proof")
+public func barnard_core_verify_self_proof(
+  _ eventIdHash32: UnsafePointer<UInt8>?,
+  _ eventSigningPublicKey33: UnsafePointer<UInt8>?,
+  _ eninStart: UInt64,
+  _ eninEnd: UInt64,
+  _ ownerPublicKey33: UnsafePointer<UInt8>?,
+  _ signatureR32: UnsafePointer<UInt8>?,
+  _ signatureS32: UnsafePointer<UInt8>?,
+  _ signatureV: Int32
+) -> Int32 {
+  guard
+    let eventIdHash = bytes(eventIdHash32, 32),
+    let eventSigningPublicKey = bytes(eventSigningPublicKey33, 33),
+    let ownerPublicKey = bytes(ownerPublicKey33, 33),
+    let signatureR = bytes(signatureR32, 32),
+    let signatureS = bytes(signatureS32, 32)
+  else {
+    return -1
+  }
+  let signature = BarnardCoreRecoverableSignature(
+    r: signatureR,
+    s: signatureS,
+    v: Int(signatureV)
+  )
+  return BarnardCoreSigning.verifySelfProof(
+    eventIdHash: eventIdHash,
+    eventSigningPublicKey: eventSigningPublicKey,
+    eninStart: eninStart,
+    eninEnd: eninEnd,
+    ownerPublicKey: ownerPublicKey,
+    signature: signature
+  ) ? 1 : 0
+}
+
+/// Returns BarnardCoreWalletSignatureClassification raw values:
+/// 0 invalid, 1 EOA shape, 2 unsupported ERC-6492; -1 on invalid arguments.
+@_cdecl("barnard_core_classify_wallet_signature")
+public func barnard_core_classify_wallet_signature(
+  _ signature: UnsafePointer<UInt8>?,
+  _ signatureLength: Int32
+) -> Int32 {
+  guard let signatureBytes = bytes(signature, signatureLength) else {
+    return -1
+  }
+  return BarnardCoreSigning.classifyWalletSignature(signatureBytes).rawValue
+}
+
+/// Verifies one EOA wallet-binding record. Fixed inputs:
+/// expected_wallet_address20 (20), expected_owner_public_key33 (33),
+/// acknowledgement_r32/s32 (32 each). Returns
+/// BarnardCoreWalletBindingVerification raw values: 0 invalid, 1 valid,
+/// 2 unsupported ERC-6492; -1 on invalid arguments.
+@_cdecl("barnard_core_verify_wallet_binding")
+public func barnard_core_verify_wallet_binding(
+  _ bindingTextUtf8: UnsafePointer<UInt8>?,
+  _ bindingTextLength: Int32,
+  _ walletSignature: UnsafePointer<UInt8>?,
+  _ walletSignatureLength: Int32,
+  _ expectedWalletAddress20: UnsafePointer<UInt8>?,
+  _ expectedOwnerPublicKey33: UnsafePointer<UInt8>?,
+  _ acknowledgementR32: UnsafePointer<UInt8>?,
+  _ acknowledgementS32: UnsafePointer<UInt8>?,
+  _ acknowledgementV: Int32
+) -> Int32 {
+  guard
+    let text = strictUtf8String(bindingTextUtf8, bindingTextLength),
+    let signature = bytes(walletSignature, walletSignatureLength),
+    let address = bytes(expectedWalletAddress20, 20),
+    let ownerPublicKey = bytes(expectedOwnerPublicKey33, 33),
+    let acknowledgementR = bytes(acknowledgementR32, 32),
+    let acknowledgementS = bytes(acknowledgementS32, 32)
+  else {
+    return -1
+  }
+  let acknowledgement = BarnardCoreRecoverableSignature(
+    r: acknowledgementR,
+    s: acknowledgementS,
+    v: Int(acknowledgementV)
+  )
+  return BarnardCoreSigning.verifyWalletBinding(
+    text: text,
+    walletSignature: signature,
+    expectedWalletAddress: address,
+    expectedOwnerPublicKey: ownerPublicKey,
+    acknowledgement: acknowledgement
+  ).rawValue
 }
 
 /// Returns 1 when the RSSI update should be emitted, else 0.

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -117,6 +117,245 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(enin, 0)
   }
 
+  func testOwnerKeyCAbiMatchesGoldenVectorsAndVerifiesProofs() {
+    let accountSecret = [UInt8](repeating: 0, count: 32)
+    var ownerPrivateKey = [UInt8](repeating: 0, count: 32)
+    var ownerPublicKey = [UInt8](repeating: 0, count: 33)
+    XCTAssertEqual(
+      barnard_core_derive_owner_keypair(
+        accountSecret,
+        &ownerPrivateKey,
+        &ownerPublicKey
+      ),
+      0
+    )
+    XCTAssertEqual(
+      hex(ownerPrivateKey),
+      "46cbfd04992339fab4937354a6f24c115a238f4bd133a8c43b18162ab986bf27"
+    )
+    XCTAssertEqual(
+      hex(ownerPublicKey),
+      "03351e5165d083f53425fc4a51e7228d53e88eb2899bcb6a83368a8aafaa1de5f4"
+    )
+
+    let abc = Array("abc".utf8)
+    var digest = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(barnard_core_keccak256(abc, Int32(abc.count), &digest), 0)
+    XCTAssertEqual(
+      hex(digest),
+      "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"
+    )
+
+    let personalMessage = Array("Hello World".utf8)
+    XCTAssertEqual(
+      barnard_core_eip191_digest(
+        personalMessage,
+        Int32(personalMessage.count),
+        &digest
+      ),
+      0
+    )
+    XCTAssertEqual(
+      hex(digest),
+      "a1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2"
+    )
+
+    let eventHash = (0x00...0x1f).map(UInt8.init)
+    let eventPublicKey = decodeHex(
+      "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d"
+        + "959f2815b16f81798"
+    )
+    var selfProofMessage = [UInt8](repeating: 0, count: 135)
+    XCTAssertEqual(
+      barnard_core_build_self_proof_message(
+        eventHash,
+        eventPublicKey,
+        12,
+        34,
+        ownerPublicKey,
+        &selfProofMessage
+      ),
+      0
+    )
+    XCTAssertEqual(
+      Array(selfProofMessage.prefix(21)),
+      Array("barnard-self-proof:v1".utf8)
+    )
+    XCTAssertEqual(Array(selfProofMessage[53..<86]), eventPublicKey)
+    XCTAssertEqual(Array(selfProofMessage[102..<135]), ownerPublicKey)
+
+    var selfProofHash = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_sha256(
+        selfProofMessage,
+        Int32(selfProofMessage.count),
+        &selfProofHash
+      ),
+      0
+    )
+    var selfProofR = [UInt8](repeating: 0, count: 32)
+    var selfProofS = [UInt8](repeating: 0, count: 32)
+    var selfProofV: Int32 = -1
+    XCTAssertEqual(
+      barnard_core_sign_recoverable(
+        ownerPrivateKey,
+        selfProofHash,
+        &selfProofR,
+        &selfProofS,
+        &selfProofV
+      ),
+      0
+    )
+    XCTAssertEqual(
+      barnard_core_verify_self_proof(
+        eventHash,
+        eventPublicKey,
+        12,
+        34,
+        ownerPublicKey,
+        selfProofR,
+        selfProofS,
+        selfProofV
+      ),
+      1
+    )
+    XCTAssertEqual(
+      barnard_core_verify_self_proof(
+        eventHash,
+        eventPublicKey,
+        12,
+        35,
+        ownerPublicKey,
+        selfProofR,
+        selfProofS,
+        selfProofV
+      ),
+      0
+    )
+
+    let walletPrivateKey = [UInt8](repeating: 0, count: 31) + [1]
+    let walletAddress = decodeHex("7e5f4552091a69125d5dfcb7b8c2659029395bdf")
+    let bindingText = Array(
+      """
+      beid.levarac.org wants to bind this wallet to a Levarac owner key.
+
+      This signature authorizes no transaction and moves no assets.
+
+      Domain-Tag: barnard-account-binding:v1
+      Wallet: 0x\(hex(walletAddress))
+      Owner-Key: 0x\(hex(ownerPublicKey))
+      Chain-ID: eip155:1
+      Nonce: 0x000102030405060708090a0b0c0d0e0f
+      Issued-At: 2026-07-30T09:00:00Z
+      """.utf8
+    )
+    var bindingDigest = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_eip191_digest(
+        bindingText,
+        Int32(bindingText.count),
+        &bindingDigest
+      ),
+      0
+    )
+    var walletR = [UInt8](repeating: 0, count: 32)
+    var walletS = [UInt8](repeating: 0, count: 32)
+    var walletV: Int32 = -1
+    XCTAssertEqual(
+      barnard_core_sign_recoverable(
+        walletPrivateKey,
+        bindingDigest,
+        &walletR,
+        &walletS,
+        &walletV
+      ),
+      0
+    )
+    let walletSignature = walletR + walletS + [UInt8(walletV + 27)]
+    var walletSignatureHash = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_sha256(
+        walletSignature,
+        Int32(walletSignature.count),
+        &walletSignatureHash
+      ),
+      0
+    )
+    let acknowledgementMessage =
+      Array("barnard-wallet-ack:v1".utf8)
+      + walletAddress
+      + walletSignatureHash
+    var acknowledgementHash = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_sha256(
+        acknowledgementMessage,
+        Int32(acknowledgementMessage.count),
+        &acknowledgementHash
+      ),
+      0
+    )
+    var acknowledgementR = [UInt8](repeating: 0, count: 32)
+    var acknowledgementS = [UInt8](repeating: 0, count: 32)
+    var acknowledgementV: Int32 = -1
+    XCTAssertEqual(
+      barnard_core_sign_recoverable(
+        ownerPrivateKey,
+        acknowledgementHash,
+        &acknowledgementR,
+        &acknowledgementS,
+        &acknowledgementV
+      ),
+      0
+    )
+    XCTAssertEqual(
+      barnard_core_verify_wallet_binding(
+        bindingText,
+        Int32(bindingText.count),
+        walletSignature,
+        Int32(walletSignature.count),
+        walletAddress,
+        ownerPublicKey,
+        acknowledgementR,
+        acknowledgementS,
+        acknowledgementV
+      ),
+      1
+    )
+    XCTAssertEqual(
+      barnard_core_verify_wallet_binding(
+        personalMessage,
+        Int32(personalMessage.count),
+        walletSignature,
+        Int32(walletSignature.count),
+        walletAddress,
+        ownerPublicKey,
+        acknowledgementR,
+        acknowledgementS,
+        acknowledgementV
+      ),
+      0
+    )
+
+    let erc6492Magic = decodeHex(
+      "6492649264926492649264926492649264926492649264926492649264926492"
+    )
+    XCTAssertEqual(
+      barnard_core_classify_wallet_signature(
+        walletSignature,
+        Int32(walletSignature.count)
+      ),
+      1
+    )
+    XCTAssertEqual(
+      barnard_core_classify_wallet_signature(
+        erc6492Magic,
+        Int32(erc6492Magic.count)
+      ),
+      2
+    )
+    XCTAssertEqual(barnard_core_classify_wallet_signature(nil, 0), 0)
+  }
+
   func testInvalidArgumentsAreRejected() {
     var out = [UInt8](repeating: 0, count: 16)
     XCTAssertEqual(barnard_core_derive_tek_for_event(nil, 32, nil, 0, &out), -1)
@@ -125,5 +364,34 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(barnard_core_sha256(nil, 4, &out), -1)
     XCTAssertEqual(barnard_core_stable_read_enin(0, 0, 0, 300, 0, 0, nil), -1)
     XCTAssertEqual(barnard_core_should_serve_gatt_display_id(nil, 5), 0)
+    XCTAssertEqual(barnard_core_derive_owner_keypair(nil, nil, nil), -1)
+    XCTAssertEqual(barnard_core_keccak256(nil, 1, nil), -1)
+    XCTAssertEqual(barnard_core_eip191_digest(nil, 1, nil), -1)
+    XCTAssertEqual(
+      barnard_core_build_self_proof_message(nil, nil, 0, 0, nil, nil),
+      -1
+    )
+    XCTAssertEqual(
+      barnard_core_verify_self_proof(
+        nil,
+        nil,
+        0,
+        0,
+        nil,
+        nil,
+        nil,
+        0
+      ),
+      -1
+    )
+    XCTAssertEqual(barnard_core_classify_wallet_signature(nil, 1), -1)
+  }
+
+  private func decodeHex(_ value: String) -> [UInt8] {
+    stride(from: 0, to: value.count, by: 2).map { offset in
+      let start = value.index(value.startIndex, offsetBy: offset)
+      let end = value.index(start, offsetBy: 2)
+      return UInt8(value[start..<end], radix: 16)!
+    }
   }
 }

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -245,6 +245,7 @@ final class BarnardCoreCTests: XCTestCase {
       Wallet: 0x\(hex(walletAddress))
       Owner-Key: 0x\(hex(ownerPublicKey))
       Chain-ID: eip155:1
+      Scope: global
       Nonce: 0x000102030405060708090a0b0c0d0e0f
       Issued-At: 2026-07-30T09:00:00Z
       """.utf8

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
@@ -35,14 +35,15 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
       Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325
       Owner-Key: 0x03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67
       Chain-ID: eip155:1
+      Scope: global
       Nonce: 0x000102030405060708090a0b0c0d0e0f
       Issued-At: 2026-07-30T09:00:00Z
       """
     )
-    XCTAssertEqual(Array(text.utf8).count, 393)
+    XCTAssertEqual(Array(text.utf8).count, 407)
     XCTAssertEqual(
       hex(BarnardCoreSigning.computeEip191Digest(text: text)),
-      "ab50a5d7394456bc06b6b5d93af6fa22b433b1a48340a8aac8c35ce3791ffb50"
+      "1aad6c43694a0e64bf3994959907b7392a590a1e7139bc9f52a86dc71709dc44"
     )
     XCTAssertFalse(text.hasSuffix("\n"))
 
@@ -405,6 +406,58 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
         walletSignature: walletSignature,
         signature: walletSigner
       )
+    )
+  }
+
+  func testWalletBindingRejectsNonGlobalScopeWithMatchingSignatures() throws {
+    let ownerPrivateKey = scalarTwo
+    let ownerPublicKey = compressedPublicKey(privateKey: ownerPrivateKey)
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(
+        publicKeyCompressed: generatorCompressed
+      )
+    )
+    let canonicalText = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let alteredScopeText = canonicalText.replacingOccurrences(
+      of: "Scope: global",
+      with: "Scope: event"
+    )
+    let alteredScopeEip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: alteredScopeText
+      )
+    )
+    let alteredScopeWalletSignature =
+      alteredScopeEip191Signature.r
+      + alteredScopeEip191Signature.s
+      + [UInt8(alteredScopeEip191Signature.v + 27)]
+    let alteredScopeAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: alteredScopeWalletSignature
+      )
+    )
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: alteredScopeText,
+        walletSignature: alteredScopeWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: alteredScopeAcknowledgement
+      ),
+      .invalid
     )
   }
 

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
@@ -1,0 +1,760 @@
+// Use of this source code is governed by a BSD-style license.
+
+import XCTest
+@testable import BarnardCore
+
+final class BarnardOwnerKeyMessageTests: XCTestCase {
+  private let scalarOne = [UInt8](repeating: 0, count: 31) + [1]
+  private let scalarTwo = [UInt8](repeating: 0, count: 31) + [2]
+  private let generatorCompressed = bytes(
+    "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+  )
+
+  func testCanonicalBindingTextMatchesPinnedBytesAndDigest() throws {
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: bytes("14791697260e4c9a71f18484c9f997b308e59325"),
+        ownerPublicKey: bytes(
+          "03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67"
+        ),
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+
+    XCTAssertEqual(
+      text,
+      """
+      beid.levarac.org wants to bind this wallet to a Levarac owner key.
+
+      This signature authorizes no transaction and moves no assets.
+
+      Domain-Tag: barnard-account-binding:v1
+      Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325
+      Owner-Key: 0x03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67
+      Chain-ID: eip155:1
+      Nonce: 0x000102030405060708090a0b0c0d0e0f
+      Issued-At: 2026-07-30T09:00:00Z
+      """
+    )
+    XCTAssertEqual(Array(text.utf8).count, 393)
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: text)),
+      "ab50a5d7394456bc06b6b5d93af6fa22b433b1a48340a8aac8c35ce3791ffb50"
+    )
+    XCTAssertFalse(text.hasSuffix("\n"))
+
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "BEID.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 15),
+        issuedAt: "2026-07-30T09:00:00+09:00"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org:00080",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org:65536",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-02-29T09:00:00Z"
+      )
+    )
+    XCTAssertNotNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org:65535",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: UInt64.max,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2024-02-29T09:00:00Z"
+      )
+    )
+  }
+
+  func testSelfProofBuilderSignerAndVerifier() throws {
+    let eventHash = (0x00...0x1f).map(UInt8.init)
+    let eventPublicKey = compressedPublicKey(privateKey: scalarTwo)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildSelfProofMessage(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 0x0102_0304_0506_0708,
+        eninEnd: 0x1112_1314_1516_1718,
+        ownerPublicKey: generatorCompressed
+      )
+    )
+
+    XCTAssertEqual(message.count, 135)
+    XCTAssertEqual(
+      Array(message.prefix(21)),
+      Array("barnard-self-proof:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[21..<53]), eventHash)
+    XCTAssertEqual(Array(message[53..<86]), eventPublicKey)
+    XCTAssertEqual(
+      Array(message[86..<102]),
+      bytes("01020304050607081112131415161718")
+    )
+    XCTAssertEqual(Array(message[102..<135]), generatorCompressed)
+    XCTAssertNil(
+      BarnardCoreSigning.buildSelfProofMessage(
+        eventIdHash: Array(eventHash.dropLast()),
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed
+      )
+    )
+
+    let signature = try XCTUnwrap(
+      BarnardCoreSigning.signSelfProof(
+        ownerPrivateKey: scalarOne,
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 35,
+        ownerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: BarnardCoreRecoverableSignature(
+          r: [UInt8](repeating: 0, count: 32),
+          s: signature.s,
+          v: signature.v
+        )
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: BarnardCoreRecoverableSignature(
+          r: signature.r,
+          s: signature.s,
+          v: 2
+        )
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 35,
+        eninEnd: 12,
+        ownerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+
+    let highS = BarnardCoreSecp256k1.curveOrder.subtracting(
+      BarnardCoreSecp256k1.UInt256(bytes: signature.s)
+    ).bytes
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: BarnardCoreRecoverableSignature(
+          r: signature.r,
+          s: highS,
+          v: signature.v ^ 1
+        )
+      )
+    )
+  }
+
+  func testWalletAcknowledgementBuilderSignerAndVerifier() throws {
+    let walletAddress = (0x20...0x33).map(UInt8.init)
+    let walletSignature = (0x40...0x80).map(UInt8.init)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+
+    XCTAssertEqual(message.count, 73)
+    XCTAssertEqual(
+      Array(message.prefix(21)),
+      Array("barnard-wallet-ack:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[21..<41]), walletAddress)
+    XCTAssertEqual(
+      Array(message[41..<73]),
+      BarnardCoreCrypto.sha256(walletSignature)
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildWalletAcknowledgementMessage(
+        walletAddress: Array(walletAddress.dropLast()),
+        walletSignature: walletSignature
+      )
+    )
+
+    let signature = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: scalarOne,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyWalletAcknowledgement(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifyWalletAcknowledgement(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: Array(repeating: 0, count: 20),
+        walletSignature: walletSignature,
+        signature: signature
+      )
+    )
+  }
+
+  func testRotationBuilderSignerAndVerifier() throws {
+    let successorPublicKey = compressedPublicKey(privateKey: scalarTwo)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountRotationMessage(
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: successorPublicKey
+      )
+    )
+    XCTAssertEqual(message.count, 93)
+    XCTAssertEqual(
+      Array(message.prefix(27)),
+      Array("barnard-account-rotation:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[27..<60]), generatorCompressed)
+    XCTAssertEqual(Array(message[60..<93]), successorPublicKey)
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountRotationMessage(
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: generatorCompressed
+      )
+    )
+
+    let signature = try XCTUnwrap(
+      BarnardCoreSigning.signAccountRotation(
+        previousOwnerPrivateKey: scalarOne,
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: successorPublicKey
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyAccountRotation(
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: successorPublicKey,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifyAccountRotation(
+        previousOwnerPublicKey: successorPublicKey,
+        successorOwnerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+  }
+
+  func testUnbindingBuilderAndBothSignerKinds() throws {
+    let walletPrivateKey = scalarTwo
+    let walletPublicKey = compressedPublicKey(privateKey: walletPrivateKey)
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(publicKeyCompressed: walletPublicKey)
+    )
+    let walletSignature = (0x40...0x80).map(UInt8.init)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountUnbindingMessage(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+
+    XCTAssertEqual(message.count, 113)
+    XCTAssertEqual(
+      Array(message.prefix(28)),
+      Array("barnard-account-unbinding:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[28..<61]), generatorCompressed)
+    XCTAssertEqual(Array(message[61..<81]), walletAddress)
+    XCTAssertEqual(
+      Array(message[81..<113]),
+      BarnardCoreCrypto.sha256(walletSignature)
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountUnbindingMessage(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: Array(walletAddress.dropLast()),
+        walletSignature: walletSignature
+      )
+    )
+
+    let ownerSignature = try XCTUnwrap(
+      BarnardCoreSigning.signAccountUnbinding(
+        signerPrivateKey: scalarOne,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        signer: .owner,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: ownerSignature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        signer: .wallet,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: ownerSignature
+      )
+    )
+
+    let walletSigner = try XCTUnwrap(
+      BarnardCoreSigning.signAccountUnbinding(
+        signerPrivateKey: walletPrivateKey,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        signer: .wallet,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: walletSigner
+      )
+    )
+  }
+
+  func testWalletClassificationAndEoaBindingVerification() throws {
+    let magic = bytes(
+      "6492649264926492649264926492649264926492649264926492649264926492"
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature([UInt8](repeating: 0, count: 65)),
+      .validEoaShape
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature([0xaa] + magic),
+      .smartWalletUnsupported
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature(
+        [UInt8](repeating: 0xaa, count: 33) + magic
+      ),
+      .smartWalletUnsupported
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature([]),
+      .invalid
+    )
+
+    let ownerPrivateKey = scalarTwo
+    let ownerPublicKey = compressedPublicKey(privateKey: ownerPrivateKey)
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(
+        publicKeyCompressed: generatorCompressed
+      )
+    )
+    let nonce = (0x00...0x0f).map(UInt8.init)
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: nonce,
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let eip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(text: text)
+    )
+    let walletSignature =
+      eip191Signature.r
+      + eip191Signature.s
+      + [UInt8(eip191Signature.v + 27)]
+    let acknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .valid
+    )
+
+    var nonCanonicalLines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    nonCanonicalLines[6] =
+      "Owner-\u{212a}ey: " + nonCanonicalLines[6].dropFirst("Owner-Key: ".count)
+    let unicodeEquivalentLabelText = nonCanonicalLines.joined(separator: "\n")
+    XCTAssertNotEqual(
+      Array(unicodeEquivalentLabelText.utf8),
+      Array(text.utf8)
+    )
+    let unicodeEquivalentSignature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: unicodeEquivalentLabelText
+      )
+    )
+    let unicodeEquivalentWalletSignature =
+      unicodeEquivalentSignature.r
+      + unicodeEquivalentSignature.s
+      + [UInt8(unicodeEquivalentSignature.v + 27)]
+    let unicodeEquivalentAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: unicodeEquivalentWalletSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: unicodeEquivalentLabelText,
+        walletSignature: unicodeEquivalentWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: unicodeEquivalentAcknowledgement
+      ),
+      .invalid
+    )
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSignature,
+        expectedWalletAddress: [UInt8](repeating: 0, count: 20),
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: "Hello World",
+        walletSignature: walletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .invalid
+    )
+    let textNamingAnotherOwner = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: nonce,
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let anotherOwnerEip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: textNamingAnotherOwner
+      )
+    )
+    let anotherOwnerWalletSignature =
+      anotherOwnerEip191Signature.r
+      + anotherOwnerEip191Signature.s
+      + [UInt8(anotherOwnerEip191Signature.v + 27)]
+    let anotherOwnerAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: anotherOwnerWalletSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: textNamingAnotherOwner,
+        walletSignature: anotherOwnerWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: anotherOwnerAcknowledgement
+      ),
+      .invalid
+    )
+    let textNamingAnotherWallet = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: nonce,
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let anotherWalletEip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: textNamingAnotherWallet
+      )
+    )
+    let anotherWalletSignature =
+      anotherWalletEip191Signature.r
+      + anotherWalletEip191Signature.s
+      + [UInt8(anotherWalletEip191Signature.v + 27)]
+    let anotherWalletAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: anotherWalletSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: textNamingAnotherWallet,
+        walletSignature: anotherWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: anotherWalletAcknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: Array(walletSignature.dropLast()),
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .invalid
+    )
+
+    var invalidVSignature = walletSignature
+    invalidVSignature[64] = 2
+    let invalidVAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: invalidVSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: invalidVSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: invalidVAcknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: BarnardCoreRecoverableSignature(
+          r: [UInt8](repeating: 0, count: 32),
+          s: acknowledgement.s,
+          v: acknowledgement.v
+        )
+      ),
+      .invalid
+    )
+
+    var rawVSignature = walletSignature
+    rawVSignature[64] = UInt8(eip191Signature.v)
+    let rawVAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: rawVSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: rawVSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: rawVAcknowledgement
+      ),
+      .valid
+    )
+
+    var highSSignature = walletSignature
+    let highS = BarnardCoreSecp256k1.curveOrder.subtracting(
+      BarnardCoreSecp256k1.UInt256(bytes: eip191Signature.s)
+    ).bytes
+    highSSignature.replaceSubrange(
+      32..<64,
+      with: highS
+    )
+    highSSignature[64] = UInt8((eip191Signature.v ^ 1) + 27)
+    let highSAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: highSSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: highSSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: highSAcknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: [0xaa] + magic,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .smartWalletUnsupported
+    )
+  }
+
+  func testWalletVerifierPortCarriesObservationTime() {
+    let verifier: any BarnardCoreWalletVerifier = FixedWalletVerifier()
+    XCTAssertEqual(
+      verifier.verify(
+        address: [UInt8](repeating: 0, count: 20),
+        digest: [UInt8](repeating: 0, count: 32),
+        signature: [1, 2, 3]
+      ),
+      .valid(verifiedAtUnixSeconds: 1_753_863_200)
+    )
+  }
+
+  private func compressedPublicKey(privateKey: [UInt8]) -> [UInt8] {
+    BarnardCoreSecp256k1.compress(
+      BarnardCoreSecp256k1.multiply(
+        BarnardCoreSecp256k1.UInt256(bytes: privateKey),
+        BarnardCoreSecp256k1.generator
+      )
+    )
+  }
+}
+
+private struct FixedWalletVerifier: BarnardCoreWalletVerifier {
+  func verify(
+    address: [UInt8],
+    digest: [UInt8],
+    signature: [UInt8]
+  ) -> BarnardCoreWalletVerifierVerdict {
+    .valid(verifiedAtUnixSeconds: 1_753_863_200)
+  }
+}
+
+private func bytes(_ hex: String) -> [UInt8] {
+  stride(from: 0, to: hex.count, by: 2).map { offset in
+    let start = hex.index(hex.startIndex, offsetBy: offset)
+    let end = hex.index(start, offsetBy: 2)
+    return UInt8(hex[start..<end], radix: 16)!
+  }
+}
+
+private func hex(_ bytes: [UInt8]) -> String {
+  bytes.map {
+    let value = String($0, radix: 16)
+    return value.count == 1 ? "0" + value : value
+  }.joined()
+}

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyPrimitiveTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyPrimitiveTests.swift
@@ -1,0 +1,141 @@
+// Use of this source code is governed by a BSD-style license.
+
+import XCTest
+@testable import BarnardCore
+
+final class BarnardOwnerKeyPrimitiveTests: XCTestCase {
+  func testDeriveOwnerKeyPairMatchesCrossImplementationVectors() {
+    let zeroPair = BarnardCoreSigning.deriveOwnerKeyPair(
+      accountSecret: [UInt8](repeating: 0, count: 32)
+    )
+    XCTAssertEqual(
+      hex(zeroPair.privateKey),
+      "46cbfd04992339fab4937354a6f24c115a238f4bd133a8c43b18162ab986bf27"
+    )
+    XCTAssertEqual(
+      hex(zeroPair.publicKeyCompressed),
+      "03351e5165d083f53425fc4a51e7228d53e88eb2899bcb6a83368a8aafaa1de5f4"
+    )
+
+    let sequentialPair = BarnardCoreSigning.deriveOwnerKeyPair(
+      accountSecret: (0..<32).map(UInt8.init)
+    )
+    XCTAssertEqual(
+      hex(sequentialPair.privateKey),
+      "3cfd4805b144d962c1cddccdf8452f02bfe022a867f550b0eb5ed8b2512ec758"
+    )
+    XCTAssertEqual(
+      hex(sequentialPair.publicKeyCompressed),
+      "03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67"
+    )
+  }
+
+  func testKeccak256MatchesEthereumVectorsIncludingRateBoundaries() {
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256([])),
+      "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256(Array("abc".utf8))),
+      "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256((0..<135).map { UInt8($0 & 0xff) })),
+      "cbdfd9dee5faad3818d6b06f95a219fd290b0e1706f6a82e5a595b9ce9faca62"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256((0..<136).map { UInt8($0 & 0xff) })),
+      "7ce759f1ab7f9ce437719970c26b0a66ff11fe3e38e17df89cf5d29c7d7f807e"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256((0..<137).map { UInt8($0 & 0xff) })),
+      "ac73d4fae68b8453f764007c1a20ce95994187861f0c3227a3a8e99a73a3b1db"
+    )
+  }
+
+  func testUncompressedSec1SerializationAndEthereumAddressUseXYOnly() {
+    let generatorCompressed = bytes(
+      "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    )
+    let uncompressed = BarnardCoreSigning.serializeUncompressedPublicKey(
+      generatorCompressed
+    )
+
+    XCTAssertEqual(
+      hex(uncompressed ?? []),
+      "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        + "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.ethereumAddress(publicKeyCompressed: generatorCompressed) ?? []),
+      "7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.serializeUncompressedPublicKey(
+        [0x04] + [UInt8](repeating: 0, count: 32)
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.serializeUncompressedPublicKey(
+        [0x02] + [UInt8](repeating: 0xff, count: 32)
+      )
+    )
+  }
+
+  func testEip191DigestUsesUtf8ByteLength() {
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: "")),
+      "5f35dce98ba4fba25530a026ed80b2cecdaa31091ba4958b99b52ea1d068adad"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: "Hello World")),
+      "a1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: "é")),
+      "ba8cc708d7c0ceccba0ed21ddc61b53a0db963cffb45659d761ff24f520f0a99"
+    )
+  }
+
+  func testEthersPersonalSignVectorRecoversExpectedAddress() {
+    let digest = BarnardCoreSigning.computeEip191Digest(text: "Hello World")
+    let recovered = BarnardCoreSigning.recoverPublicKey(
+      recoveryId: 0,
+      r: bytes(
+        "a617d0558818c7a479d5063987981b59d6e619332ef52249be8243572ef10868"
+      ),
+      s: bytes(
+        "07e381afe644d9bb56b213f6e08374c893db308ac1a5ae2bf8b33bcddcb0f76a"
+      ),
+      messageHash32: digest
+    )
+
+    XCTAssertEqual(
+      hex(recovered ?? []),
+      "035163ad559bf4672c2cb557e073c8de4edc4a92a8fb39634b30ca7005fbcb1f6c"
+    )
+    XCTAssertEqual(
+      hex(
+        BarnardCoreSigning.ethereumAddress(
+          publicKeyCompressed: recovered ?? []
+        ) ?? []
+      ),
+      "0a489345f9e9bc5254e18dd14fa7ecfdb2ce5f21"
+    )
+  }
+
+  private func hex(_ input: [UInt8]) -> String {
+    input.map {
+      let value = String($0, radix: 16)
+      return value.count == 1 ? "0" + value : value
+    }.joined()
+  }
+
+  private func bytes(_ hex: String) -> [UInt8] {
+    stride(from: 0, to: hex.count, by: 2).map { offset in
+      let start = hex.index(hex.startIndex, offsetBy: offset)
+      let end = hex.index(start, offsetBy: 2)
+      return UInt8(hex[start..<end], radix: 16)!
+    }
+  }
+}

--- a/schema/barnard/v1/README.md
+++ b/schema/barnard/v1/README.md
@@ -5,8 +5,9 @@ JSON Schema definitions for Barnard v1.
 This is the shared source of truth for:
 - Events (detection/state/constraint/error + debug events)
 - Config and capabilities
+- Holder-held owner self-proof records
+- Holder-held wallet binding, owner-key rotation, and unbinding records
 
 Notes
 - Terminology is not translated: **Scan / Advertise / Central / Peripheral / GATT / Transport**
 - `DetectionEvent` is based on receiver-observed facts: `rpid + rssi + timestamp`
-

--- a/schema/barnard/v1/self-proof.schema.json
+++ b/schema/barnard/v1/self-proof.schema.json
@@ -44,7 +44,7 @@
       "x-barnard-byte-length": 33
     },
     "signature": {
-      "description": "65-byte Barnard-native recoverable signature r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
+      "description": "65-byte Barnard Recoverable secp256k1 Signature Profile v1 value r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
       "type": "string",
       "pattern": "^0x[0-9a-f]{128}(?:00|01)$",
       "x-barnard-byte-length": 65

--- a/schema/barnard/v1/self-proof.schema.json
+++ b/schema/barnard/v1/self-proof.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thegreeting.github.io/barnard/schema/barnard/v1/self-proof.schema.json",
+  "title": "Barnard Self-Proof Record (v1)",
+  "description": "Holder-held owner-key binding for one event signing key and ENIN range. This record is disclosed point-to-point and is never public or on-wire.",
+  "x-barnard-disclosure-scope": "holder-held",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "self-proof"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "eventIdHash": {
+      "description": "32-byte event identifier hash as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$",
+      "x-barnard-byte-length": 32
+    },
+    "eventSigningPublicKey": {
+      "description": "33-byte compressed SEC1 event signing public key as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+      "x-barnard-byte-length": 33
+    },
+    "eninStart": {
+      "description": "Inclusive unsigned ENIN range start.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 18446744073709551615
+    },
+    "eninEnd": {
+      "description": "Inclusive unsigned ENIN range end. It must be greater than or equal to eninStart.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 18446744073709551615
+    },
+    "ownerPublicKey": {
+      "description": "33-byte compressed SEC1 owner public key as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+      "x-barnard-byte-length": 33
+    },
+    "signature": {
+      "description": "65-byte Barnard-native recoverable signature r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{128}(?:00|01)$",
+      "x-barnard-byte-length": 65
+    }
+  },
+  "required": [
+    "type",
+    "schemaVersion",
+    "eventIdHash",
+    "eventSigningPublicKey",
+    "eninStart",
+    "eninEnd",
+    "ownerPublicKey",
+    "signature"
+  ]
+}

--- a/schema/barnard/v1/wallet-binding.schema.json
+++ b/schema/barnard/v1/wallet-binding.schema.json
@@ -35,7 +35,7 @@
       "x-barnard-byte-length": 20
     },
     "BarnardRecoverableSignature": {
-      "description": "65-byte Barnard-native signature r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
+      "description": "65-byte Barnard Recoverable secp256k1 Signature Profile v1 value r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
       "type": "string",
       "pattern": "^0x[0-9a-f]{128}(?:00|01)$",
       "x-barnard-byte-length": 65
@@ -49,7 +49,7 @@
     "BindingMessage": {
       "description": "Canonical UTF-8 account-binding text with LF line endings and no trailing newline.",
       "type": "string",
-      "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{1,5})? wants to bind this wallet to a Levarac owner key\\.\\n\\nThis signature authorizes no transaction and moves no assets\\.\\n\\nDomain-Tag: barnard-account-binding:v1\\nWallet: 0x[0-9a-f]{40}\\nOwner-Key: 0x(?:02|03)[0-9a-f]{64}\\nChain-ID: eip155:(?:0|[1-9][0-9]*)\\nNonce: 0x[0-9a-f]{32}\\nIssued-At: [0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])",
+      "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{1,5})? wants to bind this wallet to a Levarac owner key\\.\\n\\nThis signature authorizes no transaction and moves no assets\\.\\n\\nDomain-Tag: barnard-account-binding:v1\\nWallet: 0x[0-9a-f]{40}\\nOwner-Key: 0x(?:02|03)[0-9a-f]{64}\\nChain-ID: eip155:(?:0|[1-9][0-9]*)\\nScope: global\\nNonce: 0x[0-9a-f]{32}\\nIssued-At: [0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])",
       "allOf": [
         {
           "description": "The optional decimal port is canonical and in the 0...65535 range.",

--- a/schema/barnard/v1/wallet-binding.schema.json
+++ b/schema/barnard/v1/wallet-binding.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thegreeting.github.io/barnard/schema/barnard/v1/wallet-binding.schema.json",
+  "title": "Barnard Wallet Binding and Owner-Key Lifecycle Records (v1)",
+  "description": "Holder-held wallet endorsement, owner-key rotation, and account-unbinding records. These records are disclosed point-to-point and are never public or on-wire.",
+  "x-barnard-disclosure-scope": "holder-held",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/WalletBindingRecord"
+    },
+    {
+      "$ref": "#/$defs/AccountRotationRecord"
+    },
+    {
+      "$ref": "#/$defs/AccountUnbindingRecord"
+    }
+  ],
+  "$defs": {
+    "Hash32": {
+      "description": "32 bytes as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$",
+      "x-barnard-byte-length": 32
+    },
+    "OwnerPublicKey": {
+      "description": "33-byte compressed SEC1 owner public key as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+      "x-barnard-byte-length": 33
+    },
+    "WalletAddress": {
+      "description": "20-byte EVM address as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{40}$",
+      "x-barnard-byte-length": 20
+    },
+    "BarnardRecoverableSignature": {
+      "description": "65-byte Barnard-native signature r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{128}(?:00|01)$",
+      "x-barnard-byte-length": 65
+    },
+    "WalletSignature": {
+      "description": "65-byte EOA personal_sign signature r || s || v as 0x-prefixed lowercase hex. v is 0, 1, 27, or 28.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{128}(?:00|01|1b|1c)$",
+      "x-barnard-byte-length": 65
+    },
+    "BindingMessage": {
+      "description": "Canonical UTF-8 account-binding text with LF line endings and no trailing newline.",
+      "type": "string",
+      "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{1,5})? wants to bind this wallet to a Levarac owner key\\.\\n\\nThis signature authorizes no transaction and moves no assets\\.\\n\\nDomain-Tag: barnard-account-binding:v1\\nWallet: 0x[0-9a-f]{40}\\nOwner-Key: 0x(?:02|03)[0-9a-f]{64}\\nChain-ID: eip155:(?:0|[1-9][0-9]*)\\nNonce: 0x[0-9a-f]{32}\\nIssued-At: [0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])",
+      "allOf": [
+        {
+          "description": "The optional decimal port is canonical and in the 0...65535 range.",
+          "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::(?:0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))? wants "
+        },
+        {
+          "description": "Chain-ID is in the UInt64 range used by BarnardCore.",
+          "pattern": "\\nChain-ID: eip155:(?:0|[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|18446744073709550[0-9]{3}|18446744073709551[0-5][0-9]{2}|1844674407370955160[0-9]|1844674407370955161[0-4]|18446744073709551615)\\n"
+        },
+        {
+          "description": "Issued-At is a valid proleptic-Gregorian date at UTC second precision.",
+          "pattern": "\\nIssued-At: (?:[0-9]{4}-(?:(?:01|03|05|07|08|10|12)-(?:0[1-9]|[12][0-9]|3[01])|(?:04|06|09|11)-(?:0[1-9]|[12][0-9]|30)|02-(?:0[1-9]|1[0-9]|2[0-8]))|(?:[0-9]{2}(?:0[48]|[2468][048]|[13579][26])|(?:[02468][048]|[13579][26])00)-02-29)T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])"
+        }
+      ]
+    },
+    "WalletBindingRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "wallet-binding"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "message": {
+          "$ref": "#/$defs/BindingMessage"
+        },
+        "walletSignature": {
+          "$ref": "#/$defs/WalletSignature"
+        },
+        "ackSignature": {
+          "$ref": "#/$defs/BarnardRecoverableSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "message",
+        "walletSignature",
+        "ackSignature"
+      ]
+    },
+    "AccountRotationRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "account-rotation"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "previousOwnerPublicKey": {
+          "$ref": "#/$defs/OwnerPublicKey"
+        },
+        "successorOwnerPublicKey": {
+          "$ref": "#/$defs/OwnerPublicKey"
+        },
+        "signature": {
+          "$ref": "#/$defs/BarnardRecoverableSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "previousOwnerPublicKey",
+        "successorOwnerPublicKey",
+        "signature"
+      ]
+    },
+    "AccountUnbindingRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "account-unbinding"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "ownerPublicKey": {
+          "$ref": "#/$defs/OwnerPublicKey"
+        },
+        "walletAddress": {
+          "$ref": "#/$defs/WalletAddress"
+        },
+        "walletSignatureHash": {
+          "$ref": "#/$defs/Hash32"
+        },
+        "signer": {
+          "type": "string",
+          "enum": [
+            "owner",
+            "wallet"
+          ]
+        },
+        "signature": {
+          "$ref": "#/$defs/BarnardRecoverableSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "ownerPublicKey",
+        "walletAddress",
+        "walletSignatureHash",
+        "signer",
+        "signature"
+      ]
+    }
+  }
+}

--- a/scripts/check-schema-privacy-invariant.py
+++ b/scripts/check-schema-privacy-invariant.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Reject stable owner-key and wallet-address shapes in public/on-wire schemas."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urldefrag
+
+
+SCOPE_KEY = "x-barnard-disclosure-scope"
+PUBLIC_SCOPE = "public-on-wire"
+HOLDER_SCOPE = "holder-held"
+ALLOWED_SCOPES = {PUBLIC_SCOPE, HOLDER_SCOPE}
+FORBIDDEN_BYTE_LENGTHS = {20, 33}
+FORBIDDEN_HEX_LENGTHS = {40, 42, 66, 68}
+FORBIDDEN_BASE64_LENGTHS = {28, 44}
+SEMANTIC_FIELD_NAMES = {
+    "evmaddress",
+    "ownerpublickey",
+    "ownerpubkey",
+    "walletaddress",
+}
+HEX_PATTERN_LENGTH = re.compile(
+    r"(?:\{(?:40|42|66|68)\}"
+    r"|(?:02\|03|03\|02).*?\{64\})",
+    re.IGNORECASE,
+)
+PAIRED_BYTE_PATTERN_LENGTH = re.compile(
+    r"(?:"
+    r"\(\?:\[[^\]]+\]\{2\}\)\{(?:20|33)\}"
+    r"|(?:02\|03|03\|02).*?"
+    r"\(\?:\[[^\]]+\]\{2\}\)\{32\}"
+    r")",
+    re.IGNORECASE,
+)
+FORBIDDEN_DESCRIPTION = re.compile(
+    r"(?:33[\s-]*byte.*compressed.*(?:public[\s-]*key|pubkey)"
+    r"|20[\s-]*byte.*(?:evm|wallet)?\s*address)",
+    re.IGNORECASE,
+)
+
+
+def normalized_field_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def walk(value: Any, path: str = "$"):
+    yield path, value
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from walk(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from walk(child, f"{path}[{index}]")
+
+
+def shape_violations(document: dict[str, Any]) -> list[str]:
+    violations: list[str] = []
+    for path, node in walk(document):
+        if not isinstance(node, dict):
+            continue
+
+        byte_length = node.get("x-barnard-byte-length")
+        if byte_length in FORBIDDEN_BYTE_LENGTHS:
+            violations.append(
+                f"{path}: declares forbidden {byte_length}-byte stable identifier shape"
+            )
+
+        if (
+            node.get("type") == "array"
+            and node.get("minItems") == node.get("maxItems")
+            and node.get("minItems") in FORBIDDEN_BYTE_LENGTHS
+        ):
+            violations.append(
+                f"{path}: declares fixed {node['minItems']}-byte array shape"
+            )
+        prefix_items = node.get("prefixItems")
+        if (
+            node.get("type") == "array"
+            and isinstance(prefix_items, list)
+            and len(prefix_items) in FORBIDDEN_BYTE_LENGTHS
+            and node.get("items") is False
+        ):
+            violations.append(
+                f"{path}: declares fixed {len(prefix_items)}-byte prefixItems shape"
+            )
+
+        if node.get("type") == "string":
+            minimum = node.get("minLength")
+            maximum = node.get("maxLength")
+            if minimum == maximum and minimum in FORBIDDEN_HEX_LENGTHS:
+                violations.append(
+                    f"{path}: declares fixed {minimum}-character address/public-key shape"
+                )
+            if (
+                node.get("contentEncoding") == "base64"
+                and minimum == maximum
+                and minimum in FORBIDDEN_BASE64_LENGTHS
+            ):
+                violations.append(
+                    f"{path}: declares base64 length consistent with a 20/33-byte identifier"
+                )
+            pattern = node.get("pattern")
+            if isinstance(pattern, str) and HEX_PATTERN_LENGTH.search(pattern):
+                violations.append(
+                    f"{path}: declares exact hex length consistent with a 20/33-byte identifier"
+                )
+            if (
+                isinstance(pattern, str)
+                and PAIRED_BYTE_PATTERN_LENGTH.search(pattern)
+            ):
+                violations.append(
+                    f"{path}: declares paired-byte hex shape consistent with a 20/33-byte identifier"
+                )
+
+        properties = node.get("properties")
+        if isinstance(properties, dict):
+            for field_name in properties:
+                if normalized_field_name(field_name) in SEMANTIC_FIELD_NAMES:
+                    violations.append(
+                        f"{path}.properties.{field_name}: stable identifier field is public/on-wire"
+                    )
+
+        description = node.get("description")
+        if isinstance(description, str) and FORBIDDEN_DESCRIPTION.search(description):
+            violations.append(
+                f"{path}.description: describes a 20/33-byte stable identifier"
+            )
+    return violations
+
+
+def reference_violations(
+    schema_path: Path,
+    document: dict[str, Any],
+    scopes_by_path: dict[Path, str],
+    paths_by_id: dict[str, Path],
+) -> list[str]:
+    violations: list[str] = []
+    for path, node in walk(document):
+        if not isinstance(node, dict) or not isinstance(node.get("$ref"), str):
+            continue
+        reference, _ = urldefrag(node["$ref"])
+        if not reference:
+            continue
+        if reference in paths_by_id:
+            target = paths_by_id[reference]
+        else:
+            target = (schema_path.parent / reference).resolve()
+        if scopes_by_path.get(target) == HOLDER_SCOPE:
+            violations.append(
+                f"{path}.$ref: public/on-wire schema references holder-held schema {reference}"
+            )
+    return violations
+
+
+def check(schema_root: Path) -> tuple[list[str], int, int]:
+    failures: list[str] = []
+    documents: dict[Path, dict[str, Any]] = {}
+    scopes_by_path: dict[Path, str] = {}
+    paths_by_id: dict[str, Path] = {}
+
+    for schema_path in sorted(schema_root.rglob("*.schema.json")):
+        resolved_path = schema_path.resolve()
+        try:
+            raw = json.loads(schema_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            failures.append(f"{schema_path}: invalid JSON schema document: {error}")
+            continue
+        if not isinstance(raw, dict):
+            failures.append(f"{schema_path}: schema document root must be an object")
+            continue
+        scope = raw.get(SCOPE_KEY, PUBLIC_SCOPE)
+        if scope not in ALLOWED_SCOPES:
+            failures.append(
+                f"{schema_path}: {SCOPE_KEY} must be one of {sorted(ALLOWED_SCOPES)}"
+            )
+            continue
+        for path, node in walk(raw):
+            if (
+                path != "$"
+                and isinstance(node, dict)
+                and SCOPE_KEY in node
+            ):
+                failures.append(
+                    f"{schema_path}:{path}: {SCOPE_KEY} is valid only at the document root"
+                )
+        documents[resolved_path] = raw
+        scopes_by_path[resolved_path] = scope
+        schema_id = raw.get("$id")
+        if isinstance(schema_id, str):
+            paths_by_id[schema_id] = resolved_path
+
+    for schema_path, document in documents.items():
+        if scopes_by_path[schema_path] != PUBLIC_SCOPE:
+            continue
+        for violation in shape_violations(document):
+            failures.append(f"{schema_path}: {violation}")
+        for violation in reference_violations(
+            schema_path,
+            document,
+            scopes_by_path,
+            paths_by_id,
+        ):
+            failures.append(f"{schema_path}: {violation}")
+
+    public_count = sum(scope == PUBLIC_SCOPE for scope in scopes_by_path.values())
+    holder_count = sum(scope == HOLDER_SCOPE for scope in scopes_by_path.values())
+    return failures, public_count, holder_count
+
+
+def self_test() -> list[str]:
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        root = Path(temporary_directory)
+        holder = {
+            "$id": "https://example.invalid/holder.schema.json",
+            SCOPE_KEY: HOLDER_SCOPE,
+            "type": "string",
+            "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+            "x-barnard-byte-length": 33,
+        }
+        public_address = {
+            "type": "object",
+            "properties": {
+                "walletAddress": {
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{40}$",
+                }
+            },
+        }
+        public_reference = {
+            "type": "object",
+            "properties": {
+                "leak": {"$ref": "https://example.invalid/holder.schema.json"}
+            },
+        }
+        public_paired_address = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "pattern": "^0x(?:[0-9a-f]{2}){20}$",
+                }
+            },
+        }
+        public_paired_public_key = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "pattern": "^(?:02|03)(?:[0-9a-f]{2}){32}$",
+                }
+            },
+        }
+        byte_item = {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255,
+        }
+        public_prefix_items_20 = {
+            "type": "array",
+            "prefixItems": [byte_item] * 20,
+            "items": False,
+        }
+        public_prefix_items_33 = {
+            "type": "array",
+            "prefixItems": [byte_item] * 33,
+            "items": False,
+        }
+        (root / "holder.schema.json").write_text(
+            json.dumps(holder),
+            encoding="utf-8",
+        )
+        (root / "public-address.schema.json").write_text(
+            json.dumps(public_address),
+            encoding="utf-8",
+        )
+        (root / "public-reference.schema.json").write_text(
+            json.dumps(public_reference),
+            encoding="utf-8",
+        )
+        (root / "public-paired-address.schema.json").write_text(
+            json.dumps(public_paired_address),
+            encoding="utf-8",
+        )
+        (root / "public-paired-public-key.schema.json").write_text(
+            json.dumps(public_paired_public_key),
+            encoding="utf-8",
+        )
+        (root / "public-prefix-items-20.schema.json").write_text(
+            json.dumps(public_prefix_items_20),
+            encoding="utf-8",
+        )
+        (root / "public-prefix-items-33.schema.json").write_text(
+            json.dumps(public_prefix_items_33),
+            encoding="utf-8",
+        )
+
+        violations, public_count, holder_count = check(root)
+        joined = "\n".join(violations)
+        if "exact hex length" not in joined:
+            failures.append("self-test did not reject a public 20-byte hex shape")
+        if "stable identifier field" not in joined:
+            failures.append("self-test did not reject a public walletAddress field")
+        if "references holder-held schema" not in joined:
+            failures.append("self-test did not reject a public reference to holder-held data")
+        if joined.count("paired-byte hex shape") != 2:
+            failures.append(
+                "self-test did not reject both 20- and 33-byte paired-hex shapes"
+            )
+        if joined.count("prefixItems shape") != 2:
+            failures.append(
+                "self-test did not reject both 20- and 33-byte prefixItems shapes"
+            )
+        if public_count != 6 or holder_count != 1:
+            failures.append(
+                "self-test scope counts drifted "
+                f"(public={public_count}, holder={holder_count})"
+            )
+
+        positive_root = root / "holder-only"
+        positive_root.mkdir()
+        (positive_root / "holder.schema.json").write_text(
+            json.dumps(holder),
+            encoding="utf-8",
+        )
+        positive_violations, _, _ = check(positive_root)
+        if positive_violations:
+            failures.append(
+                "self-test rejected an explicitly holder-held identifier shape"
+            )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_root = Path(__file__).resolve().parents[1] / "schema"
+    parser.add_argument(
+        "--schema-root",
+        type=Path,
+        default=default_root,
+        help="schema directory to scan (defaults to the repository schema directory)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="exercise synthetic forbidden and holder-held fixtures before scanning",
+    )
+    arguments = parser.parse_args()
+
+    if arguments.self_test:
+        self_test_failures = self_test()
+        if self_test_failures:
+            for failure in self_test_failures:
+                print(f"ERROR: {failure}", file=sys.stderr)
+            return 1
+        print("OK: schema privacy invariant self-tests passed.")
+
+    failures, public_count, holder_count = check(arguments.schema_root)
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+    print(
+        "OK: schema privacy invariant holds "
+        f"({public_count} public/on-wire, {holder_count} holder-held documents)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-wallet-binding-schema.py
+++ b/scripts/check-wallet-binding-schema.py
@@ -54,6 +54,7 @@ def message(
                 "959f2815b16f81798"
             ),
             f"Chain-ID: eip155:{chain_id}",
+            "Scope: global",
             "Nonce: 0x000102030405060708090a0b0c0d0e0f",
             f"Issued-At: {issued_at}",
         ]
@@ -93,6 +94,18 @@ def main() -> int:
         message(issued_at="2026-02-31T09:00:00Z"),
         message(issued_at="1900-02-29T09:00:00Z"),
         message(issued_at="2026-04-31T09:00:00Z"),
+        message().replace("\nScope: global", ""),
+        message().replace("Scope: global", "Scope: event"),
+        message().replace(
+            (
+                "\nScope: global"
+                "\nNonce: 0x000102030405060708090a0b0c0d0e0f"
+            ),
+            (
+                "\nNonce: 0x000102030405060708090a0b0c0d0e0f"
+                "\nScope: global"
+            ),
+        ),
         message() + "\n",
         message().replace("\n", "\r\n"),
     ]

--- a/scripts/check-wallet-binding-schema.py
+++ b/scripts/check-wallet-binding-schema.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Exercise canonical wallet-binding schema boundaries without dependencies."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def binding_message_schema(schema_path: Path) -> dict[str, Any]:
+    document = json.loads(schema_path.read_text(encoding="utf-8"))
+    message = document.get("$defs", {}).get("BindingMessage")
+    if not isinstance(message, dict):
+        raise ValueError("$defs.BindingMessage is missing or is not an object")
+    return message
+
+
+def matches(schema: dict[str, Any], value: str) -> bool:
+    patterns = [schema.get("pattern")]
+    all_of = schema.get("allOf")
+    if not isinstance(all_of, list):
+        return False
+    patterns.extend(
+        constraint.get("pattern")
+        for constraint in all_of
+        if isinstance(constraint, dict)
+    )
+    return all(
+        isinstance(pattern, str) and re.search(pattern, value) is not None
+        for pattern in patterns
+    )
+
+
+def message(
+    *,
+    domain: str = "beid.levarac.org",
+    chain_id: str = "1",
+    issued_at: str = "2026-07-30T09:00:00Z",
+) -> str:
+    return "\n".join(
+        [
+            f"{domain} wants to bind this wallet to a Levarac owner key.",
+            "",
+            "This signature authorizes no transaction and moves no assets.",
+            "",
+            "Domain-Tag: barnard-account-binding:v1",
+            "Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325",
+            (
+                "Owner-Key: "
+                "0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d"
+                "959f2815b16f81798"
+            ),
+            f"Chain-ID: eip155:{chain_id}",
+            "Nonce: 0x000102030405060708090a0b0c0d0e0f",
+            f"Issued-At: {issued_at}",
+        ]
+    )
+
+
+def main() -> int:
+    schema_path = (
+        Path(__file__).resolve().parents[1]
+        / "schema"
+        / "barnard"
+        / "v1"
+        / "wallet-binding.schema.json"
+    )
+    try:
+        schema = binding_message_schema(schema_path)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
+        print(f"ERROR: cannot load binding-message schema: {error}", file=sys.stderr)
+        return 1
+
+    accepted = [
+        message(),
+        message(domain="beid.levarac.org:0"),
+        message(domain="beid.levarac.org:65535"),
+        message(chain_id="0"),
+        message(chain_id="18446744073709551615"),
+        message(issued_at="2024-02-29T23:59:59Z"),
+        message(issued_at="2000-02-29T00:00:00Z"),
+    ]
+    rejected = [
+        message(domain="beid.levarac.org:00080"),
+        message(domain="beid.levarac.org:65536"),
+        message(domain="beid.levarac.org:99999"),
+        message(chain_id="01"),
+        message(chain_id="18446744073709551616"),
+        message(issued_at="2026-02-29T09:00:00Z"),
+        message(issued_at="2026-02-31T09:00:00Z"),
+        message(issued_at="1900-02-29T09:00:00Z"),
+        message(issued_at="2026-04-31T09:00:00Z"),
+        message() + "\n",
+        message().replace("\n", "\r\n"),
+    ]
+
+    failures: list[str] = []
+    for index, fixture in enumerate(accepted):
+        if not matches(schema, fixture):
+            failures.append(f"valid fixture {index} was rejected")
+    for index, fixture in enumerate(rejected):
+        if matches(schema, fixture):
+            failures.append(f"invalid fixture {index} was accepted")
+
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+    print(
+        "OK: wallet-binding schema accepts canonical boundary fixtures "
+        f"({len(accepted)} valid, {len(rejected)} invalid)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mirror-manifest.sh
+++ b/scripts/mirror-manifest.sh
@@ -16,6 +16,7 @@ swift_mirrored_pairs=(
   "BarnardCore/BarnardCoreCrypto.swift|BarnardCore/BarnardCoreCrypto.swift"
   "BarnardCore/BarnardCorePolicy.swift|BarnardCore/BarnardCorePolicy.swift"
   "BarnardCore/BarnardCorePrimitives.swift|BarnardCore/BarnardCorePrimitives.swift"
+  "BarnardCore/BarnardCoreOwnerKey.swift|BarnardCore/BarnardCoreOwnerKey.swift"
   "BarnardCore/BarnardCoreSigning.swift|BarnardCore/BarnardCoreSigning.swift"
   "BarnardCore/Secp256k1.swift|BarnardCore/Secp256k1.swift"
 )

--- a/specs/092-owner-key/spec.md
+++ b/specs/092-owner-key/spec.md
@@ -1,0 +1,485 @@
+# Owner Key and Optional Wallet Endorsement
+
+## Problem statement
+
+Barnard has per-event signing keys and RPID-ownership proofs, but it has no
+long-lived identity anchor. A holder therefore cannot selectively prove that
+multiple pseudonymous event histories belong to the same persona. Requiring an
+EVM wallet as that anchor would exclude wallet-less participants and would
+couple the protocol to wallet software and RPC availability.
+
+This specification adds an **owner key**: a deterministic, long-lived
+secp256k1 key pair derived from an independently generated `AccountSecret`.
+Every participant can use the owner key without a wallet (Tier 0). An EVM
+wallet may optionally endorse the owner key through a human-readable
+`personal_sign` ceremony (Tier 1).
+
+Key generation entropy, secret custody, backup, migration, wallet transport,
+and user-interface flows remain host responsibilities. Barnard provides only
+pure, deterministic formats, builders, signing, and verification.
+
+## Goals
+
+- Define a long-lived owner key that is independent of `DeviceSecret`.
+- Bind an event signing key to an owner key without disclosing TEK or RPIK.
+- Define an optional, mutually authenticated EVM wallet endorsement.
+- Define deterministic rotation and unbinding formats before host UX ships.
+- Keep every operation in `BarnardCore` free of randomness, clock access,
+  storage, wallet SDKs, and RPC configuration.
+- Preserve full protocol capability for wallet-less Tier 0 holders.
+- Keep all stable owner and wallet identifiers out of public and on-wire
+  artifacts.
+
+## Non-goals
+
+- Generating, storing, backing up, or migrating `AccountSecret`.
+- Wallet discovery, connection, SDK integration, or transaction signing.
+- ERC-1271 or ERC-6492 RPC verification in v1.
+- Presentation-time challenge-response or credential-transfer resistance.
+- Changing Scan, Advertise, Central, Peripheral, GATT, Transport, RPID,
+  event-signing, or existing RPID-ownership-proof behavior.
+- Adding Kotlin or React Native implementations.
+
+## Glossary
+
+- **owner key**: a long-lived secp256k1 key pair anchoring one holder-chosen
+  persona. Its compressed public key is 33-byte SEC1.
+- **AccountSecret**: an independently generated 32-byte random seed and the
+  sole input to owner-key derivation.
+- **event signing key**: the per-event secp256k1 key pair derived from
+  `DeviceSecret` and `EventCode`.
+- **self-proof**: an owner-key signature binding one event signing public key
+  and ENIN range to the owner key.
+- **wallet endorsement / account binding**: an EIP-191 `personal_sign`
+  signature by an EVM account over the canonical binding text, plus a
+  mandatory owner-key acknowledgement.
+- **EOA**: an externally owned EVM account whose signature can be verified by
+  public-key recovery without RPC.
+- **smart wallet**: an account requiring contract-aware verification such as
+  ERC-1271 or ERC-6492.
+- **Tier 0 / Tier 1**: owner-key identity without / with a wallet endorsement.
+- **holder-held artifact**: a record retained by the holder and disclosed
+  point-to-point, never placed in Advertise, GATT, anchors, or witness blobs.
+
+## Key hierarchy
+
+```text
+DeviceSecret (device-scoped random seed)
+├─ TEK = HKDF(DeviceSecret || EventCode)
+│  └─ RPID = f(TEK, ENIN)
+└─ event signing key = KDF(DeviceSecret, EventCode)
+
+AccountSecret (independent 32-byte random seed)
+└─ owner key = ownerKDF(AccountSecret)
+   └─ signs self-proofs for event signing keys
+
+wallet EOA -- personal_sign --> endorses the owner public key
+owner key  -- SHA-256/ECDSA --> acknowledges the exact wallet endorsement
+```
+
+`AccountSecret` MUST NOT be derived from `DeviceSecret`. The owner key needs an
+independent backup and migration lifetime; `DeviceSecret` remains
+device-scoped.
+
+### Owner-key derivation
+
+`deriveOwnerKeyPair` accepts exactly 32 bytes and follows the existing
+`deriveSigningKeyPair` scalar convention:
+
+1. Compute HKDF-SHA256 with:
+   - IKM = `AccountSecret`
+   - salt = 32 zero bytes (the existing omitted-salt convention)
+   - info = UTF-8 `barnard-owner`
+   - output length = 32 bytes
+2. Interpret the output as one unsigned big-endian integer.
+3. Reduce once modulo the secp256k1 curve order `n`.
+4. If the result is zero, set `seed = SHA256(seed)` and repeat steps 2–4.
+5. Serialize the private scalar as 32-byte big-endian and the public key as
+   33-byte compressed SEC1.
+
+The same `AccountSecret` MUST produce the same key pair on every platform.
+The `AccountSecret` itself is never used directly as a private key.
+
+## Barnard-native signature rules
+
+All four binary message families below use secp256k1 with deterministic
+RFC 6979 signing over `SHA256(message)`. Signers emit low-S signatures.
+Signatures serialize as:
+
+```text
+r (32-byte unsigned big-endian)
+|| s (32-byte unsigned big-endian)
+|| recoveryId (1 byte, 0x00 or 0x01)
+```
+
+Every verifier MUST reject:
+
+- a field whose byte length does not match its layout;
+- `r` or `s` equal to zero or greater than or equal to curve order `n`;
+- `s > n / 2`;
+- a recovery ID other than `0` or `1`;
+- a recovered key that does not match the required signer.
+
+Domain tags are raw UTF-8 bytes. All following fields have fixed widths; a
+variable input is converted to a fixed 32-byte digest before inclusion. No
+delimiter or implicit host-language encoding is present.
+
+## Message formats and behavior
+
+### 1. Self-proof
+
+Domain tag: `barnard-self-proof:v1`
+
+```text
+offset  size  value
+0       21    UTF-8 "barnard-self-proof:v1"
+21      32    eventIdHash
+53      33    eventSigningPublicKey (compressed SEC1)
+86       8    eninStart (unsigned big-endian)
+94       8    eninEnd (unsigned big-endian)
+102     33    ownerPublicKey (compressed SEC1)
+total  135
+```
+
+`eninStart` MUST be less than or equal to `eninEnd`. The owner private key signs
+the 135-byte message. Verification hashes the message with SHA-256, recovers
+the signer, and requires it to equal `ownerPublicKey`.
+
+The self-proof binds control of the owner key to the named event signing key
+for the stated ENIN range. It does not contain TEK, RPIK, or an RPID.
+
+### 2. Wallet acknowledgement
+
+Domain tag: `barnard-wallet-ack:v1`
+
+```text
+offset  size  value
+0       21    UTF-8 "barnard-wallet-ack:v1"
+21      20    walletAddress
+41      32    SHA256(walletSignatureBytes)
+total   73
+```
+
+The owner private key signs this message. Verification recovers the signer and
+requires it to equal the owner public key from the canonical binding text.
+Hashing the exact wallet signature makes the acknowledgement specific to one
+endorsement, rather than merely to an address.
+
+### 3. Owner-key rotation
+
+Domain tag: `barnard-account-rotation:v1`
+
+```text
+offset  size  value
+0       27    UTF-8 "barnard-account-rotation:v1"
+27      33    previousOwnerPublicKey (compressed SEC1)
+60      33    successorOwnerPublicKey (compressed SEC1)
+total   93
+```
+
+The previous owner key signs this message. Verification recovers the signer
+and requires it to equal `previousOwnerPublicKey`. Including both keys makes
+the direction of succession explicit. The previous and successor keys MUST
+be distinct; a same-key rotation is invalid. A Tier 1 holder MUST run a new
+wallet binding ceremony for the successor; wallet endorsements do not
+transfer implicitly.
+
+### 4. Account unbinding
+
+Domain tag: `barnard-account-unbinding:v1`
+
+```text
+offset  size  value
+0       28    UTF-8 "barnard-account-unbinding:v1"
+28      33    ownerPublicKey (compressed SEC1)
+61      20    walletAddress
+81      32    walletSignatureHash = SHA256(walletSignatureBytes)
+total  113
+```
+
+The digest identifies one exact wallet-binding record. Either the owner key or
+the EOA key controlling `walletAddress` may sign the SHA-256 digest of this
+Barnard-native message. Verification therefore takes an explicit signer kind:
+
+- `owner`: the recovered compressed key MUST equal `ownerPublicKey`;
+- `wallet`: the recovered key is decompressed, its Ethereum address is
+  derived, and that address MUST equal `walletAddress`.
+
+The wallet-signing host UX for this reserved lifecycle format is not part of
+v1. It is not the account-binding `personal_sign` ceremony and MUST NOT be
+silently substituted for it.
+
+## Canonical wallet-binding text
+
+Open question 2 from the issue is resolved here. v1 includes the drafted
+human-readable authorization statement but omits the unrelated URI, request,
+resource, and expiration fields from full EIP-4361. This is the smallest field
+set that identifies the protocol, account, owner key, chain context, ceremony,
+and issuance time while stating that no transaction is authorized.
+
+The exact text is:
+
+```text
+{domain} wants to bind this wallet to a Levarac owner key.
+
+This signature authorizes no transaction and moves no assets.
+
+Domain-Tag: barnard-account-binding:v1
+Wallet: 0x{walletAddress lowercase hex}
+Owner-Key: 0x{compressed owner public key lowercase hex}
+Chain-ID: eip155:{chainId unsigned decimal}
+Nonce: 0x{16-byte nonce lowercase hex}
+Issued-At: {issuedAt}
+```
+
+Canonical encoding rules are normative:
+
+- Encode the complete text as UTF-8.
+- Use LF (`0x0a`) only; CR is forbidden.
+- Preserve the exact field names, punctuation, capitalization, blank lines,
+  and order shown above.
+- Do not append a trailing LF or any other trailing byte.
+- `domain` is an already-normalized, lowercase ASCII authority (host or host
+  plus a decimal port in the range 0 through 65535) with no whitespace, slash,
+  CR, or LF. A port has no leading zero unless it is exactly `0`. Lowercase is
+  pinned so two hosts cannot produce different signatures by varying DNS
+  casing; Barnard emits the validated value exactly as supplied.
+- `walletAddress` is exactly 20 bytes and is emitted as `0x` plus 40 lowercase
+  hexadecimal digits.
+- `ownerPublicKey` is exactly 33-byte compressed SEC1, begins with `0x02` or
+  `0x03`, and is emitted as `0x` plus 66 lowercase hexadecimal digits.
+- `chainId` is an unsigned 64-bit integer in the range 0 through
+  18446744073709551615, emitted in base 10 with no leading zero, except that
+  zero is emitted as `0`.
+- `nonce` is exactly 16 bytes and is emitted as `0x` plus 32 lowercase
+  hexadecimal digits.
+- `issuedAt` is supplied by the host as a valid proleptic-Gregorian calendar
+  date in RFC 3339 UTC, second precision: `YYYY-MM-DDTHH:MM:SSZ`. Barnard does
+  not read a clock.
+- No Unicode normalization, address checksum casing, JSON serialization, or
+  locale-sensitive formatting is applied.
+
+`nonce` and `issuedAt` make ceremonies unique and referenceable. They are not
+a replay-prevention promise: a valid binding remains an idempotent long-lived
+fact until an account-unbinding record revokes it. `Chain-ID` is context and
+policy metadata; EIP-191 `personal_sign` itself is chain-agnostic.
+
+### Example
+
+For domain `beid.levarac.org`, the EOA derived from private scalar 1, the
+compressed generator owner key, chain ID 1, nonce bytes `00` through `0f`, and
+issuance at 2026-07-30 09:00 UTC, the byte-exact text is:
+
+```text
+beid.levarac.org wants to bind this wallet to a Levarac owner key.
+
+This signature authorizes no transaction and moves no assets.
+
+Domain-Tag: barnard-account-binding:v1
+Wallet: 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+Owner-Key: 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+Chain-ID: eip155:1
+Nonce: 0x000102030405060708090a0b0c0d0e0f
+Issued-At: 2026-07-30T09:00:00Z
+```
+
+## EIP-191 and Ethereum address derivation
+
+`computeEip191Digest(text)` computes:
+
+```text
+keccak256(
+  0x19
+  || UTF-8 "Ethereum Signed Message:\n"
+  || ASCII decimal(UTF8(text).count)
+  || UTF8(text)
+)
+```
+
+The length is the UTF-8 byte count, not a character count. `keccak256` is the
+Ethereum Keccak-256 variant with rate 136 bytes and domain/padding bytes
+`0x01 ... 0x80`. NIST SHA3-256 (`0x06 ... 0x80`) is incompatible and MUST NOT
+be substituted.
+
+To derive an EVM address from a recovered compressed public key:
+
+1. Parse the 33-byte compressed SEC1 point and serialize it as uncompressed
+   SEC1 `0x04 || x32 || y32`.
+2. Hash `x32 || y32` with Ethereum Keccak-256; do not hash the `0x04` prefix.
+3. Take the last 20 bytes.
+
+## Wallet signature classification
+
+Classification is a pure shape check and returns a typed result:
+
+1. If the byte string ends with the 32-byte ERC-6492 magic suffix
+   `0x6492` repeated 16 times, return `smartWalletUnsupported`. Suffix
+   detection has priority over length.
+2. Otherwise, if its length is exactly 65 bytes, return `validEoaShape`.
+3. Otherwise return `invalid`.
+
+`validEoaShape` does not mean cryptographically valid. Scalar, low-S,
+recovery-ID, recovered-address, and acknowledgement checks occur during
+verification.
+
+## EOA wallet-binding verification
+
+`verifyWalletBinding` verifies one record only. It takes the byte-exact
+canonical text, wallet signature, expected 20-byte wallet address, expected
+33-byte owner public key, and owner acknowledgement signature.
+
+1. Parse the supplied text under the canonical grammar, reconstruct it
+   byte-for-byte, and require its `Wallet:` and `Owner-Key:` fields to equal
+   `expectedWalletAddress` and `expectedOwnerPublicKey`. Reject any
+   noncanonical text, field mismatch, CR, or trailing LF before treating the
+   signature as an endorsement.
+2. Classify the wallet signature.
+   - `smartWalletUnsupported` returns an unverified smart-wallet result.
+   - `invalid` returns an invalid-shape result.
+3. Parse `r || s || v` from the 65-byte signature.
+4. Normalize `v = 27` to recovery ID 0 and `v = 28` to recovery ID 1. Raw
+   `v = 0` and `v = 1` are also accepted. Reject every other value.
+5. Require valid non-zero `r` and `s` scalars and low-S.
+6. Compute the EIP-191 digest and recover the public key with the existing
+   recovery primitive. Recovery IDs 2 and 3 remain unsupported deliberately.
+7. Derive the recovered Ethereum address and compare it byte-for-byte with
+   `expectedWalletAddress`. Human-readable hex comparisons at API boundaries
+   are case-insensitive, then decoded to these 20 bytes.
+8. Rebuild `barnard-wallet-ack:v1` from the expected address and exact wallet
+   signature bytes. Verify its SHA-256 signature, including scalar and low-S
+   rules, against `expectedOwnerPublicKey`.
+9. Only if the canonical binding and both signatures pass, return `valid`.
+
+The API does not aggregate endorsements and does not query RPC.
+
+## Smart-wallet verifier port
+
+Barnard defines a host-implemented port only:
+
+```text
+verify(address20, digest32, signatureBytes) -> verdict
+```
+
+The verdict is one of:
+
+- `valid(verifiedAtUnixSeconds)`;
+- `invalid(verifiedAtUnixSeconds)`;
+- `unverified`.
+
+No RPC client, endpoint, credential, retry, timeout, cache, or chain-selection
+code belongs in Barnard. v2 hosts may implement the port with ERC-1271/6492
+RPC. Contract state is time-dependent, so every valid or invalid RPC verdict
+MUST record the observation time. A verifier without RPC returns `unverified`;
+the endorsement then contributes no Tier 1 claim and the holder retains normal
+Tier 0 semantics.
+
+## Multi-wallet and persona rules
+
+The model is **N wallets to one owner key**. Every wallet independently signs a
+binding text for the same owner public key and receives its own owner
+acknowledgement.
+
+- Verifiers MUST NOT require disclosure of every endorsement.
+- Verification APIs MUST remain per-record and MUST NOT offer aggregate
+  all-wallet verification.
+- Choosing another wallet endorsement changes only what the holder discloses;
+  it MUST NOT create or rotate an owner key.
+- Multiple owner keys (personas) are legal only through explicit user action.
+- Hosts manage endorsement collections and disclosure choices outside
+  BarnardCore.
+
+## Tier 0 guarantee
+
+| Capability | Tier 0 (no wallet) | Tier 1 (wallet-bound) |
+|---|---|---|
+| Within-event RPID ownership | Full | Same |
+| Three-leg credential | Full, using the local owner key | Same |
+| Cross-event selective disclosure | Full, same owner-key algorithm | Same plus optional wallet check |
+| Device-loss continuity | Requires `AccountSecret` backup | Wallet may endorse a successor after rotation |
+| External identity bridge | None by design | EVM address endorsement |
+
+Loss of an unbacked-up `AccountSecret` orphans cross-event linkage. Existing
+per-event artifacts remain independently verifiable; Barnard does not invent a
+custodial recovery service.
+
+## Compatibility
+
+- All schemas and APIs in this specification are additive.
+- No existing public schema or on-wire format changes.
+- Existing Advertise, Scan, Central, Peripheral, GATT, Transport, RPID,
+  event-signing, and RPID-proof behavior remains unchanged.
+- New domain tags are disjoint from existing Barnard tags.
+- EIP-191 prefixing and Ethereum Keccak keep wallet signatures in a different
+  hash universe from Barnard-native SHA-256 signatures.
+
+## Security and privacy
+
+**No device-unique persistent identifiers are added on-wire.** Owner public
+keys, wallet addresses, self-proofs, wallet bindings, rotations, and
+unbindings are holder-held artifacts disclosed point-to-point. They MUST NOT
+appear in Advertise data, GATT values, public anchors, or witness blobs.
+
+The schema privacy invariant treats every schema as public/on-wire unless its
+document root explicitly declares holder-held disclosure scope. Public/on-wire
+schemas MUST NOT define a 33-byte compressed-public-key shape, a 20-byte
+address shape, or references into holder-held schemas.
+
+The wallet ceremony has three domain-separation layers:
+
+1. EIP-191 prevents cross-use as a transaction or Barnard-native signature.
+2. `Domain-Tag: barnard-account-binding:v1` prevents cross-protocol reuse.
+3. The visible domain and no-assets statement reduce blind-signing risk.
+
+Wallet linkage intentionally connects disclosed event history to a public
+address. Hosts MUST request explicit consent and MUST NOT auto-prompt binding.
+Using a fresh wallet address remains valid.
+
+## Errors and retry behavior
+
+- Pure builders are deterministic and perform no retries.
+- Invalid fixed-length inputs are rejected before hashing or recovery.
+- Cryptographically invalid signatures return typed invalid verdicts and do
+  not throw or trap.
+- ERC-6492 is classified before EOA validation and returns
+  `smartWalletUnsupported` in v1.
+- Owner-key zero-scalar derivation is the only retry loop and re-hashes the
+  32-byte seed deterministically as specified above.
+- RPC retry, timeout, and backoff are outside Barnard and belong to a future
+  host implementation of the verifier port.
+
+## Rejected alternatives
+
+- Using `AccountSecret` directly as the private key: rejected to preserve
+  domain separation and sibling-key derivation headroom.
+- Deriving the owner key from `DeviceSecret`: rejected because device and
+  identity migration lifetimes differ.
+- P-256 Secure Enclave / StrongBox or passkeys: rejected because
+  non-exportable keys conflict with the required backup and migration model,
+  and passkeys cannot sign arbitrary protocol payloads.
+- Ed25519: rejected to avoid a third signature stack with no protocol benefit.
+- BLAKE3: rejected because SHA-256 matches the existing portable Barnard stack.
+- Full EIP-4361 login fields: rejected because this is an endorsement, not an
+  authentication session; unused URI/resource/expiration fields add canonical
+  inputs without improving the binding.
+- A binding text without the no-assets statement: rejected because the
+  ceremony must remain human-readable and explicitly non-transactional.
+
+## Future work
+
+- ERC-1271/6492 verification through the verifier port.
+- EIP-712 binding under `barnard-account-binding:v2`.
+- Host UX for account rotation and wallet-authorized unbinding.
+- Presentation-time challenge-response.
+- Post-quantum migration through versioned domain tags and rotation records.
+
+## Validation
+
+- Cross-implementation HKDF owner-key vectors.
+- Standard Ethereum Keccak-256 vectors, including empty input and `abc`.
+- EIP-191 digest and `personal_sign` fixtures generated outside BarnardCore.
+- Unit tests for every builder, signer, verifier, malformed scalar, high-S
+  signature, recovery-ID normalization, address mismatch, acknowledgement
+  mismatch, ERC-6492 suffix, and canonical text byte.
+- C ABI tests for all exported owner-key functions and invalid arguments.
+- Schema syntax and privacy-invariant CI.
+- Existing Swift package and mirror checks remain green.

--- a/specs/092-owner-key/spec.md
+++ b/specs/092-owner-key/spec.md
@@ -104,13 +104,19 @@ The `AccountSecret` itself is never used directly as a private key.
 
 All four binary message families below use secp256k1 with deterministic
 RFC 6979 signing over `SHA256(message)`. Signers emit low-S signatures.
-Signatures serialize as:
+This 65-byte format is named the **Barnard Recoverable secp256k1 Signature
+Profile v1**. Signatures in this profile serialize as:
 
 ```text
 r (32-byte unsigned big-endian)
 || s (32-byte unsigned big-endian)
 || recoveryId (1 byte, 0x00 or 0x01)
 ```
+
+The Barnard profile is not ES256K. ES256K, as specified by RFC 8812, is a
+64-octet `R || S` ECDSA signature over SHA-256 and has no recovery byte.
+Implementations, schemas, and documentation MUST NOT label a Barnard
+`r || s || recoveryId` signature as ES256K.
 
 Every verifier MUST reject:
 
@@ -147,6 +153,15 @@ the signer, and requires it to equal `ownerPublicKey`.
 
 The self-proof binds control of the owner key to the named event signing key
 for the stated ENIN range. It does not contain TEK, RPIK, or an RPID.
+
+The self-proof maps to the typed-envelope fields as follows: envelope `type`
+is represented by the `barnard-self-proof` domain tag, `protocolVersion` by
+its `:v1` suffix, `eventIdHash` by the same-named message field,
+`signingPubkey` by `eventSigningPublicKey`, the ENIN window by `eninStart` and
+`eninEnd`, and `ownerPubkey` by `ownerPublicKey`. Reporting-layer
+`eventDefinitionDigest` and `reportDigest` fields are deliberately outside
+the self-proof signature scope. The SCITT RFCs listed under References are
+prior art for that separate reporting layer.
 
 ### 2. Wallet acknowledgement
 
@@ -214,8 +229,9 @@ silently substituted for it.
 Open question 2 from the issue is resolved here. v1 includes the drafted
 human-readable authorization statement but omits the unrelated URI, request,
 resource, and expiration fields from full EIP-4361. This is the smallest field
-set that identifies the protocol, account, owner key, chain context, ceremony,
-and issuance time while stating that no transaction is authorized.
+set that identifies the protocol, account, owner key, chain context, global
+scope, ceremony, and issuance time while stating that no transaction is
+authorized.
 
 The exact text is:
 
@@ -228,6 +244,7 @@ Domain-Tag: barnard-account-binding:v1
 Wallet: 0x{walletAddress lowercase hex}
 Owner-Key: 0x{compressed owner public key lowercase hex}
 Chain-ID: eip155:{chainId unsigned decimal}
+Scope: global
 Nonce: 0x{16-byte nonce lowercase hex}
 Issued-At: {issuedAt}
 ```
@@ -251,6 +268,9 @@ Canonical encoding rules are normative:
 - `chainId` is an unsigned 64-bit integer in the range 0 through
   18446744073709551615, emitted in base 10 with no leading zero, except that
   zero is emitted as `0`.
+- `Scope` is the literal ASCII value `global` in v1. A scoped binding requires
+  a future versioned domain tag and MUST NOT be represented by changing this
+  line.
 - `nonce` is exactly 16 bytes and is emitted as `0x` plus 32 lowercase
   hexadecimal digits.
 - `issuedAt` is supplied by the host as a valid proleptic-Gregorian calendar
@@ -279,6 +299,7 @@ Domain-Tag: barnard-account-binding:v1
 Wallet: 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
 Owner-Key: 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
 Chain-ID: eip155:1
+Scope: global
 Nonce: 0x000102030405060708090a0b0c0d0e0f
 Issued-At: 2026-07-30T09:00:00Z
 ```
@@ -461,6 +482,9 @@ Using a fresh wallet address remains valid.
 - Full EIP-4361 login fields: rejected because this is an endorsement, not an
   authentication session; unused URI/resource/expiration fields add canonical
   inputs without improving the binding.
+- An `expiresAt` binding field: rejected because a binding is a long-lived,
+  idempotent fact, revocation occurs through account unbinding, and v1 defines
+  no expiry semantics.
 - A binding text without the no-assets statement: rejected because the
   ceremony must remain human-readable and explicitly non-transactional.
 
@@ -468,9 +492,20 @@ Using a fresh wallet address remains valid.
 
 - ERC-1271/6492 verification through the verifier port.
 - EIP-712 binding under `barnard-account-binding:v2`.
+- A versioned COSE/CBOR interoperability profile in v2.
 - Host UX for account rotation and wallet-authorized unbinding.
 - Presentation-time challenge-response.
 - Post-quantum migration through versioned domain tags and rotation records.
+
+## References
+
+- [RFC 8812: CBOR Object Signing and Encryption (COSE) and JSON Object
+  Signing and Encryption (JOSE) Registrations for
+  secp256k1](https://www.rfc-editor.org/rfc/rfc8812.html)
+- [RFC 9942: An Information Model for Supply Chain Integrity,
+  Transparency, and Trust](https://www.rfc-editor.org/rfc/rfc9942.html)
+- [RFC 9943: An Architecture for Trustworthy and Transparent Digital Supply
+  Chains](https://www.rfc-editor.org/rfc/rfc9943.html)
 
 ## Validation
 


### PR DESCRIPTION
## Summary

- Define the owner-key hierarchy, Tier 0/Tier 1 behavior, four exact Barnard-native message layouts, canonical wallet-binding text, lifecycle rules, and verification algorithms in `specs/092-owner-key/spec.md`.
- Add holder-held self-proof and wallet-binding/rotation/unbinding schemas, plus CI invariants that reject 20-byte wallet-address and 33-byte compressed-owner-key shapes from public/on-wire schemas.
- Implement one-stage HKDF-SHA256 owner-key derivation, Ethereum Keccak-256, uncompressed SEC1 serialization, EIP-191 digesting, message builders/signers/verifiers, strict EOA wallet verification, and the time-stamped smart-wallet verifier port in pure `BarnardCore`.
- Export the seven requested `barnard_core_*` C ABI functions and regenerate the Dart Swift mirrors from the native Swift origin.

## Spec decision

Open Question 2 uses a minimal human-readable EIP-191 binding text instead of full SIWE login fields. URI, request, resource, and expiration fields are omitted because this is a long-lived endorsement ceremony, not an authentication session; the exact choice and rationale are normative in the spec.

## Compatibility and security

- Schema changes are additive; existing public/on-wire shapes are unchanged.
- Owner keys, wallet addresses, bindings, rotations, and unbindings are holder-held only.
- No device-unique persistent identifiers are added to on-wire payloads.
- Wallet-less Tier 0 operation remains fully supported.
- ERC-6492 is classified as unsupported for v1; the verifier port contains no RPC implementation.
- Kotlin and React Native ports remain out of scope.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer /Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild -scheme Barnard-Package -destination id=27100795-EBB1-4BD9-AB43-A96CFE145FC5 test`
  - 54 tests, 0 failures: Barnard 33, BarnardCore 17, BarnardCoreC 4
  - `** TEST SUCCEEDED **`
- `swift build --target BarnardCore --disable-sandbox` — passed
- `swift build --target BarnardCoreC --disable-sandbox` — passed
- `./scripts/check-swift-mirror.sh` — passed
- `./scripts/check-android-mirror.sh` — passed
- `python3 scripts/check-schema-privacy-invariant.py --self-test` — passed
- `python3 scripts/check-wallet-binding-schema.py` — 7 valid and 11 invalid boundary fixtures passed

Refs #92