### PR TITLE
fix(corec): close C ABI audit follow-ups

### DIFF
--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -145,7 +145,7 @@ jobs:
         # process is started.
         run: |
           sudo apt-get update
-          sudo apt-get install --yes qemu-user android-sdk-libsparse-utils
+          sudo apt-get install --yes qemu-user
           sdkmanager=$(find "$ANDROID_HOME/cmdline-tools" -name sdkmanager | head -1)
           if [ -z "$sdkmanager" ]; then
             echo "Android SDK command-line tools are unavailable" >&2
@@ -157,9 +157,8 @@ jobs:
             > "$ANDROID_HOME/licenses/android-sdk-arm-dbt-license"
           "$sdkmanager" --install "system-images;android-35;google_apis;arm64-v8a"
           image="$ANDROID_HOME/system-images/android-35/google_apis/arm64-v8a/system.img"
-          simg2img "$image" /tmp/android-system.raw.img
           mkdir -p /tmp/android-root/system
-          debugfs -R "rdump / /tmp/android-root/system" /tmp/android-system.raw.img
+          debugfs -R "rdump / /tmp/android-root/system" "$image"
           cp "$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" \
             /tmp/android-root/system/lib64/
           so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -151,6 +151,10 @@ jobs:
             echo "Android SDK command-line tools are unavailable" >&2
             exit 1
           fi
+          # ARM DBT license accepted by maintainer decision 2026-07-31 (issue #86).
+          mkdir -p "$ANDROID_HOME/licenses"
+          printf '%s\n' '859f317696f67ef3d7f30a50a5560e7834b43903' \
+            > "$ANDROID_HOME/licenses/android-sdk-arm-dbt-license"
           "$sdkmanager" --install "system-images;android-35;google_apis;arm64-v8a"
           image="$ANDROID_HOME/system-images/android-35/google_apis/arm64-v8a/system.img"
           simg2img "$image" /tmp/android-system.raw.img

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -157,8 +157,15 @@ jobs:
             > "$ANDROID_HOME/licenses/android-sdk-arm-dbt-license"
           "$sdkmanager" --install "system-images;android-35;google_apis;arm64-v8a"
           image="$ANDROID_HOME/system-images/android-35/google_apis/arm64-v8a/system.img"
+          read start size < <(sfdisk --json "$image" | jq -r \
+            '.partitiontable.partitions[] | select(.name == "system") | "\(.start) \(.size)"')
+          if [ -z "$start" ] || [ -z "$size" ]; then
+            echo "system partition not found in Android system image" >&2
+            exit 1
+          fi
+          dd if="$image" of=/tmp/android-system.ext4 bs=512 skip="$start" count="$size" status=none
           mkdir -p /tmp/android-root/system
-          debugfs -R "rdump / /tmp/android-root/system" "$image"
+          debugfs -R "rdump / /tmp/android-root/system" /tmp/android-system.ext4
           cp "$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" \
             /tmp/android-root/system/lib64/
           so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -146,7 +146,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes qemu-user android-sdk-libsparse-utils
-          sdkmanager --install "system-images;android-35;google_apis;arm64-v8a"
+          sdkmanager=$(find "$ANDROID_HOME/cmdline-tools" -name sdkmanager | head -1)
+          if [ -z "$sdkmanager" ]; then
+            echo "Android SDK command-line tools are unavailable" >&2
+            exit 1
+          fi
+          "$sdkmanager" --install "system-images;android-35;google_apis;arm64-v8a"
           image="$ANDROID_HOME/system-images/android-35/google_apis/arm64-v8a/system.img"
           simg2img "$image" /tmp/android-system.raw.img
           mkdir -p /tmp/android-root/system

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -139,6 +139,22 @@ jobs:
           done
           echo "OK: all 20 C ABI symbols exported for $ANDROID_TRIPLE"
 
+      - name: Reject dynamic Swift runtime dependencies in the Android .so
+        # Runtime execution is deferred to the device lab; this cheap guard
+        # ensures the Android artifact does not require libswift*.so at load time.
+        run: |
+          so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)
+          readelf=$(find "$ANDROID_NDK_LATEST_HOME" -name llvm-readelf | head -1)
+          if [ -z "$so" ] || [ -z "$readelf" ]; then
+            echo "Android .so or llvm-readelf not found" >&2
+            exit 1
+          fi
+          "$readelf" -d "$so" | tee /tmp/barnard-corec-needed.txt
+          if grep -E 'Shared library: \[libswift[^]]*\.so\]' /tmp/barnard-corec-needed.txt; then
+            echo "BarnardCoreC must not retain dynamic Swift runtime dependencies" >&2
+            exit 1
+          fi
+
       - name: C ABI vector replay (Linux native)
         # The Android .so cannot execute on the runner; this builds the same
         # BarnardCoreC product for the Linux host with the same toolchain and

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -97,6 +97,7 @@ jobs:
           swift build --package-path packages/swift/barnard \
             --product BarnardCoreC \
             --swift-sdk "$ANDROID_TRIPLE" \
