### PR TITLE
fix(swift): require EIP-191 wallet unbinding

### DIFF
--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -70,6 +70,39 @@ public extension BarnardCoreSigning {
     ].joined(separator: "\n")
   }
 
+  static func buildAccountUnbindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to revoke this wallet's binding to a Levarac owner key.",
+      "",
+      "This signature REVOKES a wallet binding and authorizes no transaction.",
+      "",
+      "Domain-Tag: \(accountUnbindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
   static func buildSelfProofMessage(
     eventIdHash: [UInt8],
     eventSigningPublicKey: [UInt8],
@@ -303,27 +336,68 @@ public extension BarnardCoreSigning {
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    guard
-      let message = buildAccountUnbindingMessage(
-        ownerPublicKey: ownerPublicKey,
-        walletAddress: walletAddress,
-        walletSignature: walletSignature
-      ),
-      let recoveredPublicKey = strictRecoveredPublicKey(
-        signature,
-        messageHash32: BarnardCorePrimitives.sha256(message)
-      )
-    else {
-      return false
-    }
-
     switch signer {
     case .owner:
+      guard
+        let message = buildAccountUnbindingMessage(
+          ownerPublicKey: ownerPublicKey,
+          walletAddress: walletAddress,
+          walletSignature: walletSignature
+        ),
+        let recoveredPublicKey = strictRecoveredPublicKey(
+          signature,
+          messageHash32: BarnardCorePrimitives.sha256(message)
+        )
+      else {
+        return false
+      }
       return recoveredPublicKey == ownerPublicKey
     case .wallet:
-      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
-        == walletAddress
+      return false
     }
+  }
+
+  static func verifyAccountUnbinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountUnbindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress
+    else {
+      return .invalid
+    }
+    return .valid
   }
 
   static func classifyWalletSignature(
@@ -455,6 +529,83 @@ public extension BarnardCoreSigning {
     let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
 
     guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func isCanonicalAccountUnbindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 11,
+      lines[1].isEmpty,
+      lines[2]
+        == "This signature REVOKES a wallet binding and authorizes no transaction.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountUnbindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
+    else {
+      return false
+    }
+
+    let headerSuffix =
+      " wants to revoke this wallet's binding to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[9].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[9].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountUnbindingText(
       domain: domain,
       walletAddress: expectedWalletAddress,
       ownerPublicKey: expectedOwnerPublicKey,

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -70,6 +70,39 @@ public extension BarnardCoreSigning {
     ].joined(separator: "\n")
   }
 
+  static func buildAccountUnbindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to revoke this wallet's binding to a Levarac owner key.",
+      "",
+      "This signature REVOKES a wallet binding and authorizes no transaction.",
+      "",
+      "Domain-Tag: \(accountUnbindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
   static func buildSelfProofMessage(
     eventIdHash: [UInt8],
     eventSigningPublicKey: [UInt8],
@@ -303,27 +336,68 @@ public extension BarnardCoreSigning {
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    guard
-      let message = buildAccountUnbindingMessage(
-        ownerPublicKey: ownerPublicKey,
-        walletAddress: walletAddress,
-        walletSignature: walletSignature
-      ),
-      let recoveredPublicKey = strictRecoveredPublicKey(
-        signature,
-        messageHash32: BarnardCorePrimitives.sha256(message)
-      )
-    else {
-      return false
-    }
-
     switch signer {
     case .owner:
+      guard
+        let message = buildAccountUnbindingMessage(
+          ownerPublicKey: ownerPublicKey,
+          walletAddress: walletAddress,
+          walletSignature: walletSignature
+        ),
+        let recoveredPublicKey = strictRecoveredPublicKey(
+          signature,
+          messageHash32: BarnardCorePrimitives.sha256(message)
+        )
+      else {
+        return false
+      }
       return recoveredPublicKey == ownerPublicKey
     case .wallet:
-      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
-        == walletAddress
+      return false
     }
+  }
+
+  static func verifyAccountUnbinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountUnbindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress
+    else {
+      return .invalid
+    }
+    return .valid
   }
 
   static func classifyWalletSignature(
@@ -455,6 +529,83 @@ public extension BarnardCoreSigning {
     let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
 
     guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func isCanonicalAccountUnbindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 11,
+      lines[1].isEmpty,
+      lines[2]
+        == "This signature REVOKES a wallet binding and authorizes no transaction.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountUnbindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
+    else {
+      return false
+    }
+
+    let headerSuffix =
+      " wants to revoke this wallet's binding to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[9].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[9].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountUnbindingText(
       domain: domain,
       walletAddress: expectedWalletAddress,
       ownerPublicKey: expectedOwnerPublicKey,

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
@@ -109,6 +109,63 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
     )
   }
 
+  func testCanonicalUnbindingTextMatchesPinnedBytesAndDigest() throws {
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "beid.levarac.org",
+        walletAddress: bytes("7e5f4552091a69125d5dfcb7b8c2659029395bdf"),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+
+    XCTAssertEqual(
+      text,
+      """
+      beid.levarac.org wants to revoke this wallet's binding to a Levarac owner key.
+
+      This signature REVOKES a wallet binding and authorizes no transaction.
+
+      Domain-Tag: barnard-account-unbinding:v1
+      Wallet: 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+      Owner-Key: 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+      Chain-ID: eip155:1
+      Scope: global
+      Nonce: 0x000102030405060708090a0b0c0d0e0f
+      Issued-At: 2026-07-30T09:00:00Z
+      """
+    )
+    XCTAssertEqual(Array(text.utf8).count, 430)
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: text)),
+      "f11e3d04d85d6ac228dde88cebea4ba9554ed06b9c363d5a32f3e4fd89366929"
+    )
+    XCTAssertFalse(text.hasSuffix("\n"))
+
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "BEID.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 15),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+  }
+
   func testSelfProofBuilderSignerAndVerifier() throws {
     let eventHash = (0x00...0x1f).map(UInt8.init)
     let eventPublicKey = compressedPublicKey(privateKey: scalarTwo)
@@ -329,7 +386,7 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
     )
   }
 
