### PR TITLE
fix(swift): polish owner-key unbinding before v0.2.0

### DIFF
--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -12,11 +12,6 @@ public enum BarnardCoreWalletBindingVerification: Int32 {
   case smartWalletUnsupported = 2
 }
 
-public enum BarnardCoreAccountUnbindingSigner: Int32 {
-  case owner = 0
-  case wallet = 1
-}
-
 public enum BarnardCoreWalletVerifierVerdict: Equatable {
   case valid(verifiedAtUnixSeconds: Int64)
   case invalid(verifiedAtUnixSeconds: Int64)
@@ -308,13 +303,13 @@ public extension BarnardCoreSigning {
   }
 
   static func signAccountUnbinding(
-    signerPrivateKey: [UInt8],
+    ownerPrivateKey: [UInt8],
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8]
   ) -> BarnardCoreRecoverableSignature? {
     guard
-      isValidPrivateKey(signerPrivateKey),
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
       let message = buildAccountUnbindingMessage(
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
@@ -324,37 +319,31 @@ public extension BarnardCoreSigning {
       return nil
     }
     return signRecoverable(
-      privateKey: signerPrivateKey,
+      privateKey: ownerPrivateKey,
       messageHash32: BarnardCorePrimitives.sha256(message)
     )
   }
 
   static func verifyAccountUnbinding(
-    signer: BarnardCoreAccountUnbindingSigner,
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    switch signer {
-    case .owner:
-      guard
-        let message = buildAccountUnbindingMessage(
-          ownerPublicKey: ownerPublicKey,
-          walletAddress: walletAddress,
-          walletSignature: walletSignature
-        ),
-        let recoveredPublicKey = strictRecoveredPublicKey(
-          signature,
-          messageHash32: BarnardCorePrimitives.sha256(message)
-        )
-      else {
-        return false
-      }
-      return recoveredPublicKey == ownerPublicKey
-    case .wallet:
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      ),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        signature,
+        messageHash32: BarnardCorePrimitives.sha256(message)
+      )
+    else {
       return false
     }
+    return recoveredPublicKey == ownerPublicKey
   }
 
   static func verifyAccountUnbinding(

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -335,15 +335,15 @@ public extension BarnardCoreSigning {
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
         walletSignature: walletSignature
-      ),
-      let recoveredPublicKey = strictRecoveredPublicKey(
-        signature,
-        messageHash32: BarnardCorePrimitives.sha256(message)
       )
     else {
       return false
     }
-    return recoveredPublicKey == ownerPublicKey
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
   }
 
   static func verifyAccountUnbinding(

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -12,11 +12,6 @@ public enum BarnardCoreWalletBindingVerification: Int32 {
   case smartWalletUnsupported = 2
 }
 
-public enum BarnardCoreAccountUnbindingSigner: Int32 {
-  case owner = 0
-  case wallet = 1
-}
-
 public enum BarnardCoreWalletVerifierVerdict: Equatable {
   case valid(verifiedAtUnixSeconds: Int64)
   case invalid(verifiedAtUnixSeconds: Int64)
@@ -308,13 +303,13 @@ public extension BarnardCoreSigning {
   }
 
   static func signAccountUnbinding(
-    signerPrivateKey: [UInt8],
+    ownerPrivateKey: [UInt8],
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8]
   ) -> BarnardCoreRecoverableSignature? {
     guard
-      isValidPrivateKey(signerPrivateKey),
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
       let message = buildAccountUnbindingMessage(
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
@@ -324,37 +319,31 @@ public extension BarnardCoreSigning {
       return nil
     }
     return signRecoverable(
-      privateKey: signerPrivateKey,
+      privateKey: ownerPrivateKey,
       messageHash32: BarnardCorePrimitives.sha256(message)
     )
   }
 
   static func verifyAccountUnbinding(
-    signer: BarnardCoreAccountUnbindingSigner,
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    switch signer {
-    case .owner:
-      guard
-        let message = buildAccountUnbindingMessage(
-          ownerPublicKey: ownerPublicKey,
-          walletAddress: walletAddress,
-          walletSignature: walletSignature
-        ),
-        let recoveredPublicKey = strictRecoveredPublicKey(
-          signature,
-          messageHash32: BarnardCorePrimitives.sha256(message)
-        )
-      else {
-        return false
-      }
-      return recoveredPublicKey == ownerPublicKey
-    case .wallet:
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      ),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        signature,
+        messageHash32: BarnardCorePrimitives.sha256(message)
+      )
+    else {
       return false
     }
+    return recoveredPublicKey == ownerPublicKey
   }
 
   static func verifyAccountUnbinding(

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -335,15 +335,15 @@ public extension BarnardCoreSigning {
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
         walletSignature: walletSignature
-      ),
-      let recoveredPublicKey = strictRecoveredPublicKey(
-        signature,
-        messageHash32: BarnardCorePrimitives.sha256(message)
       )
     else {
       return false
     }
-    return recoveredPublicKey == ownerPublicKey
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
   }
 
   static func verifyAccountUnbinding(

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
@@ -422,7 +422,7 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
 
     let ownerSignature = try XCTUnwrap(
       BarnardCoreSigning.signAccountUnbinding(
-        signerPrivateKey: scalarOne,
+        ownerPrivateKey: scalarOne,
         ownerPublicKey: generatorCompressed,
         walletAddress: walletAddress,
         walletSignature: walletSignature
@@ -430,20 +430,18 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
     )
     XCTAssertTrue(
       BarnardCoreSigning.verifyAccountUnbinding(
-        signer: .owner,
         ownerPublicKey: generatorCompressed,
         walletAddress: walletAddress,
         walletSignature: walletSignature,
         signature: ownerSignature
       )
     )
-    XCTAssertFalse(
-      BarnardCoreSigning.verifyAccountUnbinding(
-        signer: .wallet,
+    XCTAssertNil(
+      BarnardCoreSigning.signAccountUnbinding(
+        ownerPrivateKey: walletPrivateKey,
         ownerPublicKey: generatorCompressed,
         walletAddress: walletAddress,
-        walletSignature: walletSignature,
-        signature: ownerSignature
+        walletSignature: walletSignature
       )
     )
   }
@@ -484,6 +482,57 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
         expectedOwnerPublicKey: ownerPublicKey
       ),
       .valid
+    )
+
+    func walletSignature(for candidate: String) -> [UInt8] {
+      let signature = BarnardCoreSigning.signRecoverable(
+        privateKey: walletPrivateKey,
+        messageHash32: BarnardCoreSigning.computeEip191Digest(text: candidate)
+      )
+      return signature.r + signature.s + [UInt8(signature.v + 27)]
+    }
+
+    func assertUnbindingRejected(
+      _ candidate: String,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) {
+      XCTAssertEqual(
+        BarnardCoreSigning.verifyAccountUnbinding(
+          text: candidate,
+          walletSignature: walletSignature(for: candidate),
+          expectedWalletAddress: walletAddress,
+          expectedOwnerPublicKey: ownerPublicKey
+        ),
+        .invalid,
+        file: file,
+        line: line
+      )
+    }
+
+    assertUnbindingRejected(
+      text.replacingOccurrences(of: "\n", with: "\r\n")
+    )
+
+    var wrongLineCount = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    wrongLineCount.remove(at: 1)
+    assertUnbindingRejected(wrongLineCount.joined(separator: "\n"))
+
+    var reorderedFields = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    reorderedFields.swapAt(5, 6)
+    assertUnbindingRejected(reorderedFields.joined(separator: "\n"))
+
+    assertUnbindingRejected(
+      text.replacingOccurrences(
+        of: "This signature REVOKES a wallet binding and authorizes no transaction.",
+        with: "This signature authorizes no transaction and moves no assets."
+      )
     )
 
     var rawRecoveryIdSignature = walletSigner
@@ -578,26 +627,31 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
       .invalid
     )
 
-    let rawDigestSigner = try XCTUnwrap(
+    let unbindingAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: scalarTwo,
+        walletAddress: walletAddress,
+        walletSignature: walletSigner
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSigner,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: unbindingAcknowledgement
+      ),
+      .invalid
+    )
+
+    XCTAssertNil(
       BarnardCoreSigning.signAccountUnbinding(
-        signerPrivateKey: walletPrivateKey,
+        ownerPrivateKey: walletPrivateKey,
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
         walletSignature: originalBindingSignature
       )
-    )
-    let rawDigestWalletSignature =
-      rawDigestSigner.r
-      + rawDigestSigner.s
-      + [UInt8(rawDigestSigner.v)]
-    XCTAssertEqual(
-      BarnardCoreSigning.verifyAccountUnbinding(
-        text: text,
-        walletSignature: rawDigestWalletSignature,
-        expectedWalletAddress: walletAddress,
-        expectedOwnerPublicKey: ownerPublicKey
-      ),
-      .invalid
     )
 
     let smartWalletMagic = bytes(

--- a/specs/092-owner-key/spec.md
+++ b/specs/092-owner-key/spec.md
@@ -216,7 +216,10 @@ total  113
 
 The digest identifies one exact wallet-binding record. The owner key signs the
 SHA-256 digest of this message. Verification recovers the compressed key and
-requires it to equal `ownerPublicKey`.
+requires it to equal `ownerPublicKey`. The BarnardCore signer is owner-only:
+it accepts `ownerPrivateKey`, requires that key to derive `ownerPublicKey`,
+and rejects a mismatched key rather than minting an unverifiable signature.
+The corresponding verifier has no signer-kind parameter.
 
 The EOA-authorized path MUST NOT sign this raw digest. It uses the canonical
 human-readable account-unbinding text defined below, signs it through
@@ -224,6 +227,16 @@ EIP-191 `personal_sign`, and verifies the recovered Ethereum address against
 `walletAddress`. The two signer paths deliberately retain different message
 formats because owner-key signatures are Barnard-native while wallet
 signatures must remain human-readable.
+
+The two paths also have deliberately different revocation granularity. An
+owner-key-authorized unbinding revokes one exact binding record, identified by
+`walletSignatureHash`. The wallet-authorized ceremony carries no wallet
+signature hash and revokes at `(walletAddress, ownerPublicKey, chainId)`
+granularity. A valid wallet-authorized unbinding therefore revokes the binding
+fact for that tuple, not merely one encoding or signature of it. This follows
+from treating a binding as an idempotent, long-lived fact: repeating the same
+binding ceremony MUST NOT bypass an existing revocation by producing different
+signature bytes.
 
 ## Canonical wallet-binding text
 
@@ -413,6 +426,36 @@ canonical text, wallet signature, expected 20-byte wallet address, expected
 9. Only if the canonical binding and both signatures pass, return `valid`.
 
 The API does not aggregate endorsements and does not query RPC.
+
+## Wallet-authorized unbinding verification
+
+`verifyAccountUnbinding` verifies one wallet-authorized unbinding ceremony
+only. It takes the byte-exact canonical unbinding text, wallet signature,
+expected 20-byte wallet address, and expected 33-byte owner public key.
+
+1. Parse the supplied text under the canonical unbinding grammar, reconstruct
+   it byte-for-byte, and require its `Wallet:` and `Owner-Key:` fields to equal
+   `expectedWalletAddress` and `expectedOwnerPublicKey`. Reject any
+   noncanonical text, field mismatch, CR, trailing LF, binding statement, or
+   binding domain tag before treating the signature as a revocation.
+2. Classify the wallet signature.
+   - `smartWalletUnsupported` returns an unverified smart-wallet result.
+   - `invalid` returns an invalid-shape result.
+3. Parse `r || s || v` from the 65-byte signature.
+4. Normalize `v = 27` to recovery ID 0 and `v = 28` to recovery ID 1. Raw
+   `v = 0` and `v = 1` are also accepted. Reject every other value.
+5. Require valid non-zero `r` and `s` scalars and low-S.
+6. Compute the EIP-191 digest and recover the public key with the existing
+   recovery primitive. Recovery IDs 2 and 3 remain unsupported deliberately.
+7. Derive the recovered Ethereum address and compare it byte-for-byte with
+   `expectedWalletAddress`.
+8. Only if the canonical unbinding and wallet signature pass, return `valid`.
+
+The wallet-signed unbinding has no owner-acknowledgement step. A conforming
+verifier MUST NOT require an owner signature or owner cooperation: a wallet
+can unilaterally revoke its binding to an owner key.
+
+The API does not aggregate revocations and does not query RPC.
 
 ## Smart-wallet verifier port
 


### PR DESCRIPTION
## Summary

- document the wallet-authorized unbinding verification procedure, unilateral revocation property, and the deliberate revocation-granularity divergence
- make the native owner-key unbinding signer/verifier owner-only and reject private keys that do not derive the declared owner public key
- add canonical-encoding negative coverage and binding/unbinding cross-direction rejection coverage
- synchronize the Dart-package Swift mirror from the native source

## Spec and compatibility

- Spec: `specs/092-owner-key/spec.md`
- Schema: no public on-wire shape changes
- Compatibility: intentional pre-tag Swift source API break; removes the dead signer-kind branch before v0.2.0 freezes it
- Security/privacy: wallet-authorized unbinding requires no owner acknowledgement, allowing unilateral revocation; no device-unique persistent identifiers are added on-wire

## Validation

- BarnardCore XCTest bundle: 20 tests, 0 failures
- `swift build --target BarnardCore`: passed
- `swift build --target BarnardCoreC`: passed
- `./scripts/check-swift-mirror.sh`: passed
- `./scripts/check-swift-package-manifest-mirror.sh`: passed
- removed-surface/C ABI reference search: no C export references the deleted signer enum or signer-kind parameter

Refs #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account unbinding now requires the owner’s private key to match the declared owner public key.
  * Added canonical validation for unbinding messages and wallet-authorized revocation, including smart-wallet support.
  * Wallets can revoke bindings unilaterally without owner acknowledgement.

* **Bug Fixes**
  * Prevented wallet acknowledgement signatures and wallet keys from being used as owner unbinding signatures.
  * Added validation for malformed, reordered, or non-canonical unbinding messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->