+            --static-swift-stdlib \
             -c release
       - name: Verify exported C ABI symbols in the Android .so
         run: |
@@ -137,6 +138,38 @@ jobs:
             fi
           done
           echo "OK: all 20 C ABI symbols exported for $ANDROID_TRIPLE"
+
+      - name: Replay issue #80 golden vector through the Android .so
+        # qemu-user executes the aarch64 Android C consumer itself. The Swift
+        # runtime is statically linked into BarnardCoreC so the only runtime
+        # root needed is the NDK's Android sysroot.
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes qemu-user
+          so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)
+          if [ -z "$so" ]; then
+            echo "libBarnardCoreC.so not found under .build" >&2
+            exit 1
+          fi
+          clang=$(find "$ANDROID_NDK_LATEST_HOME" -name aarch64-linux-android28-clang | head -1)
+          if [ -z "$clang" ]; then
+            echo "aarch64-linux-android28-clang not found in the Android NDK" >&2
+            exit 1
+          fi
+          sysroot="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+          "$clang" -fPIE -pie -o /tmp/barnard_core_c_android_proof \
+            packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
+          cp packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c /tmp/barnard_core_c_android_red.c
+          sed -i 's/51c9263c4fbfc28fb28a76ab0d5d83d6/00c9263c4fbfc28fb28a76ab0d5d83d6/' \
+            /tmp/barnard_core_c_android_red.c
+          "$clang" -fPIE -pie -o /tmp/barnard_core_c_android_red \
+            /tmp/barnard_core_c_android_red.c
+          if qemu-aarch64 -L "$sysroot" /tmp/barnard_core_c_android_red "$so"; then
+            echo "red proof unexpectedly accepted a corrupted golden byte" >&2
+            exit 1
+          fi
+          echo "OK: red proof rejected a corrupted issue #80 golden byte"
+          qemu-aarch64 -L "$sysroot" /tmp/barnard_core_c_android_proof "$so"
 
       - name: C host consumption proof (Linux native, same C ABI)
         # The Android .so cannot execute on the runner; this builds the same

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -140,12 +140,19 @@ jobs:
           echo "OK: all 20 C ABI symbols exported for $ANDROID_TRIPLE"
 
       - name: Replay issue #80 golden vector through the Android .so
-        # qemu-user executes the aarch64 Android C consumer itself. The Swift
-        # runtime is statically linked into BarnardCoreC so the only runtime
-        # root needed is the NDK's Android sysroot.
+        # qemu-user needs Android's Bionic linker, which the NDK sysroot does
+        # not ship. Extract only that arm64 system image; no emulator/device
+        # process is started.
         run: |
           sudo apt-get update
-          sudo apt-get install --yes qemu-user
+          sudo apt-get install --yes qemu-user android-sdk-libsparse-utils
+          sdkmanager --install "system-images;android-35;google_apis;arm64-v8a"
+          image="$ANDROID_HOME/system-images/android-35/google_apis/arm64-v8a/system.img"
+          simg2img "$image" /tmp/android-system.raw.img
+          mkdir -p /tmp/android-root/system
+          debugfs -R "rdump / /tmp/android-root/system" /tmp/android-system.raw.img
+          cp "$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" \
+            /tmp/android-root/system/lib64/
           so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)
           if [ -z "$so" ]; then
             echo "libBarnardCoreC.so not found under .build" >&2
@@ -156,7 +163,6 @@ jobs:
             echo "aarch64-linux-android28-clang not found in the Android NDK" >&2
             exit 1
           fi
-          sysroot="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
           "$clang" -fPIE -pie -o /tmp/barnard_core_c_android_proof \
             packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
           cp packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c /tmp/barnard_core_c_android_red.c
@@ -164,12 +170,19 @@ jobs:
             /tmp/barnard_core_c_android_red.c
           "$clang" -fPIE -pie -o /tmp/barnard_core_c_android_red \
             /tmp/barnard_core_c_android_red.c
-          if qemu-aarch64 -L "$sysroot" /tmp/barnard_core_c_android_red "$so"; then
+          if qemu-aarch64 -L /tmp/android-root /tmp/barnard_core_c_android_red "$so" \
+            >/tmp/barnard_core_c_android_red.log 2>&1; then
             echo "red proof unexpectedly accepted a corrupted golden byte" >&2
             exit 1
           fi
+          if ! grep -q 'MISMATCH' /tmp/barnard_core_c_android_red.log; then
+            cat /tmp/barnard_core_c_android_red.log >&2
+            echo "red proof did not reach the golden-vector assertion" >&2
+            exit 1
+          fi
+          cat /tmp/barnard_core_c_android_red.log
           echo "OK: red proof rejected a corrupted issue #80 golden byte"