-  func testUnbindingBuilderAndBothSignerKinds() throws {
+  func testNativeUnbindingBuilderAndOwnerSigner() throws {
     let walletPrivateKey = scalarTwo
     let walletPublicKey = compressedPublicKey(privateKey: walletPrivateKey)
     let walletAddress = try XCTUnwrap(
@@ -389,23 +446,171 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
         signature: ownerSignature
       )
     )
+  }
 
-    let walletSigner = try XCTUnwrap(
-      BarnardCoreSigning.signAccountUnbinding(
-        signerPrivateKey: walletPrivateKey,
-        ownerPublicKey: generatorCompressed,
-        walletAddress: walletAddress,
-        walletSignature: walletSignature
+  func testWalletSignerUnbindingRequiresCanonicalEip191Text() throws {
+    let walletPrivateKey = scalarOne
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(
+        publicKeyCompressed: generatorCompressed
       )
     )
-    XCTAssertTrue(
-      BarnardCoreSigning.verifyAccountUnbinding(
-        signer: .wallet,
-        ownerPublicKey: generatorCompressed,
+    let ownerPublicKey = compressedPublicKey(privateKey: scalarTwo)
+    let originalBindingSignature = (0x40...0x80).map(UInt8.init)
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "beid.levarac.org",
         walletAddress: walletAddress,
-        walletSignature: walletSignature,
-        signature: walletSigner
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
       )
+    )
+    let eip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: walletPrivateKey,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(text: text)
+    )
+    let walletSigner =
+      eip191Signature.r
+      + eip191Signature.s
+      + [UInt8(eip191Signature.v + 27)]
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: walletSigner,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .valid
+    )
+
+    var rawRecoveryIdSignature = walletSigner
+    rawRecoveryIdSignature[64] = UInt8(eip191Signature.v)
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: rawRecoveryIdSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .valid
+    )
+
+    var invalidRecoveryIdSignature = walletSigner
+    invalidRecoveryIdSignature[64] = 2
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: invalidRecoveryIdSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    var highSSignature = walletSigner
+    let highS = BarnardCoreSecp256k1.curveOrder.subtracting(
+      BarnardCoreSecp256k1.UInt256(bytes: eip191Signature.s)
+    ).bytes
+    highSSignature.replaceSubrange(32..<64, with: highS)
+    highSSignature[64] = UInt8((eip191Signature.v ^ 1) + 27)
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: highSSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let wrongDomainTagText = text.replacingOccurrences(
+      of: "Domain-Tag: barnard-account-unbinding:v1",
+      with: "Domain-Tag: barnard-account-binding:v1"
+    )
+    let wrongDomainTagSignature = BarnardCoreSigning.signRecoverable(
+      privateKey: walletPrivateKey,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: wrongDomainTagText
+      )
+    )
+    let wrongDomainTagWalletSignature =
+      wrongDomainTagSignature.r
+      + wrongDomainTagSignature.s
+      + [UInt8(wrongDomainTagSignature.v)]
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: wrongDomainTagText,
+        walletSignature: wrongDomainTagWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let bindingText = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let bindingSignature = BarnardCoreSigning.signRecoverable(
+      privateKey: walletPrivateKey,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(text: bindingText)
+    )
+    let bindingWalletSignature =
+      bindingSignature.r
+      + bindingSignature.s
+      + [UInt8(bindingSignature.v)]
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: bindingText,
+        walletSignature: bindingWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let rawDigestSigner = try XCTUnwrap(
+      BarnardCoreSigning.signAccountUnbinding(
+        signerPrivateKey: walletPrivateKey,
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: originalBindingSignature
+      )
+    )
+    let rawDigestWalletSignature =
+      rawDigestSigner.r
+      + rawDigestSigner.s
+      + [UInt8(rawDigestSigner.v)]
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: rawDigestWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let smartWalletMagic = bytes(
+      "6492649264926492649264926492649264926492649264926492649264926492"
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: [0xaa] + smartWalletMagic,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .smartWalletUnsupported
     )
   }
 

