### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,45 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+# Public repo (free tier). Review output stays in English: barnard is a public
+# OSS repo whose issues/PRs are English by convention.
+language: "en-US"
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "main"
+      - "release/.*"
+  path_instructions:
+    - path: "packages/swift/barnard/Sources/BarnardCore/**"
+      instructions: |
+        Pure-logic core layer. Review with a cryptography lens: domain-tag
+        separation (no tag may be a prefix of another), canonical encodings
+        must be byte-exact and round-trip through their parsers, golden
+        vectors must be regenerated together with any encoding change, and
+        secrets must never be logged. New dependencies on Foundation are
+        forbidden here (stdlib purity is CI-enforced).
+    - path: "packages/dart/barnard/**"
+      instructions: |
+        Parts of this tree are byte-for-byte mirrors of native origins (see
+        scripts/mirror-manifest.sh). Never suggest editing a mirrored file
+        directly; the fix belongs in the native origin followed by
+        scripts/sync-mirrors.sh.
+    - path: "specs/**"
+      instructions: |
+        Spec-first repository (Spec Kit discipline). Frozen :v1 message
+        formats must not change shape; propose a :v2 profile instead.
+        Normative language should use RFC 2119 keywords consistently.
+    - path: ".github/workflows/**"
+      instructions: |
+        Workflows must keep push triggers scoped (main and release/**),
+        job-level timeout-minutes, and concurrency groups that cancel only
+        pull_request runs. Flag any job added without a timeout.
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,8 +32,11 @@ reviews:
         scripts/sync-mirrors.sh.
     - path: "specs/**"
       instructions: |
-        Spec-first repository (Spec Kit discipline). Frozen :v1 message
-        formats must not change shape; propose a :v2 profile instead.
+        Spec-first repository (Spec Kit discipline). A :v1 message format
+        freezes at the release tag that ships it: BEFORE that tag,
+        amendments are legitimate but must update golden vectors, mirrors,
+        and schemas together; AFTER it, shape changes belong in a :v2
+        profile.
         Normative language should use RFC 2119 keywords consistently.
     - path: ".github/workflows/**"
       instructions: |

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,8 +6,20 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches: [ main, "release/**" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   flutter:

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -6,8 +6,20 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches: [ main, "release/**" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   schema-privacy-invariant:


### PR DESCRIPTION
Repo-side setup for the CodeRabbit reviewer (app install is a separate one-time step by the org owner; public repos are on the free tier).

Choices, all tunable: English output (public-OSS convention), `assertive` profile (this repo values strictness; drop to `chill` if noisy), auto-review for PRs targeting `main` and `release/**`, drafts excluded so worker draft-PRs don't burn reviews early. Path instructions teach it the standing disciplines: BarnardCore crypto/purity rules, the mirror-tree don't-edit-directly rule, the spec :v1 freeze policy, and the workflow timeout/concurrency requirements.

CodeRabbit reads the config from the PR head branch (falling back to the default branch), so landing this on `release/0.2.0` covers all active work; `main` inherits it at release integration. Milestone 0.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new automated review configuration with English output, assertive review style, and improved summary/status reporting.
  * Streamlined automated reviews by disabling specific review behaviors and focusing on relevant branch activity (excluding drafts).
  * Updated CI triggers so documentation and general repository/config changes no longer start unnecessary build runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->