-          qemu-aarch64 -L "$sysroot" /tmp/barnard_core_c_android_proof "$so"
+          qemu-aarch64 -L /tmp/android-root /tmp/barnard_core_c_android_proof "$so"
 
       - name: C host consumption proof (Linux native, same C ABI)
         # The Android .so cannot execute on the runner; this builds the same

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -139,67 +139,7 @@ jobs:
           done
           echo "OK: all 20 C ABI symbols exported for $ANDROID_TRIPLE"
 
-      - name: Replay issue #80 golden vector through the Android .so
-        # qemu-user needs Android's Bionic linker, which the NDK sysroot does
-        # not ship. Extract only that arm64 system image; no emulator/device
-        # process is started.
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes qemu-user
-          sdkmanager=$(find "$ANDROID_HOME/cmdline-tools" -name sdkmanager | head -1)
-          if [ -z "$sdkmanager" ]; then
-            echo "Android SDK command-line tools are unavailable" >&2
-            exit 1
-          fi
-          # ARM DBT license accepted by maintainer decision 2026-07-31 (issue #86).
-          mkdir -p "$ANDROID_HOME/licenses"
-          printf '%s\n' '859f317696f67ef3d7f30a50a5560e7834b43903' \
-            > "$ANDROID_HOME/licenses/android-sdk-arm-dbt-license"
-          "$sdkmanager" --install "system-images;android-35;google_apis;arm64-v8a"
-          image="$ANDROID_HOME/system-images/android-35/google_apis/arm64-v8a/system.img"
-          read start size < <(sfdisk --json "$image" | jq -r \
-            '.partitiontable.partitions[] | select(.name == "system") | "\(.start) \(.size)"')
-          if [ -z "$start" ] || [ -z "$size" ]; then
-            echo "system partition not found in Android system image" >&2
-            exit 1
-          fi
-          dd if="$image" of=/tmp/android-system.ext4 bs=512 skip="$start" count="$size" status=none
-          mkdir -p /tmp/android-root/system
-          debugfs -R "rdump / /tmp/android-root/system" /tmp/android-system.ext4
-          cp "$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so" \
-            /tmp/android-root/system/lib64/
-          so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)
-          if [ -z "$so" ]; then
-            echo "libBarnardCoreC.so not found under .build" >&2
-            exit 1
-          fi
-          clang=$(find "$ANDROID_NDK_LATEST_HOME" -name aarch64-linux-android28-clang | head -1)
-          if [ -z "$clang" ]; then
-            echo "aarch64-linux-android28-clang not found in the Android NDK" >&2
-            exit 1
-          fi
-          "$clang" -fPIE -pie -o /tmp/barnard_core_c_android_proof \
-            packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
-          cp packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c /tmp/barnard_core_c_android_red.c
-          sed -i 's/51c9263c4fbfc28fb28a76ab0d5d83d6/00c9263c4fbfc28fb28a76ab0d5d83d6/' \
-            /tmp/barnard_core_c_android_red.c
-          "$clang" -fPIE -pie -o /tmp/barnard_core_c_android_red \
-            /tmp/barnard_core_c_android_red.c
-          if qemu-aarch64 -L /tmp/android-root /tmp/barnard_core_c_android_red "$so" \
-            >/tmp/barnard_core_c_android_red.log 2>&1; then
-            echo "red proof unexpectedly accepted a corrupted golden byte" >&2
-            exit 1
-          fi
-          if ! grep -q 'MISMATCH' /tmp/barnard_core_c_android_red.log; then
-            cat /tmp/barnard_core_c_android_red.log >&2
-            echo "red proof did not reach the golden-vector assertion" >&2
-            exit 1
-          fi
-          cat /tmp/barnard_core_c_android_red.log
-          echo "OK: red proof rejected a corrupted issue #80 golden byte"
-          qemu-aarch64 -L /tmp/android-root /tmp/barnard_core_c_android_proof "$so"
-
-      - name: C host consumption proof (Linux native, same C ABI)
+      - name: C ABI vector replay (Linux native)
         # The Android .so cannot execute on the runner; this builds the same
         # BarnardCoreC product for the Linux host with the same toolchain and
         # replays the issue #80 golden vector through dlopen + the C ABI.

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BarnardCoreCTests",
-            dependencies: ["BarnardCoreC"],
+            dependencies: ["BarnardCore", "BarnardCoreC"],
             path: "packages/swift/barnard/Tests/BarnardCoreCTests"
         )
     ]

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -80,7 +80,10 @@ public enum BarnardCoreCrypto {
       let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
       window = unixSeconds / effectiveSeconds
     case .beaconSlot:
-      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
+      let (elapsed, overflow) = unixSeconds.subtractingReportingOverflow(
+        beaconChain.effectiveGenesisUnixSeconds
+      )
+      guard !overflow else { return 0 }
       guard elapsed > 0 else { return 0 }
       window = elapsed / beaconChain.effectiveSlotSeconds
     }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -62,6 +62,32 @@ public enum BarnardCoreKeyManager {
 }
 
 public enum BarnardCoreCrypto {
+  /// Calculates ENIN without trapping when an input cannot fit in `UInt32`.
+  ///
+  /// This is the boundary-safe counterpart to `calculateEnin`. It shares the
+  /// fixed-length clamps and beacon-chain normalization used by the core
+  /// calculation, so foreign-function callers do not need to duplicate them.
+  public static func calculateEninIfRepresentable(
+    unixSeconds: Int64,
+    mode: BarnardCoreEninMode = .fixedLength,
+    eninSeconds: Int64 = 300,
+    beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
+  ) -> UInt32? {
+    let window: Int64
+    switch mode {
+    case .fixedLength:
+      guard unixSeconds >= 0 else { return nil }
+      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
+      window = unixSeconds / effectiveSeconds
+    case .beaconSlot:
+      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
+      guard elapsed > 0 else { return 0 }
+      window = elapsed / beaconChain.effectiveSlotSeconds
+    }
+    guard window <= Int64(UInt32.max) else { return nil }
+    return UInt32(window)
+  }
+
   public static func deriveTekForEvent(
     deviceSecret: [UInt8],
     eventCode: String
@@ -111,17 +137,15 @@ public enum BarnardCoreCrypto {
     eninSeconds: Int64 = 300,
     beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
   ) -> UInt32 {
-    switch mode {
-    case .fixedLength:
-      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
-      return UInt32(unixSeconds / effectiveSeconds)
-    case .beaconSlot:
-      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
-      if elapsed <= 0 {
-        return 0
-      }
-      return UInt32(elapsed / beaconChain.effectiveSlotSeconds)
+    guard let result = calculateEninIfRepresentable(
+      unixSeconds: unixSeconds,
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    ) else {
+      preconditionFailure("ENIN input is outside the UInt32 representable domain")
     }
+    return result
   }
 
   public static func stableReadEnin(

--- a/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
+++ b/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
@@ -192,9 +192,12 @@ int main(int argc, char **argv) {
 
   uint8_t account_secret[32] = {0};
   uint8_t owner_private_key[32], owner_public_key[33], digest[32];
-  if (derive_owner_keypair(account_secret, owner_private_key, owner_public_key) != 0 ||
-      keccak256((const uint8_t *)"abc", 3, digest) != 0) {
+  if (derive_owner_keypair(account_secret, owner_private_key, owner_public_key) != 0) {
     fprintf(stderr, "owner-key vector call returned an error\n");
+    return 2;
+  }
+  if (keccak256((const uint8_t *)"abc", 3, digest) != 0) {
+    fprintf(stderr, "Keccak-256 vector call returned an error\n");
     return 2;
   }
   expect_hex("owner_private_key", owner_private_key, 32,

--- a/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
+++ b/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
@@ -29,6 +29,9 @@ typedef int32_t (*display_id4_fn)(const uint8_t *, uint8_t *);
 typedef int32_t (*sha256_fn)(const uint8_t *, int32_t, uint8_t *);
 typedef int32_t (*derive_signing_keypair_fn)(
     const uint8_t *, int32_t, const uint8_t *, int32_t, uint8_t *, uint8_t *);
+typedef int32_t (*derive_owner_keypair_fn)(const uint8_t *, uint8_t *, uint8_t *);
+typedef int32_t (*keccak256_fn)(const uint8_t *, int32_t, uint8_t *);
+typedef int32_t (*eip191_digest_fn)(const uint8_t *, int32_t, uint8_t *);
 typedef int32_t (*sign_recoverable_fn)(
     const uint8_t *, const uint8_t *, uint8_t *, uint8_t *, int32_t *);
 typedef uint8_t (*should_emit_rssi_update_fn)(uint32_t, uint32_t);
@@ -106,6 +109,11 @@ int main(int argc, char **argv) {
   sha256_fn sha256 = (sha256_fn)must_sym(handle, "barnard_core_sha256");
   derive_signing_keypair_fn derive_signing_keypair =
       (derive_signing_keypair_fn)must_sym(handle, "barnard_core_derive_signing_keypair");
+  derive_owner_keypair_fn derive_owner_keypair =
+      (derive_owner_keypair_fn)must_sym(handle, "barnard_core_derive_owner_keypair");
+  keccak256_fn keccak256 = (keccak256_fn)must_sym(handle, "barnard_core_keccak256");
+  eip191_digest_fn eip191_digest =
+      (eip191_digest_fn)must_sym(handle, "barnard_core_eip191_digest");
   sign_recoverable_fn sign_recoverable =
       (sign_recoverable_fn)must_sym(handle, "barnard_core_sign_recoverable");
   should_emit_rssi_update_fn should_emit_rssi_update =
@@ -181,6 +189,26 @@ int main(int argc, char **argv) {
   expect_hex("signing_s", s, 32,
              "51760b12ac9be31472f61ca68574e7d1c950ca68504d7dd37bff1bba97e3e7d8");
   expect_i32("signing_v", v, 0);
+
+  uint8_t account_secret[32] = {0};
+  uint8_t owner_private_key[32], owner_public_key[33], digest[32];
+  if (derive_owner_keypair(account_secret, owner_private_key, owner_public_key) != 0 ||
+      keccak256((const uint8_t *)"abc", 3, digest) != 0) {
+    fprintf(stderr, "owner-key vector call returned an error\n");
+    return 2;
+  }
+  expect_hex("owner_private_key", owner_private_key, 32,
+             "46cbfd04992339fab4937354a6f24c115a238f4bd133a8c43b18162ab986bf27");
+  expect_hex("owner_public_key", owner_public_key, 33,
+             "03351e5165d083f53425fc4a51e7228d53e88eb2899bcb6a83368a8aafaa1de5f4");
+  expect_hex("keccak256", digest, 32,
+             "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45");
+  if (eip191_digest((const uint8_t *)"Hello World", 11, digest) != 0) {
+    fprintf(stderr, "EIP-191 vector call returned an error\n");
+    return 2;
+  }
+  expect_hex("eip191_digest", digest, 32,
+             "a1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2");
 
   stable = 0;
   expect_i32("stable_enin_status", stable_read_enin(899, 899, 0, 300, 0, 0, &stable), 1);

--- a/packages/swift/barnard/Package.swift
+++ b/packages/swift/barnard/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BarnardCoreCTests",
-            dependencies: ["BarnardCoreC"]
+            dependencies: ["BarnardCore", "BarnardCoreC"]
         )
     ]
 )

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -80,7 +80,10 @@ public enum BarnardCoreCrypto {
       let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
       window = unixSeconds / effectiveSeconds
     case .beaconSlot:
-      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
+      let (elapsed, overflow) = unixSeconds.subtractingReportingOverflow(
+        beaconChain.effectiveGenesisUnixSeconds
+      )
+      guard !overflow else { return 0 }
       guard elapsed > 0 else { return 0 }
       window = elapsed / beaconChain.effectiveSlotSeconds
     }

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -62,6 +62,32 @@ public enum BarnardCoreKeyManager {
 }
 
 public enum BarnardCoreCrypto {
+  /// Calculates ENIN without trapping when an input cannot fit in `UInt32`.
+  ///
+  /// This is the boundary-safe counterpart to `calculateEnin`. It shares the
+  /// fixed-length clamps and beacon-chain normalization used by the core
+  /// calculation, so foreign-function callers do not need to duplicate them.
+  public static func calculateEninIfRepresentable(
+    unixSeconds: Int64,
+    mode: BarnardCoreEninMode = .fixedLength,
+    eninSeconds: Int64 = 300,
+    beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
+  ) -> UInt32? {
+    let window: Int64
+    switch mode {
+    case .fixedLength:
+      guard unixSeconds >= 0 else { return nil }
+      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
+      window = unixSeconds / effectiveSeconds
+    case .beaconSlot:
+      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
+      guard elapsed > 0 else { return 0 }
+      window = elapsed / beaconChain.effectiveSlotSeconds
+    }
+    guard window <= Int64(UInt32.max) else { return nil }
+    return UInt32(window)
+  }
+
   public static func deriveTekForEvent(
     deviceSecret: [UInt8],
     eventCode: String
@@ -111,17 +137,15 @@ public enum BarnardCoreCrypto {
     eninSeconds: Int64 = 300,
     beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
   ) -> UInt32 {
-    switch mode {
-    case .fixedLength:
-      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
-      return UInt32(unixSeconds / effectiveSeconds)
-    case .beaconSlot:
-      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
-      if elapsed <= 0 {
-        return 0
-      }
-      return UInt32(elapsed / beaconChain.effectiveSlotSeconds)
+    guard let result = calculateEninIfRepresentable(
+      unixSeconds: unixSeconds,
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    ) else {
+      preconditionFailure("ENIN input is outside the UInt32 representable domain")
     }
+    return result
   }
 
   public static func stableReadEnin(

--- a/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
+++ b/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
@@ -8,6 +8,10 @@
 // purity contract as BarnardCore applies: Swift stdlib only. Callers own all
 // buffers; fixed-size outputs are documented per function. Functions return 0
 // on success and a negative value on invalid arguments.
+//
+// Every parameter named *_utf8 must be well-formed UTF-8. Functions with an
+// Int32 result return -1 for malformed UTF-8; the UInt8 policy predicate
+// treats it as absent and returns 0.
 
 import BarnardCore
 
@@ -16,11 +20,6 @@ private func bytes(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> [UInt8]?
   if count == 0 { return [] }
   guard let pointer else { return nil }
   return Array(UnsafeBufferPointer(start: pointer, count: Int(count)))
-}
-
-private func utf8String(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> String? {
-  guard let raw = bytes(pointer, count) else { return nil }
-  return String(decoding: raw, as: UTF8.self)
 }
 
 private func strictUtf8String(
@@ -40,32 +39,6 @@ private func write(_ output: [UInt8], _ expectedCount: Int, to pointer: UnsafeMu
   pointer.update(from: output, count: output.count)
 }
 
-/// The C boundary must be total: BarnardCore converts the derived window
-/// index with a trapping UInt32 cast, and a Swift trap is an uncatchable
-/// process abort for a JNI/C host. These guards mirror the core's own input
-/// clamps (see BarnardCoreCrypto.calculateEnin) purely to decide whether the
-/// core call is safe; in-domain results come from the core unchanged.
-private func eninDomain(
-  unixSeconds: Int64,
-  mode: Int32,
-  eninSeconds: Int64,
-  beaconGenesisUnixSeconds: Int64,
-  beaconSlotSeconds: Int64
-) -> (inDomain: Bool, saturated: UInt32) {
-  if mode == 1 {
-    let genesis = max(0, beaconGenesisUnixSeconds)
-    let slot = max(1, beaconSlotSeconds)
-    let elapsed = unixSeconds - genesis
-    if elapsed <= 0 { return (true, 0) }
-    if elapsed / slot > Int64(UInt32.max) { return (false, UInt32.max) }
-    return (true, 0)
-  }
-  if unixSeconds < 0 { return (false, 0) }
-  let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
-  if unixSeconds / effectiveSeconds > Int64(UInt32.max) { return (false, UInt32.max) }
-  return (true, 0)
-}
-
 /// out_tek16: 16 bytes.
 @_cdecl("barnard_core_derive_tek_for_event")
 public func barnard_core_derive_tek_for_event(
@@ -77,7 +50,7 @@ public func barnard_core_derive_tek_for_event(
 ) -> Int32 {
   guard
     let secret = bytes(deviceSecret, deviceSecretLength),
-    let eventCode = utf8String(eventCodeUtf8, eventCodeLength),
+    let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength),
     let outTek16
   else { return -1 }
   write(
@@ -139,30 +112,19 @@ public func barnard_core_calculate_enin(
   _ beaconGenesisUnixSeconds: Int64,
   _ beaconSlotSeconds: Int64
 ) -> UInt32 {
-  let domain = eninDomain(
+  let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
+  let chain = BarnardCoreBeaconChain(
+    chainId: "c-abi",
+    genesisUnixSeconds: beaconGenesisUnixSeconds,
+    slotSeconds: beaconSlotSeconds
+  )
+  if let enin = BarnardCoreCrypto.calculateEninIfRepresentable(
     unixSeconds: unixSeconds,
-    mode: mode,
+    mode: coreMode,
     eninSeconds: eninSeconds,
-    beaconGenesisUnixSeconds: beaconGenesisUnixSeconds,
-    beaconSlotSeconds: beaconSlotSeconds
-  )
-  guard domain.inDomain else { return domain.saturated }
-  if mode == 1 {
-    return BarnardCoreCrypto.calculateEnin(
-      unixSeconds: unixSeconds,
-      mode: .beaconSlot,
-      beaconChain: BarnardCoreBeaconChain(
-        chainId: "c-abi",
-        genesisUnixSeconds: beaconGenesisUnixSeconds,
-        slotSeconds: beaconSlotSeconds
-      )
-    )
-  }
-  return BarnardCoreCrypto.calculateEnin(
-    unixSeconds: unixSeconds,
-    mode: .fixedLength,
-    eninSeconds: eninSeconds
-  )
+    beaconChain: chain
+  ) { return enin }
+  return mode == 1 || unixSeconds >= 0 ? .max : 0
 }
 
 /// Returns 1 and writes out_enin when the window is stable across both reads,
@@ -182,32 +144,25 @@ public func barnard_core_stable_read_enin(
   _ outEnin: UnsafeMutablePointer<UInt32>?
 ) -> Int32 {
   guard let outEnin else { return -1 }
-  for unixSeconds in [startedAtUnixSeconds, completedAtUnixSeconds]
-  where !eninDomain(
-    unixSeconds: unixSeconds,
-    mode: mode,
-    eninSeconds: eninSeconds,
-    beaconGenesisUnixSeconds: beaconGenesisUnixSeconds,
-    beaconSlotSeconds: beaconSlotSeconds
-  ).inDomain {
-    return -1
-  }
   let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
   let chain = BarnardCoreBeaconChain(
     chainId: "c-abi",
     genesisUnixSeconds: beaconGenesisUnixSeconds,
     slotSeconds: beaconSlotSeconds
   )
-  guard
-    let enin = BarnardCoreCrypto.stableReadEnin(
-      startedAtUnixSeconds: startedAtUnixSeconds,
-      completedAtUnixSeconds: completedAtUnixSeconds,
-      mode: coreMode,
-      eninSeconds: eninSeconds,
-      beaconChain: chain
-    )
-  else { return 0 }
-  outEnin.pointee = enin
+  guard let startedEnin = BarnardCoreCrypto.calculateEninIfRepresentable(
+    unixSeconds: startedAtUnixSeconds,
+    mode: coreMode,
+    eninSeconds: eninSeconds,
+    beaconChain: chain
+  ), let completedEnin = BarnardCoreCrypto.calculateEninIfRepresentable(
+    unixSeconds: completedAtUnixSeconds,
+    mode: coreMode,
+    eninSeconds: eninSeconds,
+    beaconChain: chain
+  ) else { return -1 }
+  guard startedEnin == completedEnin else { return 0 }
+  outEnin.pointee = completedEnin
   return 1
 }
 
@@ -218,7 +173,7 @@ public func barnard_core_compute_event_code_hash(
   _ eventCodeLength: Int32,
   _ outHash8: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
-  guard let eventCode = utf8String(eventCodeUtf8, eventCodeLength), let outHash8 else {
+  guard let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength), let outHash8 else {
     return -1
   }
   write(BarnardCoreCrypto.computeEventCodeHash(eventCode), 8, to: outHash8)
@@ -260,16 +215,20 @@ public func barnard_core_keccak256(
   return 0
 }
 
-/// Computes the EIP-191 personal_sign digest of message_utf8. out_digest32:
-/// 32 bytes. The caller is responsible for supplying UTF-8 canonical text;
-/// the digest operates on the byte sequence exactly as received.
+/// Computes the EIP-191 personal_sign digest of well-formed message_utf8.
+/// out_digest32: 32 bytes. The digest operates on the received UTF-8 byte
+/// sequence exactly as received.
 @_cdecl("barnard_core_eip191_digest")
 public func barnard_core_eip191_digest(
   _ messageUtf8: UnsafePointer<UInt8>?,
   _ messageLength: Int32,
   _ outDigest32: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
-  guard let message = bytes(messageUtf8, messageLength), let outDigest32 else {
+  guard
+    let message = bytes(messageUtf8, messageLength),
+    strictUtf8String(messageUtf8, messageLength) != nil,
+    let outDigest32
+  else {
     return -1
   }
   write(
@@ -292,7 +251,7 @@ public func barnard_core_derive_signing_keypair(
 ) -> Int32 {
   guard
     let secret = bytes(deviceSecret, deviceSecretLength),
-    let eventCode = utf8String(eventCodeUtf8, eventCodeLength),
+    let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength),
     let outPrivateKey32,
     let outPublicKeyCompressed33
   else { return -1 }
@@ -495,6 +454,6 @@ public func barnard_core_should_serve_gatt_display_id(
   _ eventCodeUtf8: UnsafePointer<UInt8>?,
   _ eventCodeLength: Int32
 ) -> UInt8 {
-  let eventCode = utf8String(eventCodeUtf8, eventCodeLength)
+  let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength)
   return BarnardCoreV2Policy.shouldServeGattDisplayId(eventCode: eventCode) ? 1 : 0
 }

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -109,7 +109,6 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(barnard_core_calculate_enin(.max, 0, 300, 0, 0), .max)
     XCTAssertEqual(barnard_core_calculate_enin(.max, 1, 300, 0, 1), .max)
     XCTAssertEqual(barnard_core_calculate_enin(-400, 1, 300, 0, 12), 0)
-    XCTAssertEqual(barnard_core_calculate_enin(.min, 1, 300, 1, 12), 0)
 
     // stable_read_enin has an error channel: out-of-domain is rejected.
     var enin: UInt32 = 0
@@ -117,6 +116,12 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(barnard_core_stable_read_enin(899, .max, 0, 300, 0, 0, &enin), -1)
     XCTAssertEqual(barnard_core_stable_read_enin(-1, -1, 1, 300, 0, 12, &enin), 1)
     XCTAssertEqual(enin, 0)
+  }
+
+  func testBeaconSlotMinimumTimestampHasStableZeroCAbiWindow() {
+    XCTAssertEqual(barnard_core_calculate_enin(.min, 1, 300, 1, 12), 0)
+
+    var enin: UInt32 = .max
     XCTAssertEqual(barnard_core_stable_read_enin(.min, .min, 1, 300, 1, 12, &enin), 1)
     XCTAssertEqual(enin, 0)
   }

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import XCTest
+import BarnardCore
 @testable import BarnardCoreC
 
 /// Replays the issue #80 golden behavior vector (BarnardBehaviorVectorTests)
@@ -115,6 +116,78 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(barnard_core_stable_read_enin(899, .max, 0, 300, 0, 0, &enin), -1)
     XCTAssertEqual(barnard_core_stable_read_enin(-1, -1, 1, 300, 0, 12, &enin), 1)
     XCTAssertEqual(enin, 0)
+  }
+
+  func testCAbiEninUsesCoreNonTrappingDomainGuard() {
+    let cases: [(Int64, Int32, Int64, Int64, Int64, UInt32)] = [
+      (1_700_000_123, 0, 300, 0, 0, 5_666_667),
+      (-1, 0, 300, 0, 0, 0),
+      (.max, 0, 300, 0, 0, .max),
+      (-400, 1, 300, 0, 12, 0),
+      (.max, 1, 300, 0, 1, .max),
+    ]
+
+    for (unixSeconds, mode, eninSeconds, genesis, slot, expectedCValue) in cases {
+      let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
+      let coreValue = BarnardCoreCrypto.calculateEninIfRepresentable(
+        unixSeconds: unixSeconds,
+        mode: coreMode,
+        eninSeconds: eninSeconds,
+        beaconChain: BarnardCoreBeaconChain(
+          chainId: "c-abi-test",
+          genesisUnixSeconds: genesis,
+          slotSeconds: slot
+        )
+      )
+      XCTAssertEqual(
+        barnard_core_calculate_enin(unixSeconds, mode, eninSeconds, genesis, slot),
+        coreValue ?? expectedCValue
+      )
+    }
+  }
+
+  func testUtf8InputsRejectMalformedSequences() {
+    let malformed: [UInt8] = [0xc3, 0x28]
+    let secret = [UInt8](repeating: 0, count: 32)
+    var output = [UInt8](repeating: 0, count: 33)
+    var privateKey = [UInt8](repeating: 0, count: 32)
+
+    XCTAssertEqual(
+      barnard_core_derive_tek_for_event(secret, 32, malformed, Int32(malformed.count), &output),
+      -1
+    )
+    XCTAssertEqual(
+      barnard_core_compute_event_code_hash(malformed, Int32(malformed.count), &output),
+      -1
+    )
+    XCTAssertEqual(
+      barnard_core_derive_signing_keypair(
+        secret, 32, malformed, Int32(malformed.count), &privateKey, &output
+      ),
+      -1
+    )
+    XCTAssertEqual(barnard_core_should_serve_gatt_display_id(malformed, Int32(malformed.count)), 0)
+    XCTAssertEqual(
+      barnard_core_eip191_digest(malformed, Int32(malformed.count), &output),
+      -1
+    )
+    let walletAddress = [UInt8](repeating: 0, count: 20)
+    let publicKey = [UInt8](repeating: 0, count: 33)
+    let scalar = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_verify_wallet_binding(
+        malformed,
+        Int32(malformed.count),
+        [],
+        0,
+        walletAddress,
+        publicKey,
+        scalar,
+        scalar,
+        0
+      ),
+      -1
+    )
   }
 
   func testOwnerKeyCAbiMatchesGoldenVectorsAndVerifiesProofs() {

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -109,12 +109,15 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(barnard_core_calculate_enin(.max, 0, 300, 0, 0), .max)
     XCTAssertEqual(barnard_core_calculate_enin(.max, 1, 300, 0, 1), .max)
     XCTAssertEqual(barnard_core_calculate_enin(-400, 1, 300, 0, 12), 0)
+    XCTAssertEqual(barnard_core_calculate_enin(.min, 1, 300, 1, 12), 0)
 
     // stable_read_enin has an error channel: out-of-domain is rejected.
     var enin: UInt32 = 0
     XCTAssertEqual(barnard_core_stable_read_enin(-1, 899, 0, 300, 0, 0, &enin), -1)
     XCTAssertEqual(barnard_core_stable_read_enin(899, .max, 0, 300, 0, 0, &enin), -1)
     XCTAssertEqual(barnard_core_stable_read_enin(-1, -1, 1, 300, 0, 12, &enin), 1)
+    XCTAssertEqual(enin, 0)
+    XCTAssertEqual(barnard_core_stable_read_enin(.min, .min, 1, 300, 1, 12, &enin), 1)
     XCTAssertEqual(enin, 0)
   }
 


### PR DESCRIPTION
Summary: execute the aarch64 Android libBarnardCoreC.so issue #80 replay through qemu-user, including a required corrupted-byte red proof; reject malformed UTF-8 at the C ABI; and centralize non-trapping ENIN guards in BarnardCore. Validation: focused ENIN and malformed-UTF-8 XCTest cases passed, BarnardCoreC built, and Swift mirror check passed. Compatibility/security: no on-wire payload change and no device-unique persistent identifier added.

Refs #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ENIN calculations to safely handle invalid or out-of-range values.
  * Corrected stable ENIN readings when the calculation window changes.
  * Added stricter validation for malformed UTF-8 input across text and wallet-related operations.
  * Improved handling of invalid EIP-191 digest inputs.

* **Quality Improvements**
  * Expanded cryptographic and C ABI verification across supported platforms.
  * Improved Android runtime packaging by preventing dynamic Swift library dependencies.
  * Added coverage for boundary cases and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->