--- a/schema/barnard/v1/wallet-binding.schema.json
+++ b/schema/barnard/v1/wallet-binding.schema.json
@@ -65,6 +65,25 @@
         }
       ]
     },
+    "UnbindingMessage": {
+      "description": "Canonical UTF-8 wallet-authorized account-unbinding text with LF line endings and no trailing newline.",
+      "type": "string",
+      "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{1,5})? wants to revoke this wallet's binding to a Levarac owner key\\.\\n\\nThis signature REVOKES a wallet binding and authorizes no transaction\\.\\n\\nDomain-Tag: barnard-account-unbinding:v1\\nWallet: 0x[0-9a-f]{40}\\nOwner-Key: 0x(?:02|03)[0-9a-f]{64}\\nChain-ID: eip155:(?:0|[1-9][0-9]*)\\nScope: global\\nNonce: 0x[0-9a-f]{32}\\nIssued-At: [0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])",
+      "allOf": [
+        {
+          "description": "The optional decimal port is canonical and in the 0...65535 range.",
+          "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::(?:0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))? wants to revoke "
+        },
+        {
+          "description": "Chain-ID is in the UInt64 range used by BarnardCore.",
+          "pattern": "\\nChain-ID: eip155:(?:0|[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|18446744073709550[0-9]{3}|18446744073709551[0-5][0-9]{2}|1844674407370955160[0-9]|1844674407370955161[0-4]|18446744073709551615)\\n"
+        },
+        {
+          "description": "Issued-At is a valid proleptic-Gregorian date at UTC second precision.",
+          "pattern": "\\nIssued-At: (?:[0-9]{4}-(?:(?:01|03|05|07|08|10|12)-(?:0[1-9]|[12][0-9]|3[01])|(?:04|06|09|11)-(?:0[1-9]|[12][0-9]|30)|02-(?:0[1-9]|1[0-9]|2[0-8]))|(?:[0-9]{2}(?:0[48]|[2468][048]|[13579][26])|(?:[02468][048]|[13579][26])00)-02-29)T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])"
+        }
+      ]
+    },
     "WalletBindingRecord": {
       "type": "object",
       "additionalProperties": false,
@@ -122,6 +141,16 @@
       ]
     },
     "AccountUnbindingRecord": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/OwnerAccountUnbindingRecord"
+        },
+        {
+          "$ref": "#/$defs/WalletAccountUnbindingRecord"
+        }
+      ]
+    },
+    "OwnerAccountUnbindingRecord": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -141,11 +170,7 @@
           "$ref": "#/$defs/Hash32"
         },
         "signer": {
-          "type": "string",
-          "enum": [
-            "owner",
-            "wallet"
-          ]
+          "const": "owner"
         },
         "signature": {
           "$ref": "#/$defs/BarnardRecoverableSignature"
@@ -157,6 +182,34 @@
         "ownerPublicKey",
         "walletAddress",
         "walletSignatureHash",
+        "signer",
+        "signature"
+      ]
+    },
+    "WalletAccountUnbindingRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "account-unbinding"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "message": {
+          "$ref": "#/$defs/UnbindingMessage"
+        },
+        "signer": {
+          "const": "wallet"
+        },
+        "signature": {
+          "$ref": "#/$defs/WalletSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "message",
         "signer",
         "signature"
       ]

