### PR TITLE
fix: close manifest and podspec audit gaps

### DIFF
--- a/packages/dart/barnard/ios/barnard.podspec
+++ b/packages/dart/barnard/ios/barnard.podspec
@@ -11,7 +11,7 @@ Barnard BLE Transport for Flutter (GATT-first RPID).
                        DESC
   s.homepage         = 'https://github.com/levarac/barnard'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'Levarac' => 'https://github.com/levarac/barnard/issues' }
   s.source           = { :path => '.' }
   s.source_files = 'barnard/Sources/barnard/**/*'
   s.dependency 'Flutter'

--- a/scripts/check-swift-package-manifest-mirror.sh
+++ b/scripts/check-swift-package-manifest-mirror.sh
@@ -40,6 +40,7 @@ for target in targets:
     target.pop("path", None)
 
 declarations = {
+    "dependencies": package["dependencies"],
     "platforms": package["platforms"],
     "products": package["products"],
     "targets": targets,


### PR DESCRIPTION
## Summary
- include package-level SwiftPM dependencies in the mirror drift guard
- replace the Flutter-template podspec author metadata with Levarac project metadata

## Verification
- `./scripts/check-swift-package-manifest-mirror.sh` passes on the untouched tree
- a scratch copy with a dependency added to only one manifest fails with `DRIFT`
- `ruby -c packages/dart/barnard/ios/barnard.podspec` passes

## Compatibility and privacy
- No public on-wire payloads or schemas changed.
- No device-unique persistent identifiers are introduced.

Refs #89