### PR TITLE
ci: raise swift-package timeout to 50 minutes

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -24,7 +24,7 @@ jobs:
     # toolchain is installed in this job (barnard#56 acceptance criterion:
     # "CI validates each first-class SDK surface independently").
     runs-on: macos-15
-    timeout-minutes: 35
+    timeout-minutes: 50
     defaults:
       run:
         working-directory: packages/swift/barnard


### PR DESCRIPTION
Evidence: run 30546390984 attempts 1 and 2 both cancelled at exactly 35m with the suite mid-progress and every completed test passing — pre-existing `BarnardSigningTests` cases ran at 9–155s each (10–30x normal) on the macos-15 pool, while the identical content passed in normal time on the PR run (1c3660a). Runner-pool slowness, not a hang and not a #96 regression. 50m still catches genuine hangs (vs the 6h default) while absorbing observed VM variance. One line. Milestone 0.2.0.