--- a/scripts/check-wallet-binding-schema.py
+++ b/scripts/check-wallet-binding-schema.py
@@ -10,12 +10,45 @@ from pathlib import Path
 from typing import Any
 
 
-def binding_message_schema(schema_path: Path) -> dict[str, Any]:
+def message_schemas(
+    schema_path: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
     document = json.loads(schema_path.read_text(encoding="utf-8"))
-    message = document.get("$defs", {}).get("BindingMessage")
-    if not isinstance(message, dict):
+    definitions = document.get("$defs", {})
+    binding_message = definitions.get("BindingMessage")
+    unbinding_message = definitions.get("UnbindingMessage")
+    unbinding_record = definitions.get("AccountUnbindingRecord")
+    owner_unbinding_record = definitions.get("OwnerAccountUnbindingRecord")
+    wallet_unbinding_record = definitions.get("WalletAccountUnbindingRecord")
+    if not isinstance(binding_message, dict):
         raise ValueError("$defs.BindingMessage is missing or is not an object")
-    return message
+    if not isinstance(unbinding_message, dict):
+        raise ValueError("$defs.UnbindingMessage is missing or is not an object")
+    if not isinstance(unbinding_record, dict):
+        raise ValueError(
+            "$defs.AccountUnbindingRecord is missing or is not an object"
+        )
+    if not isinstance(owner_unbinding_record, dict):
+        raise ValueError(
+            "$defs.OwnerAccountUnbindingRecord is missing or is not an object"
+        )
+    if not isinstance(wallet_unbinding_record, dict):
+        raise ValueError(
+            "$defs.WalletAccountUnbindingRecord is missing or is not an object"
+        )
+    return (
+        binding_message,
+        unbinding_message,
+        unbinding_record,
+        owner_unbinding_record,
+        wallet_unbinding_record,
+    )
 
 
 def matches(schema: dict[str, Any], value: str) -> bool:
@@ -36,17 +69,34 @@ def matches(schema: dict[str, Any], value: str) -> bool:
 
 def message(
     *,
+    ceremony: str = "binding",
     domain: str = "beid.levarac.org",
     chain_id: str = "1",
     issued_at: str = "2026-07-30T09:00:00Z",
 ) -> str:
+    if ceremony == "binding":
+        header = f"{domain} wants to bind this wallet to a Levarac owner key."
+        statement = "This signature authorizes no transaction and moves no assets."
+        domain_tag = "barnard-account-binding:v1"
+    elif ceremony == "unbinding":
+        header = (
+            f"{domain} wants to revoke this wallet's binding "
+            "to a Levarac owner key."
+        )
+        statement = (
+            "This signature REVOKES a wallet binding "
+            "and authorizes no transaction."
+        )
+        domain_tag = "barnard-account-unbinding:v1"
+    else:
+        raise ValueError(f"unsupported ceremony: {ceremony}")
     return "\n".join(
         [
-            f"{domain} wants to bind this wallet to a Levarac owner key.",
+            header,
             "",
-            "This signature authorizes no transaction and moves no assets.",
+            statement,
             "",
-            "Domain-Tag: barnard-account-binding:v1",
+            f"Domain-Tag: {domain_tag}",
             "Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325",
             (
                 "Owner-Key: "
@@ -70,12 +120,18 @@ def main() -> int:
         / "wallet-binding.schema.json"
     )
     try:
-        schema = binding_message_schema(schema_path)
+        (
+            binding_schema,
+            unbinding_schema,
+            unbinding_record,
+            owner_unbinding_record,
+            wallet_unbinding_record,
+        ) = message_schemas(schema_path)
     except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
         print(f"ERROR: cannot load binding-message schema: {error}", file=sys.stderr)
         return 1
 
-    accepted = [
+    binding_accepted = [
         message(),
         message(domain="beid.levarac.org:0"),
         message(domain="beid.levarac.org:65535"),
@@ -84,7 +140,7 @@ def main() -> int:
         message(issued_at="2024-02-29T23:59:59Z"),
         message(issued_at="2000-02-29T00:00:00Z"),
     ]
-    rejected = [
+    binding_rejected = [
         message(domain="beid.levarac.org:00080"),
         message(domain="beid.levarac.org:65536"),
         message(domain="beid.levarac.org:99999"),
@@ -109,22 +165,121 @@ def main() -> int:
         message() + "\n",
         message().replace("\n", "\r\n"),
     ]
+    unbinding_accepted = [
+        message(ceremony="unbinding"),
+        message(ceremony="unbinding", domain="beid.levarac.org:0"),
+        message(ceremony="unbinding", domain="beid.levarac.org:65535"),
+        message(ceremony="unbinding", chain_id="0"),
+        message(ceremony="unbinding", chain_id="18446744073709551615"),
+        message(
+            ceremony="unbinding",
+            issued_at="2024-02-29T23:59:59Z",
+        ),
+    ]
+    unbinding_rejected = [
+        message(ceremony="unbinding").replace(
+            "Domain-Tag: barnard-account-unbinding:v1",
+            "Domain-Tag: barnard-account-binding:v1",
+        ),
+        message(),
+        message(ceremony="unbinding", domain="beid.levarac.org:00080"),
+        message(ceremony="unbinding", domain="beid.levarac.org:65536"),
+        message(ceremony="unbinding", chain_id="01"),
+        message(ceremony="unbinding", chain_id="18446744073709551616"),
+        message(ceremony="unbinding", issued_at="2026-02-29T09:00:00Z"),
+        message(ceremony="unbinding").replace(
+            "This signature REVOKES a wallet binding "
+            "and authorizes no transaction.",
+            "This signature authorizes no transaction and moves no assets.",
+        ),
+        message(ceremony="unbinding") + "\n",
+        message(ceremony="unbinding").replace("\n", "\r\n"),
+    ]
 
     failures: list[str] = []
-    for index, fixture in enumerate(accepted):
-        if not matches(schema, fixture):
-            failures.append(f"valid fixture {index} was rejected")
-    for index, fixture in enumerate(rejected):
-        if matches(schema, fixture):
-            failures.append(f"invalid fixture {index} was accepted")
+    for name, schema, accepted, rejected in [
+        (
+            "binding",
+            binding_schema,
+            binding_accepted,
+            binding_rejected,
+        ),
+        (
+            "unbinding",
+            unbinding_schema,
+            unbinding_accepted,
+            unbinding_rejected,
+        ),
+    ]:
+        for index, fixture in enumerate(accepted):
+            if not matches(schema, fixture):
+                failures.append(f"valid {name} fixture {index} was rejected")
+        for index, fixture in enumerate(rejected):
+            if matches(schema, fixture):
+                failures.append(f"invalid {name} fixture {index} was accepted")
+
+    expected_variant_refs = {
+        "#/$defs/OwnerAccountUnbindingRecord",
+        "#/$defs/WalletAccountUnbindingRecord",
+    }
+    actual_variant_refs = {
+        variant.get("$ref")
+        for variant in unbinding_record.get("oneOf", [])
+        if isinstance(variant, dict)
+    }
+    if actual_variant_refs != expected_variant_refs:
+        failures.append("account-unbinding record does not define both signer variants")
+
+    record_expectations = [
+        (
+            "owner",
+            owner_unbinding_record,
+            {
+                "type",
+                "schemaVersion",
+                "ownerPublicKey",
+                "walletAddress",
+                "walletSignatureHash",
+                "signer",
+                "signature",
+            },
+            "#/$defs/BarnardRecoverableSignature",
+        ),
+        (
+            "wallet",
+            wallet_unbinding_record,
+            {"type", "schemaVersion", "message", "signer", "signature"},
+            "#/$defs/WalletSignature",
+        ),
+    ]
+    for signer, record, required, signature_ref in record_expectations:
+        properties = record.get("properties", {})
+        if (
+            record.get("additionalProperties") is not False
+            or set(record.get("required", [])) != required
+            or properties.get("signer", {}).get("const") != signer
+            or properties.get("signature", {}).get("$ref") != signature_ref
+        ):
+            failures.append(
+                f"{signer} account-unbinding record shape is not canonical"
+            )
+    if (
+        wallet_unbinding_record.get("properties", {})
+        .get("message", {})
+        .get("$ref")
+        != "#/$defs/UnbindingMessage"
+    ):
+        failures.append("wallet account-unbinding record does not use UnbindingMessage")
 
     if failures:
         for failure in failures:
             print(f"ERROR: {failure}", file=sys.stderr)
         return 1
     print(
-        "OK: wallet-binding schema accepts canonical boundary fixtures "
-        f"({len(accepted)} valid, {len(rejected)} invalid)."
+        "OK: wallet-binding schema accepts canonical binding and unbinding "
+        "boundary fixtures "
+        f"({len(binding_accepted) + len(unbinding_accepted)} valid, "
+        f"{len(binding_rejected) + len(unbinding_rejected)} invalid)."
     )
     return 0
 

--- a/specs/092-owner-key/spec.md
+++ b/specs/092-owner-key/spec.md
@@ -203,6 +203,8 @@ transfer implicitly.
 
 Domain tag: `barnard-account-unbinding:v1`
 
+The owner-key-authorized path remains a Barnard-native message:
+
 ```text
 offset  size  value
 0       28    UTF-8 "barnard-account-unbinding:v1"
@@ -212,17 +214,16 @@ offset  size  value
 total  113
 ```
 
-The digest identifies one exact wallet-binding record. Either the owner key or
-the EOA key controlling `walletAddress` may sign the SHA-256 digest of this
-Barnard-native message. Verification therefore takes an explicit signer kind:
+The digest identifies one exact wallet-binding record. The owner key signs the
+SHA-256 digest of this message. Verification recovers the compressed key and
+requires it to equal `ownerPublicKey`.
 
-- `owner`: the recovered compressed key MUST equal `ownerPublicKey`;
-- `wallet`: the recovered key is decompressed, its Ethereum address is
-  derived, and that address MUST equal `walletAddress`.
-
-The wallet-signing host UX for this reserved lifecycle format is not part of
-v1. It is not the account-binding `personal_sign` ceremony and MUST NOT be
-silently substituted for it.
+The EOA-authorized path MUST NOT sign this raw digest. It uses the canonical
+human-readable account-unbinding text defined below, signs it through
+EIP-191 `personal_sign`, and verifies the recovered Ethereum address against
+`walletAddress`. The two signer paths deliberately retain different message
+formats because owner-key signatures are Barnard-native while wallet
+signatures must remain human-readable.
 
 ## Canonical wallet-binding text
 
@@ -302,6 +303,46 @@ Chain-ID: eip155:1
 Scope: global
 Nonce: 0x000102030405060708090a0b0c0d0e0f
 Issued-At: 2026-07-30T09:00:00Z
+```
+
+## Canonical wallet-authorized unbinding text
+
+An EOA revokes its wallet binding by signing this exact 11-line text:
+
+```text
+{domain} wants to revoke this wallet's binding to a Levarac owner key.
+
+This signature REVOKES a wallet binding and authorizes no transaction.
+
+Domain-Tag: barnard-account-unbinding:v1
+Wallet: 0x{walletAddress lowercase hex}
+Owner-Key: 0x{compressed owner public key lowercase hex}
+Chain-ID: eip155:{chainId unsigned decimal}
+Scope: global
+Nonce: 0x{16-byte nonce lowercase hex}
+Issued-At: {issuedAt}
+```
+
+The canonical encoding rules are identical to the wallet-binding text rules:
+UTF-8, LF only, exact field names and order, no trailing newline, normalized
+lowercase ASCII authority with a canonical optional port, lowercase fixed-size
+hex fields, unsigned 64-bit decimal `chainId`, literal `Scope: global`,
+16-byte `nonce`, and valid RFC 3339 UTC `issuedAt` at second precision. The
+host supplies `nonce` and `issuedAt`; Barnard reads neither randomness nor a
+clock. No Unicode normalization, checksum casing, JSON serialization, or
+locale-sensitive formatting is applied.
+
+The unbinding parser reconstructs the text byte-for-byte and requires the
+`Wallet:` and `Owner-Key:` fields to match the verifier's expected values.
+Binding text, another domain tag, CR, a trailing LF, a reordered field, or a
+noncanonical value is invalid even when the signature matches the altered
+bytes.
+
+For the same example values as the binding ceremony, the EIP-191 digest of the
+430-byte unbinding text is:
+
+```text
+f11e3d04d85d6ac228dde88cebea4ba9554ed06b9c363d5a32f3e4fd89366929
 ```
 
 ## EIP-191 and Ethereum address derivation
@@ -425,13 +466,20 @@ custodial recovery service.
 
 ## Compatibility
 
-- All schemas and APIs in this specification are additive.
-- No existing public schema or on-wire format changes.
+- The wallet-authorized unbinding format and verification semantics are
+  corrected before their first release tag; no previously tagged contract
+  accepts the superseded raw-digest wallet signature.
+- The owner-key-authorized unbinding shape and verification behavior remain
+  unchanged. The canonical wallet text builder and verifier are additive.
+- The holder-held account-unbinding schema is amended before the v0.2.0 tag.
+  No public/on-wire schema or format changes.
 - Existing Advertise, Scan, Central, Peripheral, GATT, Transport, RPID,
   event-signing, and RPID-proof behavior remains unchanged.
 - New domain tags are disjoint from existing Barnard tags.
-- EIP-191 prefixing and Ethereum Keccak keep wallet signatures in a different
-  hash universe from Barnard-native SHA-256 signatures.
+- Wallet-authorized binding and unbinding signatures use EIP-191 plus Ethereum
+  Keccak; owner-key acknowledgements, rotations, and unbindings use
+  Barnard-native SHA-256. No verification path accepts one signature class as
+  the other.
 
 ## Security and privacy
 
@@ -445,11 +493,14 @@ document root explicitly declares holder-held disclosure scope. Public/on-wire
 schemas MUST NOT define a 33-byte compressed-public-key shape, a 20-byte
 address shape, or references into holder-held schemas.
 
-The wallet ceremony has three domain-separation layers:
+The wallet ceremonies have three domain-separation layers:
 
 1. EIP-191 prevents cross-use as a transaction or Barnard-native signature.
-2. `Domain-Tag: barnard-account-binding:v1` prevents cross-protocol reuse.
-3. The visible domain and no-assets statement reduce blind-signing risk.
+2. Distinct `barnard-account-binding:v1` and
+   `barnard-account-unbinding:v1` domain tags prevent cross-protocol and
+   bind-versus-revoke reuse.
+3. The visible domain and explicit non-transaction statements reduce
+   blind-signing risk.
 
 Wallet linkage intentionally connects disclosed event history to a public
 address. Hosts MUST request explicit consent and MUST NOT auto-prompt binding.
@@ -487,6 +538,9 @@ Using a fresh wallet address remains valid.
   no expiry semantics.
 - A binding text without the no-assets statement: rejected because the
   ceremony must remain human-readable and explicitly non-transactional.
+- Raw-digest wallet-authorized unbinding: rejected because `eth_sign`-style
+  blind signing contradicts the readable wallet ceremony; EIP-191
+  `personal_sign` is required.
 
 ## Future work
 


### PR DESCRIPTION
## Summary

- add a byte-exact 11-line wallet-authorized account-unbinding ceremony under `barnard-account-unbinding:v1`
- verify wallet signatures with EIP-191/Keccak recovery, Ethereum `v` normalization, low-S enforcement, ERC-6492-first classification, and recovered-address comparison
- remove raw Barnard-native SHA-256 acceptance from the wallet-signer path while preserving the owner-key-authorized native message and verification behavior
- add golden text/digest vectors and negative coverage for wrong domain tags, binding/unbinding confusion, raw-digest signatures, invalid recovery IDs, high-S signatures, and unsupported smart-wallet signatures

## Spec and schema

- update `specs/092-owner-key/spec.md` with the wallet unbinding ceremony and accurate compatibility boundaries
- split the holder-held account-unbinding schema into owner and wallet signer variants; wallet records carry the canonical message plus an EIP-191 wallet signature
- keep the disclosure scope holder-held; no device-unique persistent identifier is added to Advertise, Scan, Central, Peripheral, GATT, Transport, public anchors, or other on-wire shapes

## Validation

- `python3 scripts/check-schema-privacy-invariant.py --self-test`
- `python3 scripts/check-wallet-binding-schema.py` (13 valid, 24 invalid fixtures)
- `swift build --package-path packages/swift/barnard --target BarnardCore`
- `swift build --package-path packages/swift/barnard --target BarnardCoreC`
- `xcodebuild -scheme Barnard-Package -destination 'generic/platform=iOS Simulator' -only-testing:BarnardCoreTests/BarnardOwnerKeyMessageTests build-for-testing`
- optimized direct runtime smoke: EIP-191 valid; `v` normalization valid; low-S enforced; raw digest invalid; wrong tag invalid; owner native valid
- `./scripts/check-swift-mirror.sh`
- `./scripts/check-swift-package-manifest-mirror.sh`

Refs #97