### PR TITLE
Release 0.2.0: integrate release/0.2.0 into main

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,48 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+# Public repo (free tier). Review output stays in English: barnard is a public
+# OSS repo whose issues/PRs are English by convention.
+language: "en-US"
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "main"
+      - "release/.*"
+  path_instructions:
+    - path: "packages/swift/barnard/Sources/BarnardCore/**"
+      instructions: |
+        Pure-logic core layer. Review with a cryptography lens: domain-tag
+        separation (no tag may be a prefix of another), canonical encodings
+        must be byte-exact and round-trip through their parsers, golden
+        vectors must be regenerated together with any encoding change, and
+        secrets must never be logged. New dependencies on Foundation are
+        forbidden here (stdlib purity is CI-enforced).
+    - path: "packages/dart/barnard/**"
+      instructions: |
+        Parts of this tree are byte-for-byte mirrors of native origins (see
+        scripts/mirror-manifest.sh). Never suggest editing a mirrored file
+        directly; the fix belongs in the native origin followed by
+        scripts/sync-mirrors.sh.
+    - path: "specs/**"
+      instructions: |
+        Spec-first repository (Spec Kit discipline). A :v1 message format
+        freezes at the release tag that ships it: BEFORE that tag,
+        amendments are legitimate but must update golden vectors, mirrors,
+        and schemas together; AFTER it, shape changes belong in a :v2
+        profile.
+        Normative language should use RFC 2119 keywords consistently.
+    - path: ".github/workflows/**"
+      instructions: |
+        Workflows must keep push triggers scoped (main and release/**),
+        job-level timeout-minutes, and concurrency groups that cancel only
+        pull_request runs. Flag any job added without a timeout.
+
+chat:
+  auto_reply: true

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,8 +6,20 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches: [ main, "release/**" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   flutter:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -3,7 +3,7 @@ name: Dart CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ main, "release/**" ]
 
 jobs:
   flutter:

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,5 +1,9 @@
 name: Dart CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
   push:
@@ -8,6 +12,7 @@ on:
 jobs:
   flutter:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -34,6 +39,7 @@ jobs:
 
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [flutter]
     defaults:
       run:

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -3,7 +3,7 @@ name: Native SDK CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ main, "release/**" ]
 
 jobs:
   swift-package:

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -81,9 +81,9 @@ jobs:
             --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)"
 
   swift-mirror-sync-check:
-    # packages/swift/barnard mirrors the Flutter-free platform adapters and
-    # BarnardCore sources under packages/dart/barnard/ios; this guards against
-    # drift (see scripts/check-swift-mirror.sh).
+    # packages/swift/barnard is the origin for Flutter-free platform adapters
+    # and BarnardCore sources mirrored under packages/dart/barnard/ios; this
+    # guards against drift (see scripts/check-swift-mirror.sh).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -139,9 +139,9 @@ jobs:
         run: ./gradlew test
 
   android-mirror-sync-check:
-    # packages/android/barnard mirrors the Flutter-free crypto/signing/RPID
-    # sources under packages/dart/barnard/android; this guards against drift
-    # (see scripts/check-android-mirror.sh).
+    # packages/android/barnard is the origin for Flutter-free
+    # crypto/signing/RPID sources mirrored under packages/dart/barnard/android;
+    # this guards against drift (see scripts/check-android-mirror.sh).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -24,7 +24,7 @@ jobs:
     # toolchain is installed in this job (barnard#56 acceptance criterion:
     # "CI validates each first-class SDK surface independently").
     runs-on: macos-15
-    timeout-minutes: 35
+    timeout-minutes: 50
     defaults:
       run:
         working-directory: packages/swift/barnard

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -1,5 +1,9 @@
 name: Native SDK CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   pull_request:
   push:
@@ -11,6 +15,7 @@ jobs:
     # toolchain is installed in this job (barnard#56 acceptance criterion:
     # "CI validates each first-class SDK surface independently").
     runs-on: macos-15
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: packages/swift/barnard
@@ -85,12 +90,14 @@ jobs:
     # and BarnardCore sources mirrored under packages/dart/barnard/ios; this
     # guards against drift (see scripts/check-swift-mirror.sh).
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/check-swift-mirror.sh
 
   ios-native-example:
     runs-on: macos-15
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: examples/ios-native
@@ -123,6 +130,7 @@ jobs:
     # acceptance criterion: "CI validates each first-class SDK surface
     # independently").
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: packages/android/barnard
@@ -143,12 +151,14 @@ jobs:
     # crypto/signing/RPID sources mirrored under packages/dart/barnard/android;
     # this guards against drift (see scripts/check-android-mirror.sh).
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/check-android-mirror.sh
 
   android-native-example:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: examples/android-native

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -6,8 +6,20 @@ concurrency:
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches: [ main, "release/**" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.coderabbit.yaml'
+      - 'LICENSE'
+      - '.gitignore'
 
 jobs:
   schema-privacy-invariant:

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -10,6 +10,15 @@ on:
     branches: [ main, "release/**" ]
 
 jobs:
+  schema-privacy-invariant:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enforce schema privacy invariant
+        run: |
+          python3 scripts/check-schema-privacy-invariant.py --self-test
+          python3 scripts/check-wallet-binding-schema.py
+
   swift-package:
     # Flutter-free: builds/tests packages/swift/barnard directly. No Flutter
     # toolchain is installed in this job (barnard#56 acceptance criterion:

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -22,7 +22,7 @@ on:
       - "packages/swift/**"
       - ".github/workflows/swift-android.yml"
   push:
-    branches: [ main ]
+    branches: [ main, "release/**" ]
     paths:
       - "Package.swift"
       - "packages/swift/**"

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -97,6 +97,7 @@ jobs:
           swift build --package-path packages/swift/barnard \
             --product BarnardCoreC \
             --swift-sdk "$ANDROID_TRIPLE" \
+            --static-swift-stdlib \
             -c release
       - name: Verify exported C ABI symbols in the Android .so
         run: |
@@ -138,7 +139,23 @@ jobs:
           done
           echo "OK: all 20 C ABI symbols exported for $ANDROID_TRIPLE"
 
-      - name: C host consumption proof (Linux native, same C ABI)
+      - name: Reject dynamic Swift runtime dependencies in the Android .so
+        # Runtime execution is deferred to the device lab; this cheap guard
+        # ensures the Android artifact does not require libswift*.so at load time.
+        run: |
+          so=$(find packages/swift/barnard/.build -name libBarnardCoreC.so | head -1)
+          readelf=$(find "$ANDROID_NDK_LATEST_HOME" -name llvm-readelf | head -1)
+          if [ -z "$so" ] || [ -z "$readelf" ]; then
+            echo "Android .so or llvm-readelf not found" >&2
+            exit 1
+          fi
+          "$readelf" -d "$so" | tee /tmp/barnard-corec-needed.txt
+          if grep -E 'Shared library: \[libswift[^]]*\.so\]' /tmp/barnard-corec-needed.txt; then
+            echo "BarnardCoreC must not retain dynamic Swift runtime dependencies" >&2
+            exit 1
+          fi
+
+      - name: C ABI vector replay (Linux native)
         # The Android .so cannot execute on the runner; this builds the same
         # BarnardCoreC product for the Linux host with the same toolchain and
         # replays the issue #80 golden vector through dlopen + the C ABI.

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -120,8 +120,15 @@ jobs:
             barnard_core_compute_event_code_hash \
             barnard_core_display_id4 \
             barnard_core_sha256 \
+            barnard_core_keccak256 \
+            barnard_core_eip191_digest \
             barnard_core_derive_signing_keypair \
+            barnard_core_derive_owner_keypair \
             barnard_core_sign_recoverable \
+            barnard_core_build_self_proof_message \
+            barnard_core_verify_self_proof \
+            barnard_core_classify_wallet_signature \
+            barnard_core_verify_wallet_binding \
             barnard_core_should_emit_rssi_update \
             barnard_core_should_serve_gatt_display_id; do
             if ! grep -qw "$symbol" /tmp/exported-symbols.txt; then
@@ -129,7 +136,7 @@ jobs:
               exit 1
             fi
           done
-          echo "OK: all 13 C ABI symbols exported for $ANDROID_TRIPLE"
+          echo "OK: all 20 C ABI symbols exported for $ANDROID_TRIPLE"
 
       - name: C host consumption proof (Linux native, same C ABI)
         # The Android .so cannot execute on the runner; this builds the same

--- a/.github/workflows/swift-android.yml
+++ b/.github/workflows/swift-android.yml
@@ -1,5 +1,9 @@
 name: Swift Android Cross-Compile
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Locks in what the issue #78 spike proved manually: BarnardCore (and its C ABI
 # surface, BarnardCoreC) cross-compiles for aarch64-android with the official
 # Swift Android SDK, and the exported C symbols stay present in the .so.

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BarnardCoreCTests",
-            dependencies: ["BarnardCoreC"],
+            dependencies: ["BarnardCore", "BarnardCoreC"],
             path: "packages/swift/barnard/Tests/BarnardCoreCTests"
         )
     ]

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The repository is organized around a few design principles:
 - The Flutter/Dart and React Native packages expose BLE Scan and Advertise APIs,
   including a GATT-based RPID exchange on iOS and Android.
 - The native Swift and Android packages expose first-class platform APIs and are
-  built and tested directly in CI. Mirror checks make the relationship between
-  their shared crypto, signing, and RPID sources and the Flutter plugin's
-  Flutter-free platform sources verifiable.
+  built and tested directly in CI. They are the canonical origins for shared
+  crypto, signing, and RPID sources; mirror checks verify the Flutter plugin's
+  referencing copies byte-for-byte.
 - Examples cover mock-driven Dart use, real Flutter BLE use, and minimal native
   iOS and Android integrations. The native Android example also contains a
   two-device test-loop script for a device lab.
@@ -53,7 +53,7 @@ and the reason it is kept in the repository.
 ├── examples/     # Runnable integrations; prove each SDK surface in a minimal host application.
 ├── packages/     # Distributable SDK packages; provide native and framework-specific adoption paths.
 ├── schema/       # Versioned JSON Schema; define language-agnostic public shapes before implementation details.
-├── scripts/      # Repository checks; detect drift between native mirrors and their source files.
+├── scripts/      # Repository checks and sync; keep Dart mirrors aligned with native origins.
 ├── specs/        # Feature specifications; record behavior, boundaries, and privacy decisions independently of code.
 └── tools/        # Focused developer utilities; keep one-off protocol and scanner tooling outside SDK packages.
 ```
@@ -74,14 +74,15 @@ packages/
 
 - `packages/swift/barnard/` is a Swift Package Manager library for iOS 14 and
   later. It exists so native iOS apps can use Barnard without a Flutter runtime;
-  its mirrored Flutter-free sources are checked for byte-for-byte drift.
+  its shared Flutter-free sources are the canonical Swift origins.
 - `packages/android/barnard/` is a Gradle library for Android API 24 and later.
   It exists so native Android apps can use typed Kotlin APIs without a Flutter
-  or React Native runtime; its mirrored Flutter-free sources are likewise
-  checked for drift.
+  or React Native runtime; its shared Flutter-free sources are the canonical
+  Kotlin origins.
 - `packages/dart/barnard/` is the Flutter/Dart SDK. It exists for Flutter apps
   that need the shared domain API, a hardware-free `MockBarnard` integration
-  path, or the platform BLE Transport.
+  path, or the platform BLE Transport. Its referencing Swift and Kotlin copies
+  are synchronized from the native origins and checked for byte-for-byte drift.
 - `packages/react-native/barnard/` is the React Native SDK. It exists for React
   Native apps that need a TypeScript API over native iOS and Android BLE
   implementations.
@@ -101,9 +102,10 @@ packages/
 - `tools/` currently contains `barnard-scan`, a small scanner utility. Keeping
   it outside `packages/` prevents a focused developer tool from becoming a
   required SDK dependency.
-- `scripts/` contains the Swift and Android mirror checks. They make the
-  deliberate shared-source relationship between native SDKs and the Flutter
-  plugin verifiable in CI.
+- `scripts/` contains the Swift and Android mirror checks and the native-to-Dart
+  sync helper. They make the deliberate shared-source relationship between
+  native SDK origins and the Flutter plugin's referencing copies verifiable in
+  CI.
 - `.github/` contains the Dart and native SDK workflows. It keeps package
   verification in the repository where changes are reviewed.
 - `.specify/` contains Spec Kit templates, helper scripts, and the project

--- a/packages/android/barnard/README.md
+++ b/packages/android/barnard/README.md
@@ -68,31 +68,32 @@ See `examples/android-native` for a runnable minimal app.
 
 ## Relationship to the Flutter plugin
 
-This package is currently a **mirror**, not a move, of
-`packages/dart/barnard/android`:
+This package is the **canonical origin** for the shared Kotlin sources also
+shipped inside `packages/dart/barnard/android`. The Flutter plugin keeps a
+referencing mirror copy because pub.dev packages must be self-contained:
 
 - `BarnardCrypto.kt`, `BarnardSigning.kt`, `BarnardV2Policy.kt`, and
-  `BarnardIso8601.kt` are byte-for-byte copies of the Flutter plugin's
-  Flutter-free sources (pure JVM, no Android-framework or Flutter-embedding
-  dependency). `scripts/check-android-mirror.sh` (repo root) fails CI if
-  they drift.
+  `BarnardIso8601.kt` are the native origins for byte-for-byte copies in the
+  Flutter plugin (pure JVM, no Android-framework or Flutter-embedding
+  dependency). `scripts/sync-mirrors.sh` regenerates the copies, and
+  `scripts/check-android-mirror.sh` fails CI if they drift.
 - `BarnardEngine.kt` (Flutter-free port of `BarnardController`) and
   `BarnardIdentity.kt` (Flutter-free port of `BarnardIdentityController`)
-  are new files, not mirrors — the originals are woven into Flutter's
-  method-channel API (`MethodChannel`, `EventChannel`,
+  are native-only files, not mirrored sources. Their Flutter counterparts are
+  woven into the method-channel API (`MethodChannel`, `EventChannel`,
   `PluginRegistry.RequestPermissionsResultListener`) and cannot be copied
-  verbatim. They re-implement the same behavior with a Kotlin-first public
-  API (typed sealed events/callbacks instead of a method-channel
+  verbatim. The native files expose the same behavior through a Kotlin-first
+  public API (typed sealed events/callbacks instead of a method-channel
   dispatcher).
 
-**Why mirror instead of making the Flutter plugin depend on this
+**Why keep a mirror copy instead of making the Flutter plugin depend on this
 package**: the Flutter plugin's Android module resolves its Flutter
 embedding classpath dynamically from the Flutter SDK
 (`packages/dart/barnard/android/build.gradle`); making it depend on a
 sibling standalone Gradle library is possible but nontrivial to wire up
 safely across Flutter's own Gradle plugin, and this repo's CI/tooling here
-has no Flutter toolchain to validate that path end-to-end. Mirroring the
-pure, dependency-free sources with a byte-identical sync check is
-lower-risk for this first slice. Follow-up: evaluate making
-`packages/dart/barnard/android` depend on this package directly (true
-move) once that path is validated against a real Flutter build.
+has no Flutter toolchain to validate that path end-to-end. Synchronizing the
+pure, dependency-free sources from this native origin into the Flutter
+package, with a byte-identical drift check, is lower-risk for this first slice.
+Follow-up: evaluate making `packages/dart/barnard/android` depend on this
+package directly once that path is validated against a real Flutter build.

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -118,7 +118,16 @@ public class BarnardEngine(private val appContext: Context) {
     // MARK: - Event Mode
 
     private var eventCode: String? = null
+    @Volatile
     private var currentTek: ByteArray = ByteArray(16)
+
+    private data class CachedReporterPayload(
+        val enin: UInt,
+        val tek: ByteArray,
+        val payload: ByteArray,
+    )
+
+    private var cachedReporterPayload: CachedReporterPayload? = null
 
     // MARK: - Discovery State
 
@@ -723,15 +732,25 @@ public class BarnardEngine(private val appContext: Context) {
     /**
      * Build the 17-byte RPID wire form at [nowMs], atomically deriving ENIN
      * and RPI from the same timestamp.
+     *
+     * A cache hit returns the same array instance; callers must not mutate it.
      */
+    @Synchronized
     private fun computePayload(nowMs: Long): ByteArray {
         val enin = currentEnin(nowMs)
-        val rpik = BarnardCrypto.deriveRpik(currentTek)
+        val tek = currentTek
+        val cached = cachedReporterPayload
+        if (cached != null && cached.enin == enin && cached.tek.contentEquals(tek)) {
+            return cached.payload
+        }
+
+        val rpik = BarnardCrypto.deriveRpik(tek)
         val rpi = BarnardCrypto.generateRpi(rpik, enin)
 
         val payload = ByteArray(17)
         payload[0] = (formatVersion and 0xFF).toByte()
         System.arraycopy(rpi, 0, payload, 1, 16)
+        cachedReporterPayload = CachedReporterPayload(enin, tek.copyOf(), payload)
         return payload
     }
 

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEnginePayloadCacheTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEnginePayloadCacheTest.kt
@@ -1,0 +1,88 @@
+// Use of this source code is governed by a BSD-style license.
+
+package org.levarac.barnard
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BarnardEnginePayloadCacheTest {
+    private lateinit var context: Context
+    private lateinit var computePayload: Method
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("barnard", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        computePayload = BarnardEngine::class.java
+            .getDeclaredMethod("computePayload", Long::class.javaPrimitiveType)
+            .apply { isAccessible = true }
+    }
+
+    @Test
+    fun computePayloadReusesExactByteArrayWithinSameEninAndTek() {
+        val engine = BarnardEngine(context)
+
+        val first = engine.computePayloadAt(1_000L)
+        val second = engine.computePayloadAt(2_000L)
+
+        assertSame(first, second)
+    }
+
+    @Test
+    fun computePayloadRecomputesAcrossEninBoundary() {
+        val engine = BarnardEngine(context)
+
+        val beforeBoundary = engine.computePayloadAt(299_999L)
+        val afterBoundary = engine.computePayloadAt(300_000L)
+
+        assertNotSame(beforeBoundary, afterBoundary)
+        assertFalse(beforeBoundary.contentEquals(afterBoundary))
+    }
+
+    @Test
+    fun computePayloadRecomputesWhenTekChangesAndReturnsAfterLeave() {
+        val engine = BarnardEngine(context)
+        val anonymous = engine.computePayloadAt(1_000L)
+
+        engine.joinEvent("payload-cache-test")
+        val joined = engine.computePayloadAt(1_000L)
+        engine.leaveEvent()
+        val left = engine.computePayloadAt(1_000L)
+
+        assertNotSame(anonymous, joined)
+        assertFalse(anonymous.contentEquals(joined))
+        assertNotSame(joined, left)
+        assertFalse(joined.contentEquals(left))
+        assertNotSame(anonymous, left)
+        assertTrue(anonymous.contentEquals(left))
+    }
+
+    @Test
+    fun computePayloadSerializesCacheAccessAcrossThreads() {
+        assertTrue(Modifier.isSynchronized(computePayload.modifiers))
+    }
+
+    @Test
+    fun currentTekPublishesChangesAcrossThreads() {
+        val field = BarnardEngine::class.java.getDeclaredField("currentTek")
+
+        assertTrue(Modifier.isVolatile(field.modifiers))
+    }
+
+    private fun BarnardEngine.computePayloadAt(nowMs: Long): ByteArray =
+        computePayload.invoke(this, nowMs) as ByteArray
+}

--- a/packages/dart/barnard/ios/barnard.podspec
+++ b/packages/dart/barnard/ios/barnard.podspec
@@ -11,7 +11,7 @@ Barnard BLE Transport for Flutter (GATT-first RPID).
                        DESC
   s.homepage         = 'https://github.com/levarac/barnard'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { 'Levarac' => 'https://github.com/levarac/barnard/issues' }
   s.source           = { :path => '.' }
   s.source_files = 'barnard/Sources/barnard/**/*'
   s.dependency 'Flutter'

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -62,6 +62,35 @@ public enum BarnardCoreKeyManager {
 }
 
 public enum BarnardCoreCrypto {
+  /// Calculates ENIN without trapping when an input cannot fit in `UInt32`.
+  ///
+  /// This is the boundary-safe counterpart to `calculateEnin`. It shares the
+  /// fixed-length clamps and beacon-chain normalization used by the core
+  /// calculation, so foreign-function callers do not need to duplicate them.
+  public static func calculateEninIfRepresentable(
+    unixSeconds: Int64,
+    mode: BarnardCoreEninMode = .fixedLength,
+    eninSeconds: Int64 = 300,
+    beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
+  ) -> UInt32? {
+    let window: Int64
+    switch mode {
+    case .fixedLength:
+      guard unixSeconds >= 0 else { return nil }
+      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
+      window = unixSeconds / effectiveSeconds
+    case .beaconSlot:
+      let (elapsed, overflow) = unixSeconds.subtractingReportingOverflow(
+        beaconChain.effectiveGenesisUnixSeconds
+      )
+      guard !overflow else { return 0 }
+      guard elapsed > 0 else { return 0 }
+      window = elapsed / beaconChain.effectiveSlotSeconds
+    }
+    guard window <= Int64(UInt32.max) else { return nil }
+    return UInt32(window)
+  }
+
   public static func deriveTekForEvent(
     deviceSecret: [UInt8],
     eventCode: String
@@ -111,17 +140,15 @@ public enum BarnardCoreCrypto {
     eninSeconds: Int64 = 300,
     beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
   ) -> UInt32 {
-    switch mode {
-    case .fixedLength:
-      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
-      return UInt32(unixSeconds / effectiveSeconds)
-    case .beaconSlot:
-      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
-      if elapsed <= 0 {
-        return 0
-      }
-      return UInt32(elapsed / beaconChain.effectiveSlotSeconds)
+    guard let result = calculateEninIfRepresentable(
+      unixSeconds: unixSeconds,
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    ) else {
+      preconditionFailure("ENIN input is outside the UInt32 representable domain")
     }
+    return result
   }
 
   public static func stableReadEnin(

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -174,4 +174,9 @@ public enum BarnardCoreCrypto {
   public static func sha256(_ bytes: [UInt8]) -> [UInt8] {
     BarnardCorePrimitives.sha256(bytes)
   }
+
+  /// Ethereum Keccak-256 (legacy Keccak padding, not NIST SHA3-256).
+  public static func keccak256(_ bytes: [UInt8]) -> [UInt8] {
+    BarnardCorePrimitives.keccak256(bytes)
+  }
 }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -12,11 +12,6 @@ public enum BarnardCoreWalletBindingVerification: Int32 {
   case smartWalletUnsupported = 2
 }
 
-public enum BarnardCoreAccountUnbindingSigner: Int32 {
-  case owner = 0
-  case wallet = 1
-}
-
 public enum BarnardCoreWalletVerifierVerdict: Equatable {
   case valid(verifiedAtUnixSeconds: Int64)
   case invalid(verifiedAtUnixSeconds: Int64)
@@ -308,13 +303,13 @@ public extension BarnardCoreSigning {
   }
 
   static func signAccountUnbinding(
-    signerPrivateKey: [UInt8],
+    ownerPrivateKey: [UInt8],
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8]
   ) -> BarnardCoreRecoverableSignature? {
     guard
-      isValidPrivateKey(signerPrivateKey),
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
       let message = buildAccountUnbindingMessage(
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
@@ -324,37 +319,31 @@ public extension BarnardCoreSigning {
       return nil
     }
     return signRecoverable(
-      privateKey: signerPrivateKey,
+      privateKey: ownerPrivateKey,
       messageHash32: BarnardCorePrimitives.sha256(message)
     )
   }
 
   static func verifyAccountUnbinding(
-    signer: BarnardCoreAccountUnbindingSigner,
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    switch signer {
-    case .owner:
-      guard
-        let message = buildAccountUnbindingMessage(
-          ownerPublicKey: ownerPublicKey,
-          walletAddress: walletAddress,
-          walletSignature: walletSignature
-        ),
-        let recoveredPublicKey = strictRecoveredPublicKey(
-          signature,
-          messageHash32: BarnardCorePrimitives.sha256(message)
-        )
-      else {
-        return false
-      }
-      return recoveredPublicKey == ownerPublicKey
-    case .wallet:
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
       return false
     }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
   }
 
   static func verifyAccountUnbinding(

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -70,6 +70,39 @@ public extension BarnardCoreSigning {
     ].joined(separator: "\n")
   }
 
+  static func buildAccountUnbindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to revoke this wallet's binding to a Levarac owner key.",
+      "",
+      "This signature REVOKES a wallet binding and authorizes no transaction.",
+      "",
+      "Domain-Tag: \(accountUnbindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
   static func buildSelfProofMessage(
     eventIdHash: [UInt8],
     eventSigningPublicKey: [UInt8],
@@ -303,27 +336,68 @@ public extension BarnardCoreSigning {
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    guard
-      let message = buildAccountUnbindingMessage(
-        ownerPublicKey: ownerPublicKey,
-        walletAddress: walletAddress,
-        walletSignature: walletSignature
-      ),
-      let recoveredPublicKey = strictRecoveredPublicKey(
-        signature,
-        messageHash32: BarnardCorePrimitives.sha256(message)
-      )
-    else {
-      return false
-    }
-
     switch signer {
     case .owner:
+      guard
+        let message = buildAccountUnbindingMessage(
+          ownerPublicKey: ownerPublicKey,
+          walletAddress: walletAddress,
+          walletSignature: walletSignature
+        ),
+        let recoveredPublicKey = strictRecoveredPublicKey(
+          signature,
+          messageHash32: BarnardCorePrimitives.sha256(message)
+        )
+      else {
+        return false
+      }
       return recoveredPublicKey == ownerPublicKey
     case .wallet:
-      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
-        == walletAddress
+      return false
     }
+  }
+
+  static func verifyAccountUnbinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountUnbindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress
+    else {
+      return .invalid
+    }
+    return .valid
   }
 
   static func classifyWalletSignature(
@@ -455,6 +529,83 @@ public extension BarnardCoreSigning {
     let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
 
     guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func isCanonicalAccountUnbindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 11,
+      lines[1].isEmpty,
+      lines[2]
+        == "This signature REVOKES a wallet binding and authorizes no transaction.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountUnbindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
+    else {
+      return false
+    }
+
+    let headerSuffix =
+      " wants to revoke this wallet's binding to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[9].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[9].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountUnbindingText(
       domain: domain,
       walletAddress: expectedWalletAddress,
       ownerPublicKey: expectedOwnerPublicKey,

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreOwnerKey.swift
@@ -1,0 +1,693 @@
+// Use of this source code is governed by a BSD-style license.
+
+public enum BarnardCoreWalletSignatureClassification: Int32 {
+  case invalid = 0
+  case validEoaShape = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreWalletBindingVerification: Int32 {
+  case invalid = 0
+  case valid = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreAccountUnbindingSigner: Int32 {
+  case owner = 0
+  case wallet = 1
+}
+
+public enum BarnardCoreWalletVerifierVerdict: Equatable {
+  case valid(verifiedAtUnixSeconds: Int64)
+  case invalid(verifiedAtUnixSeconds: Int64)
+  case unverified
+}
+
+/// Host-defined smart-wallet verification port.
+///
+/// Contract signature validity can change with contract state. Implementations
+/// therefore attach their observation time to every valid or invalid verdict.
+/// BarnardCore intentionally provides no RPC implementation.
+public protocol BarnardCoreWalletVerifier {
+  func verify(
+    address: [UInt8],
+    digest: [UInt8],
+    signature: [UInt8]
+  ) -> BarnardCoreWalletVerifierVerdict
+}
+
+public extension BarnardCoreSigning {
+  static func buildAccountBindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to bind this wallet to a Levarac owner key.",
+      "",
+      "This signature authorizes no transaction and moves no assets.",
+      "",
+      "Domain-Tag: \(accountBindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
+  static func buildSelfProofMessage(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      eventIdHash.count == 32,
+      isValidCompressedPublicKey(eventSigningPublicKey),
+      eninStart <= eninEnd,
+      isValidCompressedPublicKey(ownerPublicKey)
+    else {
+      return nil
+    }
+
+    return Array(selfProofDomainTag.utf8)
+      + eventIdHash
+      + eventSigningPublicKey
+      + uint64BigEndian(eninStart)
+      + uint64BigEndian(eninEnd)
+      + ownerPublicKey
+  }
+
+  static func signSelfProof(
+    ownerPrivateKey: [UInt8],
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifySelfProof(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildWalletAcknowledgementMessage(
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard walletAddress.count == 20, !walletSignature.isEmpty else {
+      return nil
+    }
+    return Array(walletAcknowledgementDomainTag.utf8)
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signWalletAcknowledgement(
+    ownerPrivateKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(ownerPrivateKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyWalletAcknowledgement(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildAccountRotationMessage(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(previousOwnerPublicKey),
+      isValidCompressedPublicKey(successorOwnerPublicKey),
+      previousOwnerPublicKey != successorOwnerPublicKey
+    else {
+      return nil
+    }
+    return Array(accountRotationDomainTag.utf8)
+      + previousOwnerPublicKey
+      + successorOwnerPublicKey
+  }
+
+  static func signAccountRotation(
+    previousOwnerPrivateKey: [UInt8],
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: previousOwnerPrivateKey) == previousOwnerPublicKey,
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: previousOwnerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountRotation(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: previousOwnerPublicKey
+    )
+  }
+
+  static func buildAccountUnbindingMessage(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      walletAddress.count == 20,
+      !walletSignature.isEmpty
+    else {
+      return nil
+    }
+    return Array(accountUnbindingDomainTag.utf8)
+      + ownerPublicKey
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signAccountUnbinding(
+    signerPrivateKey: [UInt8],
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(signerPrivateKey),
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: signerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountUnbinding(
+    signer: BarnardCoreAccountUnbindingSigner,
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      ),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        signature,
+        messageHash32: BarnardCorePrimitives.sha256(message)
+      )
+    else {
+      return false
+    }
+
+    switch signer {
+    case .owner:
+      return recoveredPublicKey == ownerPublicKey
+    case .wallet:
+      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == walletAddress
+    }
+  }
+
+  static func classifyWalletSignature(
+    _ signature: [UInt8]
+  ) -> BarnardCoreWalletSignatureClassification {
+    let erc6492Magic = Array(
+      repeating: [UInt8(0x64), UInt8(0x92)],
+      count: 16
+    )
+      .flatMap { $0 }
+    if signature.count >= erc6492Magic.count,
+      signature.suffix(erc6492Magic.count).elementsEqual(erc6492Magic)
+    {
+      return .smartWalletUnsupported
+    }
+    return signature.count == 65 ? .validEoaShape : .invalid
+  }
+
+  static func verifyWalletBinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8],
+    acknowledgement: BarnardCoreRecoverableSignature
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountBindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress,
+      verifyWalletAcknowledgement(
+        ownerPublicKey: expectedOwnerPublicKey,
+        walletAddress: expectedWalletAddress,
+        walletSignature: walletSignature,
+        signature: acknowledgement
+      )
+    else {
+      return .invalid
+    }
+    return .valid
+  }
+
+  private static func isCanonicalAccountBindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 11,
+      lines[1].isEmpty,
+      lines[2] == "This signature authorizes no transaction and moves no assets.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountBindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
+    else {
+      return false
+    }
+
+    let headerSuffix = " wants to bind this wallet to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[9].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[9].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func verifyNativeSignature(
+    _ signature: BarnardCoreRecoverableSignature,
+    message: [UInt8],
+    expectedPublicKey: [UInt8]
+  ) -> Bool {
+    strictRecoveredPublicKey(
+      signature,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    ) == expectedPublicKey
+  }
+
+  private static func strictRecoveredPublicKey(
+    _ signature: BarnardCoreRecoverableSignature,
+    messageHash32: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      signature.r.count == 32,
+      signature.s.count == 32,
+      messageHash32.count == 32,
+      signature.v == 0 || signature.v == 1
+    else {
+      return nil
+    }
+
+    let r = BarnardCoreSecp256k1.UInt256(bytes: signature.r)
+    let s = BarnardCoreSecp256k1.UInt256(bytes: signature.s)
+    guard
+      !r.isZero,
+      r < BarnardCoreSecp256k1.curveOrder,
+      !s.isZero,
+      s < BarnardCoreSecp256k1.curveOrder,
+      s <= BarnardCoreSecp256k1.curveOrder.shiftedRight1()
+    else {
+      return nil
+    }
+
+    return recoverPublicKey(
+      recoveryId: signature.v,
+      r: signature.r,
+      s: signature.s,
+      messageHash32: messageHash32
+    )
+  }
+
+  private static func normalizedEthereumRecoveryId(_ v: UInt8) -> Int? {
+    switch v {
+    case 0, 1:
+      return Int(v)
+    case 27, 28:
+      return Int(v - 27)
+    default:
+      return nil
+    }
+  }
+
+  private static func isValidPrivateKey(_ privateKey: [UInt8]) -> Bool {
+    guard privateKey.count == 32 else {
+      return false
+    }
+    let scalar = BarnardCoreSecp256k1.UInt256(bytes: privateKey)
+    return !scalar.isZero && scalar < BarnardCoreSecp256k1.curveOrder
+  }
+
+  private static func publicKey(forPrivateKey privateKey: [UInt8]) -> [UInt8]? {
+    guard isValidPrivateKey(privateKey) else {
+      return nil
+    }
+    let point = BarnardCoreSecp256k1.multiply(
+      BarnardCoreSecp256k1.UInt256(bytes: privateKey),
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSecp256k1.compress(point)
+  }
+
+  private static func isValidCompressedPublicKey(_ publicKey: [UInt8]) -> Bool {
+    serializeUncompressedPublicKey(publicKey) != nil
+  }
+
+  private static func uint64BigEndian(_ value: UInt64) -> [UInt8] {
+    stride(from: 56, through: 0, by: -8).map {
+      UInt8((value >> UInt64($0)) & 0xff)
+    }
+  }
+
+  private static func lowercaseHex(_ bytes: [UInt8]) -> String {
+    bytes.map {
+      let value = String($0, radix: 16)
+      return value.count == 1 ? "0" + value : value
+    }.joined()
+  }
+
+  private static func decodeLowercaseHex(_ value: String) -> [UInt8]? {
+    let bytes = Array(value.utf8)
+    guard bytes.count.isMultiple(of: 2) else {
+      return nil
+    }
+    var output: [UInt8] = []
+    output.reserveCapacity(bytes.count / 2)
+    for index in stride(from: 0, to: bytes.count, by: 2) {
+      func nibble(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 0x30...0x39:
+          return byte - 0x30
+        case 0x61...0x66:
+          return byte - 0x61 + 10
+        default:
+          return nil
+        }
+      }
+      guard let high = nibble(bytes[index]), let low = nibble(bytes[index + 1])
+      else {
+        return nil
+      }
+      output.append((high << 4) | low)
+    }
+    return output
+  }
+
+  private static func isCanonicalDomain(_ domain: String) -> Bool {
+    let bytes = Array(domain.utf8)
+    guard
+      !bytes.isEmpty,
+      isLowercaseAsciiLetterOrDigit(bytes[0])
+    else {
+      return false
+    }
+
+    var colonIndex: Int?
+    for (index, byte) in bytes.enumerated() {
+      if colonIndex != nil {
+        if !(0x30...0x39).contains(byte) {
+          return false
+        }
+        continue
+      }
+      switch byte {
+      case 0x61...0x7a, 0x30...0x39, 0x2d, 0x2e:
+        break
+      case 0x3a:
+        if index == 0 {
+          return false
+        }
+        colonIndex = index
+      default:
+        return false
+      }
+    }
+
+    let hostEnd = colonIndex ?? bytes.count
+    guard
+      hostEnd > 0,
+      isLowercaseAsciiLetterOrDigit(bytes[hostEnd - 1])
+    else {
+      return false
+    }
+    guard let colonIndex else {
+      return true
+    }
+
+    let portBytes = bytes.dropFirst(colonIndex + 1)
+    guard
+      !portBytes.isEmpty,
+      portBytes.count <= 5,
+      portBytes.allSatisfy({ (0x30...0x39).contains($0) }),
+      (portBytes.count == 1 || portBytes.first != 0x30),
+      let port = UInt32(String(decoding: portBytes, as: UTF8.self)),
+      port <= 65_535
+    else {
+      return false
+    }
+    return true
+  }
+
+  private static func isLowercaseAsciiLetterOrDigit(_ byte: UInt8) -> Bool {
+    (0x61...0x7a).contains(byte) || (0x30...0x39).contains(byte)
+  }
+
+  private static func isCanonicalIssuedAt(_ value: String) -> Bool {
+    let bytes = Array(value.utf8)
+    guard
+      bytes.count == 20,
+      bytes[4] == 0x2d,
+      bytes[7] == 0x2d,
+      bytes[10] == 0x54,
+      bytes[13] == 0x3a,
+      bytes[16] == 0x3a,
+      bytes[19] == 0x5a
+    else {
+      return false
+    }
+    let digitPositions = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18]
+    guard digitPositions.allSatisfy({
+      (0x30...0x39).contains(bytes[$0])
+    }) else {
+      return false
+    }
+
+    func decimal(_ first: Int, _ second: Int) -> Int {
+      Int(bytes[first] - 0x30) * 10 + Int(bytes[second] - 0x30)
+    }
+    let year = decimal(0, 1) * 100 + decimal(2, 3)
+    let month = decimal(5, 6)
+    let day = decimal(8, 9)
+    let hour = decimal(11, 12)
+    let minute = decimal(14, 15)
+    let second = decimal(17, 18)
+    guard
+      (1...12).contains(month),
+      (0...23).contains(hour),
+      (0...59).contains(minute),
+      (0...59).contains(second)
+    else {
+      return false
+    }
+
+    var daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    let isLeapYear = year.isMultiple(of: 4)
+      && (!year.isMultiple(of: 100) || year.isMultiple(of: 400))
+    if isLeapYear {
+      daysInMonth[1] = 29
+    }
+    return (1...daysInMonth[month - 1]).contains(day)
+  }
+}

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCorePrimitives.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCorePrimitives.swift
@@ -1,6 +1,43 @@
 // Use of this source code is governed by a BSD-style license.
 
 enum BarnardCorePrimitives {
+  static func keccak256(_ input: [UInt8]) -> [UInt8] {
+    let rate = 136
+    var state = [UInt64](repeating: 0, count: 25)
+    var offset = 0
+
+    while input.count - offset >= rate {
+      absorbKeccakBlock(
+        Array(input[offset..<(offset + rate)]),
+        into: &state
+      )
+      keccakF1600(&state)
+      offset += rate
+    }
+
+    var finalBlock = [UInt8](repeating: 0, count: rate)
+    let remaining = input.count - offset
+    if remaining > 0 {
+      for index in 0..<remaining {
+        finalBlock[index] = input[offset + index]
+      }
+    }
+    finalBlock[remaining] ^= 0x01
+    finalBlock[rate - 1] ^= 0x80
+    absorbKeccakBlock(finalBlock, into: &state)
+    keccakF1600(&state)
+
+    var output: [UInt8] = []
+    output.reserveCapacity(32)
+    for byteIndex in 0..<32 {
+      let lane = state[byteIndex / 8]
+      output.append(
+        UInt8((lane >> UInt64(8 * (byteIndex % 8))) & 0xff)
+      )
+    }
+    return output
+  }
+
   static func sha256(_ input: [UInt8]) -> [UInt8] {
     let constants: [UInt32] = [
       0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
@@ -155,6 +192,88 @@ enum BarnardCorePrimitives {
 
   private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {
     (value >> count) | (value << (32 - count))
+  }
+
+  private static func absorbKeccakBlock(
+    _ block: [UInt8],
+    into state: inout [UInt64]
+  ) {
+    for index in block.indices {
+      state[index / 8] ^=
+        UInt64(block[index]) << UInt64(8 * (index % 8))
+    }
+  }
+
+  private static func keccakF1600(_ state: inout [UInt64]) {
+    let roundConstants: [UInt64] = [
+      0x0000000000000001, 0x0000000000008082,
+      0x800000000000808a, 0x8000000080008000,
+      0x000000000000808b, 0x0000000080000001,
+      0x8000000080008081, 0x8000000000008009,
+      0x000000000000008a, 0x0000000000000088,
+      0x0000000080008009, 0x000000008000000a,
+      0x000000008000808b, 0x800000000000008b,
+      0x8000000000008089, 0x8000000000008003,
+      0x8000000000008002, 0x8000000000000080,
+      0x000000000000800a, 0x800000008000000a,
+      0x8000000080008081, 0x8000000000008080,
+      0x0000000080000001, 0x8000000080008008,
+    ]
+    let rotationOffsets: [Int] = [
+      0, 1, 62, 28, 27,
+      36, 44, 6, 55, 20,
+      3, 10, 43, 25, 39,
+      41, 45, 15, 21, 8,
+      18, 2, 61, 56, 14,
+    ]
+
+    for roundConstant in roundConstants {
+      var columns = [UInt64](repeating: 0, count: 5)
+      for x in 0..<5 {
+        columns[x] =
+          state[x]
+          ^ state[x + 5]
+          ^ state[x + 10]
+          ^ state[x + 15]
+          ^ state[x + 20]
+      }
+      for x in 0..<5 {
+        let delta =
+          columns[(x + 4) % 5]
+          ^ rotateLeft(columns[(x + 1) % 5], by: 1)
+        for y in 0..<5 {
+          state[x + 5 * y] ^= delta
+        }
+      }
+
+      var permuted = [UInt64](repeating: 0, count: 25)
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let source = x + 5 * y
+          let destination = y + 5 * ((2 * x + 3 * y) % 5)
+          permuted[destination] = rotateLeft(
+            state[source],
+            by: rotationOffsets[source]
+          )
+        }
+      }
+
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let row = 5 * y
+          state[x + row] =
+            permuted[x + row]
+            ^ ((~permuted[(x + 1) % 5 + row])
+              & permuted[(x + 2) % 5 + row])
+        }
+      }
+      state[0] ^= roundConstant
+    }
+  }
+
+  private static func rotateLeft(_ value: UInt64, by count: Int) -> UInt64 {
+    guard count != 0 else { return value }
+    return (value << UInt64(count)) | (value >> UInt64(64 - count))
   }
 
   private static let aesSBox: [UInt8] = [

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreSigning.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreSigning.swift
@@ -3,12 +3,23 @@
 public struct BarnardCoreSigningKeyPair {
   public let privateKey: [UInt8]
   public let publicKeyCompressed: [UInt8]
+
+  public init(privateKey: [UInt8], publicKeyCompressed: [UInt8]) {
+    self.privateKey = privateKey
+    self.publicKeyCompressed = publicKeyCompressed
+  }
 }
 
 public struct BarnardCoreRecoverableSignature {
   public let r: [UInt8]
   public let s: [UInt8]
   public let v: Int
+
+  public init(r: [UInt8], s: [UInt8], v: Int) {
+    self.r = r
+    self.s = s
+    self.v = v
+  }
 }
 
 public struct BarnardCoreRpidOwnershipProof {
@@ -21,8 +32,14 @@ public struct BarnardCoreRpidOwnershipProof {
 
 public enum BarnardCoreSigning {
   public static let signingKeyInfo = "barnard-sign"
+  public static let ownerKeyInfo = "barnard-owner"
   public static let rpidProofDomainTag = "barnard-rpid-proof:v1"
   public static let keyBindingDomainTag = "barnard-key-binding:v1"
+  public static let selfProofDomainTag = "barnard-self-proof:v1"
+  public static let walletAcknowledgementDomainTag = "barnard-wallet-ack:v1"
+  public static let accountRotationDomainTag = "barnard-account-rotation:v1"
+  public static let accountUnbindingDomainTag = "barnard-account-unbinding:v1"
+  public static let accountBindingDomainTag = "barnard-account-binding:v1"
 
   public static func deriveSigningKeyPair(
     deviceSecret: [UInt8],
@@ -52,6 +69,86 @@ public enum BarnardCoreSigning {
       privateKey: privateKey.bytes,
       publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
     )
+  }
+
+  public static func deriveOwnerKeyPair(
+    accountSecret: [UInt8]
+  ) -> BarnardCoreSigningKeyPair {
+    precondition(accountSecret.count == 32, "accountSecret must be 32 bytes")
+    var seed = BarnardCorePrimitives.hkdfSha256(
+      inputKeyMaterial: accountSecret,
+      info: Array(ownerKeyInfo.utf8),
+      outputByteCount: 32
+    )
+    var privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+      BarnardCoreSecp256k1.UInt256(bytes: seed),
+      BarnardCoreSecp256k1.curveOrder
+    )
+    while privateKey.isZero {
+      seed = BarnardCorePrimitives.sha256(seed)
+      privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+        BarnardCoreSecp256k1.UInt256(bytes: seed),
+        BarnardCoreSecp256k1.curveOrder
+      )
+    }
+    let publicPoint = BarnardCoreSecp256k1.multiply(
+      privateKey,
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSigningKeyPair(
+      privateKey: privateKey.bytes,
+      publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
+    )
+  }
+
+  public static func serializeUncompressedPublicKey(
+    _ compressedPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      compressedPublicKey.count == 33,
+      compressedPublicKey[0] == 0x02 || compressedPublicKey[0] == 0x03
+    else {
+      return nil
+    }
+    let x = BarnardCoreSecp256k1.UInt256(
+      bytes: Array(compressedPublicKey.dropFirst())
+    )
+    guard
+      x < BarnardCoreSecp256k1.fieldPrime,
+      let point = BarnardCoreSecp256k1.decompress(
+        x: x,
+        yIsOdd: compressedPublicKey[0] == 0x03
+      )
+    else {
+      return nil
+    }
+    return BarnardCoreSecp256k1.serializeUncompressed(point)
+  }
+
+  public static func ethereumAddress(
+    publicKeyCompressed: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      let uncompressed = serializeUncompressedPublicKey(publicKeyCompressed),
+      uncompressed.count == 65
+    else {
+      return nil
+    }
+    return Array(
+      BarnardCorePrimitives.keccak256(Array(uncompressed.dropFirst())).suffix(20)
+    )
+  }
+
+  public static func computeEip191Digest(text: String) -> [UInt8] {
+    computeEip191Digest(messageBytes: Array(text.utf8))
+  }
+
+  public static func computeEip191Digest(messageBytes: [UInt8]) -> [UInt8] {
+    let prefix =
+      [UInt8(0x19)]
+      + Array("Ethereum Signed Message:\n".utf8)
+      + Array(String(messageBytes.count).utf8)
+    return BarnardCorePrimitives.keccak256(prefix + messageBytes)
   }
 
   public static func signRecoverable(

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/Secp256k1.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/Secp256k1.swift
@@ -300,6 +300,13 @@ enum BarnardCoreSecp256k1 {
     return [y.testBit(0) ? 0x03 : 0x02] + x.bytes
   }
 
+  static func serializeUncompressed(_ point: Point) -> [UInt8] {
+    guard let x = point.x, let y = point.y else {
+      return []
+    }
+    return [0x04] + x.bytes + y.bytes
+  }
+
   static func decompress(x: UInt256, yIsOdd: Bool) -> Point? {
     let xCubed = Field.multiplyMod(
       Field.multiplyMod(x, x, fieldPrime),

--- a/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
+++ b/packages/swift/barnard/CHostProof/barnard_core_c_host_proof.c
@@ -29,6 +29,9 @@ typedef int32_t (*display_id4_fn)(const uint8_t *, uint8_t *);
 typedef int32_t (*sha256_fn)(const uint8_t *, int32_t, uint8_t *);
 typedef int32_t (*derive_signing_keypair_fn)(
     const uint8_t *, int32_t, const uint8_t *, int32_t, uint8_t *, uint8_t *);
+typedef int32_t (*derive_owner_keypair_fn)(const uint8_t *, uint8_t *, uint8_t *);
+typedef int32_t (*keccak256_fn)(const uint8_t *, int32_t, uint8_t *);
+typedef int32_t (*eip191_digest_fn)(const uint8_t *, int32_t, uint8_t *);
 typedef int32_t (*sign_recoverable_fn)(
     const uint8_t *, const uint8_t *, uint8_t *, uint8_t *, int32_t *);
 typedef uint8_t (*should_emit_rssi_update_fn)(uint32_t, uint32_t);
@@ -106,6 +109,11 @@ int main(int argc, char **argv) {
   sha256_fn sha256 = (sha256_fn)must_sym(handle, "barnard_core_sha256");
   derive_signing_keypair_fn derive_signing_keypair =
       (derive_signing_keypair_fn)must_sym(handle, "barnard_core_derive_signing_keypair");
+  derive_owner_keypair_fn derive_owner_keypair =
+      (derive_owner_keypair_fn)must_sym(handle, "barnard_core_derive_owner_keypair");
+  keccak256_fn keccak256 = (keccak256_fn)must_sym(handle, "barnard_core_keccak256");
+  eip191_digest_fn eip191_digest =
+      (eip191_digest_fn)must_sym(handle, "barnard_core_eip191_digest");
   sign_recoverable_fn sign_recoverable =
       (sign_recoverable_fn)must_sym(handle, "barnard_core_sign_recoverable");
   should_emit_rssi_update_fn should_emit_rssi_update =
@@ -181,6 +189,29 @@ int main(int argc, char **argv) {
   expect_hex("signing_s", s, 32,
              "51760b12ac9be31472f61ca68574e7d1c950ca68504d7dd37bff1bba97e3e7d8");
   expect_i32("signing_v", v, 0);
+
+  uint8_t account_secret[32] = {0};
+  uint8_t owner_private_key[32], owner_public_key[33], digest[32];
+  if (derive_owner_keypair(account_secret, owner_private_key, owner_public_key) != 0) {
+    fprintf(stderr, "owner-key vector call returned an error\n");
+    return 2;
+  }
+  if (keccak256((const uint8_t *)"abc", 3, digest) != 0) {
+    fprintf(stderr, "Keccak-256 vector call returned an error\n");
+    return 2;
+  }
+  expect_hex("owner_private_key", owner_private_key, 32,
+             "46cbfd04992339fab4937354a6f24c115a238f4bd133a8c43b18162ab986bf27");
+  expect_hex("owner_public_key", owner_public_key, 33,
+             "03351e5165d083f53425fc4a51e7228d53e88eb2899bcb6a83368a8aafaa1de5f4");
+  expect_hex("keccak256", digest, 32,
+             "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45");
+  if (eip191_digest((const uint8_t *)"Hello World", 11, digest) != 0) {
+    fprintf(stderr, "EIP-191 vector call returned an error\n");
+    return 2;
+  }
+  expect_hex("eip191_digest", digest, 32,
+             "a1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2");
 
   stable = 0;
   expect_i32("stable_enin_status", stable_read_enin(899, 899, 0, 300, 0, 0, &stable), 1);

--- a/packages/swift/barnard/Package.swift
+++ b/packages/swift/barnard/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BarnardCoreCTests",
-            dependencies: ["BarnardCoreC"]
+            dependencies: ["BarnardCore", "BarnardCoreC"]
         )
     ]
 )

--- a/packages/swift/barnard/README.md
+++ b/packages/swift/barnard/README.md
@@ -47,33 +47,34 @@ See `examples/ios-native` for a runnable minimal app.
 
 ## Relationship to the Flutter plugin
 
-This package is currently a **mirror**, not a move, of
-`packages/dart/barnard/ios/barnard`:
+This package is the **canonical origin** for the shared Swift sources also
+shipped inside `packages/dart/barnard/ios/barnard`. The Flutter plugin keeps a
+referencing mirror copy because pub.dev packages must be self-contained:
 
 - The platform adapters (`BarnardCrypto.swift`, `Secp256k1.swift`,
   `BarnardSigning.swift`, `BarnardRpidGenerator.swift`,
   `BarnardV2Policy.swift`, `BarnardPlatformDependencies.swift`, and
-  `PrivacyInfo.xcprivacy`) are byte-for-byte copies of the Flutter plugin's
-  Flutter-free sources.
-- Every source under `Sources/BarnardCore` is also a byte-for-byte copy of the
-  corresponding Flutter plugin source under `Sources/barnard/BarnardCore`.
-  `scripts/check-swift-mirror.sh` (repo root) checks both groups and fails CI
-  if they drift.
+  `PrivacyInfo.xcprivacy`) are the native origins for byte-for-byte copies in
+  the Flutter plugin.
+- Every source under `Sources/BarnardCore` is likewise the native origin for
+  the corresponding Flutter plugin copy under `Sources/barnard/BarnardCore`.
+  `scripts/sync-mirrors.sh` regenerates both groups, and
+  `scripts/check-swift-mirror.sh` fails CI if they drift.
 - `BarnardEngine.swift` (Flutter-free port of `BarnardBleController`) and
   `BarnardIdentity.swift` (Flutter-free port of `BarnardIdentityController`)
-  are new files, not mirrors — the originals are woven into Flutter's
-  method-channel API (`FlutterEventSink`, `FlutterMethodCall`) and cannot be
-  copied verbatim. They re-implement the same behavior with a Swift-first
-  public API (closures/return values instead of a method-channel
-  dispatcher).
+  are native-only files, not mirrored sources. Their Flutter counterparts are
+  woven into the method-channel API (`FlutterEventSink`, `FlutterMethodCall`)
+  and cannot be copied verbatim. The native files expose the same behavior
+  through a Swift-first public API (closures/return values instead of a
+  method-channel dispatcher).
 
-**Why mirror instead of making the Flutter plugin depend on this package**:
-the Flutter plugin ships via a CocoaPods podspec
+**Why keep a mirror copy instead of making the Flutter plugin depend on this
+package**: the Flutter plugin ships via a CocoaPods podspec
 (`packages/dart/barnard/ios/barnard.podspec`); making a CocoaPods pod depend
 on a sibling local SwiftPM package is possible but nontrivial to wire up
 safely, and this repo's CI/tooling here has no Flutter/CocoaPods toolchain
-to validate that path end-to-end. Mirroring the pure, dependency-free
-sources with a byte-identical sync check is lower-risk for this first
-slice. Follow-up: evaluate making `packages/dart/barnard/ios` depend on
-this package directly (true move) once that path is validated against a
-real Flutter build.
+to validate that path end-to-end. Synchronizing the pure, dependency-free
+sources from this native origin into the Flutter package, with a byte-identical
+drift check, is lower-risk for this first slice. Follow-up: evaluate making
+`packages/dart/barnard/ios` depend on this package directly once that path is
+validated against a real Flutter build.

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -62,6 +62,35 @@ public enum BarnardCoreKeyManager {
 }
 
 public enum BarnardCoreCrypto {
+  /// Calculates ENIN without trapping when an input cannot fit in `UInt32`.
+  ///
+  /// This is the boundary-safe counterpart to `calculateEnin`. It shares the
+  /// fixed-length clamps and beacon-chain normalization used by the core
+  /// calculation, so foreign-function callers do not need to duplicate them.
+  public static func calculateEninIfRepresentable(
+    unixSeconds: Int64,
+    mode: BarnardCoreEninMode = .fixedLength,
+    eninSeconds: Int64 = 300,
+    beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
+  ) -> UInt32? {
+    let window: Int64
+    switch mode {
+    case .fixedLength:
+      guard unixSeconds >= 0 else { return nil }
+      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
+      window = unixSeconds / effectiveSeconds
+    case .beaconSlot:
+      let (elapsed, overflow) = unixSeconds.subtractingReportingOverflow(
+        beaconChain.effectiveGenesisUnixSeconds
+      )
+      guard !overflow else { return 0 }
+      guard elapsed > 0 else { return 0 }
+      window = elapsed / beaconChain.effectiveSlotSeconds
+    }
+    guard window <= Int64(UInt32.max) else { return nil }
+    return UInt32(window)
+  }
+
   public static func deriveTekForEvent(
     deviceSecret: [UInt8],
     eventCode: String
@@ -111,17 +140,15 @@ public enum BarnardCoreCrypto {
     eninSeconds: Int64 = 300,
     beaconChain: BarnardCoreBeaconChain = .ethereumMainnet
   ) -> UInt32 {
-    switch mode {
-    case .fixedLength:
-      let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
-      return UInt32(unixSeconds / effectiveSeconds)
-    case .beaconSlot:
-      let elapsed = unixSeconds - beaconChain.effectiveGenesisUnixSeconds
-      if elapsed <= 0 {
-        return 0
-      }
-      return UInt32(elapsed / beaconChain.effectiveSlotSeconds)
+    guard let result = calculateEninIfRepresentable(
+      unixSeconds: unixSeconds,
+      mode: mode,
+      eninSeconds: eninSeconds,
+      beaconChain: beaconChain
+    ) else {
+      preconditionFailure("ENIN input is outside the UInt32 representable domain")
     }
+    return result
   }
 
   public static func stableReadEnin(

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -174,4 +174,9 @@ public enum BarnardCoreCrypto {
   public static func sha256(_ bytes: [UInt8]) -> [UInt8] {
     BarnardCorePrimitives.sha256(bytes)
   }
+
+  /// Ethereum Keccak-256 (legacy Keccak padding, not NIST SHA3-256).
+  public static func keccak256(_ bytes: [UInt8]) -> [UInt8] {
+    BarnardCorePrimitives.keccak256(bytes)
+  }
 }

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -12,11 +12,6 @@ public enum BarnardCoreWalletBindingVerification: Int32 {
   case smartWalletUnsupported = 2
 }
 
-public enum BarnardCoreAccountUnbindingSigner: Int32 {
-  case owner = 0
-  case wallet = 1
-}
-
 public enum BarnardCoreWalletVerifierVerdict: Equatable {
   case valid(verifiedAtUnixSeconds: Int64)
   case invalid(verifiedAtUnixSeconds: Int64)
@@ -308,13 +303,13 @@ public extension BarnardCoreSigning {
   }
 
   static func signAccountUnbinding(
-    signerPrivateKey: [UInt8],
+    ownerPrivateKey: [UInt8],
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8]
   ) -> BarnardCoreRecoverableSignature? {
     guard
-      isValidPrivateKey(signerPrivateKey),
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
       let message = buildAccountUnbindingMessage(
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
@@ -324,37 +319,31 @@ public extension BarnardCoreSigning {
       return nil
     }
     return signRecoverable(
-      privateKey: signerPrivateKey,
+      privateKey: ownerPrivateKey,
       messageHash32: BarnardCorePrimitives.sha256(message)
     )
   }
 
   static func verifyAccountUnbinding(
-    signer: BarnardCoreAccountUnbindingSigner,
     ownerPublicKey: [UInt8],
     walletAddress: [UInt8],
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    switch signer {
-    case .owner:
-      guard
-        let message = buildAccountUnbindingMessage(
-          ownerPublicKey: ownerPublicKey,
-          walletAddress: walletAddress,
-          walletSignature: walletSignature
-        ),
-        let recoveredPublicKey = strictRecoveredPublicKey(
-          signature,
-          messageHash32: BarnardCorePrimitives.sha256(message)
-        )
-      else {
-        return false
-      }
-      return recoveredPublicKey == ownerPublicKey
-    case .wallet:
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
       return false
     }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
   }
 
   static func verifyAccountUnbinding(

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -70,6 +70,39 @@ public extension BarnardCoreSigning {
     ].joined(separator: "\n")
   }
 
+  static func buildAccountUnbindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to revoke this wallet's binding to a Levarac owner key.",
+      "",
+      "This signature REVOKES a wallet binding and authorizes no transaction.",
+      "",
+      "Domain-Tag: \(accountUnbindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
   static func buildSelfProofMessage(
     eventIdHash: [UInt8],
     eventSigningPublicKey: [UInt8],
@@ -303,27 +336,68 @@ public extension BarnardCoreSigning {
     walletSignature: [UInt8],
     signature: BarnardCoreRecoverableSignature
   ) -> Bool {
-    guard
-      let message = buildAccountUnbindingMessage(
-        ownerPublicKey: ownerPublicKey,
-        walletAddress: walletAddress,
-        walletSignature: walletSignature
-      ),
-      let recoveredPublicKey = strictRecoveredPublicKey(
-        signature,
-        messageHash32: BarnardCorePrimitives.sha256(message)
-      )
-    else {
-      return false
-    }
-
     switch signer {
     case .owner:
+      guard
+        let message = buildAccountUnbindingMessage(
+          ownerPublicKey: ownerPublicKey,
+          walletAddress: walletAddress,
+          walletSignature: walletSignature
+        ),
+        let recoveredPublicKey = strictRecoveredPublicKey(
+          signature,
+          messageHash32: BarnardCorePrimitives.sha256(message)
+        )
+      else {
+        return false
+      }
       return recoveredPublicKey == ownerPublicKey
     case .wallet:
-      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
-        == walletAddress
+      return false
     }
+  }
+
+  static func verifyAccountUnbinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountUnbindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress
+    else {
+      return .invalid
+    }
+    return .valid
   }
 
   static func classifyWalletSignature(
@@ -455,6 +529,83 @@ public extension BarnardCoreSigning {
     let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
 
     guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func isCanonicalAccountUnbindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 11,
+      lines[1].isEmpty,
+      lines[2]
+        == "This signature REVOKES a wallet binding and authorizes no transaction.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountUnbindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
+    else {
+      return false
+    }
+
+    let headerSuffix =
+      " wants to revoke this wallet's binding to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[9].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[9].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountUnbindingText(
       domain: domain,
       walletAddress: expectedWalletAddress,
       ownerPublicKey: expectedOwnerPublicKey,

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreOwnerKey.swift
@@ -1,0 +1,693 @@
+// Use of this source code is governed by a BSD-style license.
+
+public enum BarnardCoreWalletSignatureClassification: Int32 {
+  case invalid = 0
+  case validEoaShape = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreWalletBindingVerification: Int32 {
+  case invalid = 0
+  case valid = 1
+  case smartWalletUnsupported = 2
+}
+
+public enum BarnardCoreAccountUnbindingSigner: Int32 {
+  case owner = 0
+  case wallet = 1
+}
+
+public enum BarnardCoreWalletVerifierVerdict: Equatable {
+  case valid(verifiedAtUnixSeconds: Int64)
+  case invalid(verifiedAtUnixSeconds: Int64)
+  case unverified
+}
+
+/// Host-defined smart-wallet verification port.
+///
+/// Contract signature validity can change with contract state. Implementations
+/// therefore attach their observation time to every valid or invalid verdict.
+/// BarnardCore intentionally provides no RPC implementation.
+public protocol BarnardCoreWalletVerifier {
+  func verify(
+    address: [UInt8],
+    digest: [UInt8],
+    signature: [UInt8]
+  ) -> BarnardCoreWalletVerifierVerdict
+}
+
+public extension BarnardCoreSigning {
+  static func buildAccountBindingText(
+    domain: String,
+    walletAddress: [UInt8],
+    ownerPublicKey: [UInt8],
+    chainId: UInt64,
+    nonce: [UInt8],
+    issuedAt: String
+  ) -> String? {
+    guard
+      isCanonicalDomain(domain),
+      walletAddress.count == 20,
+      isValidCompressedPublicKey(ownerPublicKey),
+      nonce.count == 16,
+      isCanonicalIssuedAt(issuedAt)
+    else {
+      return nil
+    }
+
+    return [
+      "\(domain) wants to bind this wallet to a Levarac owner key.",
+      "",
+      "This signature authorizes no transaction and moves no assets.",
+      "",
+      "Domain-Tag: \(accountBindingDomainTag)",
+      "Wallet: 0x\(lowercaseHex(walletAddress))",
+      "Owner-Key: 0x\(lowercaseHex(ownerPublicKey))",
+      "Chain-ID: eip155:\(chainId)",
+      "Scope: global",
+      "Nonce: 0x\(lowercaseHex(nonce))",
+      "Issued-At: \(issuedAt)",
+    ].joined(separator: "\n")
+  }
+
+  static func buildSelfProofMessage(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      eventIdHash.count == 32,
+      isValidCompressedPublicKey(eventSigningPublicKey),
+      eninStart <= eninEnd,
+      isValidCompressedPublicKey(ownerPublicKey)
+    else {
+      return nil
+    }
+
+    return Array(selfProofDomainTag.utf8)
+      + eventIdHash
+      + eventSigningPublicKey
+      + uint64BigEndian(eninStart)
+      + uint64BigEndian(eninEnd)
+      + ownerPublicKey
+  }
+
+  static func signSelfProof(
+    ownerPrivateKey: [UInt8],
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: ownerPrivateKey) == ownerPublicKey,
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifySelfProof(
+    eventIdHash: [UInt8],
+    eventSigningPublicKey: [UInt8],
+    eninStart: UInt64,
+    eninEnd: UInt64,
+    ownerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildSelfProofMessage(
+        eventIdHash: eventIdHash,
+        eventSigningPublicKey: eventSigningPublicKey,
+        eninStart: eninStart,
+        eninEnd: eninEnd,
+        ownerPublicKey: ownerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildWalletAcknowledgementMessage(
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard walletAddress.count == 20, !walletSignature.isEmpty else {
+      return nil
+    }
+    return Array(walletAcknowledgementDomainTag.utf8)
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signWalletAcknowledgement(
+    ownerPrivateKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(ownerPrivateKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: ownerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyWalletAcknowledgement(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      let message = buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: ownerPublicKey
+    )
+  }
+
+  static func buildAccountRotationMessage(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(previousOwnerPublicKey),
+      isValidCompressedPublicKey(successorOwnerPublicKey),
+      previousOwnerPublicKey != successorOwnerPublicKey
+    else {
+      return nil
+    }
+    return Array(accountRotationDomainTag.utf8)
+      + previousOwnerPublicKey
+      + successorOwnerPublicKey
+  }
+
+  static func signAccountRotation(
+    previousOwnerPrivateKey: [UInt8],
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      publicKey(forPrivateKey: previousOwnerPrivateKey) == previousOwnerPublicKey,
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: previousOwnerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountRotation(
+    previousOwnerPublicKey: [UInt8],
+    successorOwnerPublicKey: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountRotationMessage(
+        previousOwnerPublicKey: previousOwnerPublicKey,
+        successorOwnerPublicKey: successorOwnerPublicKey
+      )
+    else {
+      return false
+    }
+    return verifyNativeSignature(
+      signature,
+      message: message,
+      expectedPublicKey: previousOwnerPublicKey
+    )
+  }
+
+  static func buildAccountUnbindingMessage(
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      isValidCompressedPublicKey(ownerPublicKey),
+      walletAddress.count == 20,
+      !walletSignature.isEmpty
+    else {
+      return nil
+    }
+    return Array(accountUnbindingDomainTag.utf8)
+      + ownerPublicKey
+      + walletAddress
+      + BarnardCorePrimitives.sha256(walletSignature)
+  }
+
+  static func signAccountUnbinding(
+    signerPrivateKey: [UInt8],
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8]
+  ) -> BarnardCoreRecoverableSignature? {
+    guard
+      isValidPrivateKey(signerPrivateKey),
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    else {
+      return nil
+    }
+    return signRecoverable(
+      privateKey: signerPrivateKey,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    )
+  }
+
+  static func verifyAccountUnbinding(
+    signer: BarnardCoreAccountUnbindingSigner,
+    ownerPublicKey: [UInt8],
+    walletAddress: [UInt8],
+    walletSignature: [UInt8],
+    signature: BarnardCoreRecoverableSignature
+  ) -> Bool {
+    guard
+      let message = buildAccountUnbindingMessage(
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      ),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        signature,
+        messageHash32: BarnardCorePrimitives.sha256(message)
+      )
+    else {
+      return false
+    }
+
+    switch signer {
+    case .owner:
+      return recoveredPublicKey == ownerPublicKey
+    case .wallet:
+      return ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == walletAddress
+    }
+  }
+
+  static func classifyWalletSignature(
+    _ signature: [UInt8]
+  ) -> BarnardCoreWalletSignatureClassification {
+    let erc6492Magic = Array(
+      repeating: [UInt8(0x64), UInt8(0x92)],
+      count: 16
+    )
+      .flatMap { $0 }
+    if signature.count >= erc6492Magic.count,
+      signature.suffix(erc6492Magic.count).elementsEqual(erc6492Magic)
+    {
+      return .smartWalletUnsupported
+    }
+    return signature.count == 65 ? .validEoaShape : .invalid
+  }
+
+  static func verifyWalletBinding(
+    text: String,
+    walletSignature: [UInt8],
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8],
+    acknowledgement: BarnardCoreRecoverableSignature
+  ) -> BarnardCoreWalletBindingVerification {
+    guard
+      expectedWalletAddress.count == 20,
+      isValidCompressedPublicKey(expectedOwnerPublicKey),
+      isCanonicalAccountBindingText(
+        text,
+        expectedWalletAddress: expectedWalletAddress,
+        expectedOwnerPublicKey: expectedOwnerPublicKey
+      )
+    else {
+      return .invalid
+    }
+    switch classifyWalletSignature(walletSignature) {
+    case .invalid:
+      return .invalid
+    case .smartWalletUnsupported:
+      return .smartWalletUnsupported
+    case .validEoaShape:
+      break
+    }
+    guard
+      let recoveryId = normalizedEthereumRecoveryId(walletSignature[64]),
+      let recoveredPublicKey = strictRecoveredPublicKey(
+        BarnardCoreRecoverableSignature(
+          r: Array(walletSignature[0..<32]),
+          s: Array(walletSignature[32..<64]),
+          v: recoveryId
+        ),
+        messageHash32: computeEip191Digest(text: text)
+      ),
+      ethereumAddress(publicKeyCompressed: recoveredPublicKey)
+        == expectedWalletAddress,
+      verifyWalletAcknowledgement(
+        ownerPublicKey: expectedOwnerPublicKey,
+        walletAddress: expectedWalletAddress,
+        walletSignature: walletSignature,
+        signature: acknowledgement
+      )
+    else {
+      return .invalid
+    }
+    return .valid
+  }
+
+  private static func isCanonicalAccountBindingText(
+    _ text: String,
+    expectedWalletAddress: [UInt8],
+    expectedOwnerPublicKey: [UInt8]
+  ) -> Bool {
+    guard !text.contains("\r"), !text.hasSuffix("\n") else {
+      return false
+    }
+    let lines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    guard
+      lines.count == 11,
+      lines[1].isEmpty,
+      lines[2] == "This signature authorizes no transaction and moves no assets.",
+      lines[3].isEmpty,
+      lines[4] == "Domain-Tag: \(accountBindingDomainTag)",
+      lines[5] == "Wallet: 0x\(lowercaseHex(expectedWalletAddress))",
+      lines[6] == "Owner-Key: 0x\(lowercaseHex(expectedOwnerPublicKey))",
+      lines[8] == "Scope: global"
+    else {
+      return false
+    }
+
+    let headerSuffix = " wants to bind this wallet to a Levarac owner key."
+    guard lines[0].hasSuffix(headerSuffix) else {
+      return false
+    }
+    let domain = String(lines[0].dropLast(headerSuffix.count))
+
+    let chainPrefix = "Chain-ID: eip155:"
+    guard lines[7].hasPrefix(chainPrefix) else {
+      return false
+    }
+    let chainIdText = String(lines[7].dropFirst(chainPrefix.count))
+    guard
+      !chainIdText.isEmpty,
+      chainIdText.utf8.allSatisfy({ (0x30...0x39).contains($0) }),
+      (chainIdText == "0" || !chainIdText.hasPrefix("0")),
+      let chainId = UInt64(chainIdText)
+    else {
+      return false
+    }
+
+    let noncePrefix = "Nonce: 0x"
+    guard
+      lines[9].hasPrefix(noncePrefix),
+      let nonce = decodeLowercaseHex(
+        String(lines[9].dropFirst(noncePrefix.count))
+      ),
+      nonce.count == 16
+    else {
+      return false
+    }
+
+    let issuedAtPrefix = "Issued-At: "
+    guard lines[10].hasPrefix(issuedAtPrefix) else {
+      return false
+    }
+    let issuedAt = String(lines[10].dropFirst(issuedAtPrefix.count))
+
+    guard let reconstructed = buildAccountBindingText(
+      domain: domain,
+      walletAddress: expectedWalletAddress,
+      ownerPublicKey: expectedOwnerPublicKey,
+      chainId: chainId,
+      nonce: nonce,
+      issuedAt: issuedAt
+    ) else {
+      return false
+    }
+    return reconstructed.utf8.elementsEqual(text.utf8)
+  }
+
+  private static func verifyNativeSignature(
+    _ signature: BarnardCoreRecoverableSignature,
+    message: [UInt8],
+    expectedPublicKey: [UInt8]
+  ) -> Bool {
+    strictRecoveredPublicKey(
+      signature,
+      messageHash32: BarnardCorePrimitives.sha256(message)
+    ) == expectedPublicKey
+  }
+
+  private static func strictRecoveredPublicKey(
+    _ signature: BarnardCoreRecoverableSignature,
+    messageHash32: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      signature.r.count == 32,
+      signature.s.count == 32,
+      messageHash32.count == 32,
+      signature.v == 0 || signature.v == 1
+    else {
+      return nil
+    }
+
+    let r = BarnardCoreSecp256k1.UInt256(bytes: signature.r)
+    let s = BarnardCoreSecp256k1.UInt256(bytes: signature.s)
+    guard
+      !r.isZero,
+      r < BarnardCoreSecp256k1.curveOrder,
+      !s.isZero,
+      s < BarnardCoreSecp256k1.curveOrder,
+      s <= BarnardCoreSecp256k1.curveOrder.shiftedRight1()
+    else {
+      return nil
+    }
+
+    return recoverPublicKey(
+      recoveryId: signature.v,
+      r: signature.r,
+      s: signature.s,
+      messageHash32: messageHash32
+    )
+  }
+
+  private static func normalizedEthereumRecoveryId(_ v: UInt8) -> Int? {
+    switch v {
+    case 0, 1:
+      return Int(v)
+    case 27, 28:
+      return Int(v - 27)
+    default:
+      return nil
+    }
+  }
+
+  private static func isValidPrivateKey(_ privateKey: [UInt8]) -> Bool {
+    guard privateKey.count == 32 else {
+      return false
+    }
+    let scalar = BarnardCoreSecp256k1.UInt256(bytes: privateKey)
+    return !scalar.isZero && scalar < BarnardCoreSecp256k1.curveOrder
+  }
+
+  private static func publicKey(forPrivateKey privateKey: [UInt8]) -> [UInt8]? {
+    guard isValidPrivateKey(privateKey) else {
+      return nil
+    }
+    let point = BarnardCoreSecp256k1.multiply(
+      BarnardCoreSecp256k1.UInt256(bytes: privateKey),
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSecp256k1.compress(point)
+  }
+
+  private static func isValidCompressedPublicKey(_ publicKey: [UInt8]) -> Bool {
+    serializeUncompressedPublicKey(publicKey) != nil
+  }
+
+  private static func uint64BigEndian(_ value: UInt64) -> [UInt8] {
+    stride(from: 56, through: 0, by: -8).map {
+      UInt8((value >> UInt64($0)) & 0xff)
+    }
+  }
+
+  private static func lowercaseHex(_ bytes: [UInt8]) -> String {
+    bytes.map {
+      let value = String($0, radix: 16)
+      return value.count == 1 ? "0" + value : value
+    }.joined()
+  }
+
+  private static func decodeLowercaseHex(_ value: String) -> [UInt8]? {
+    let bytes = Array(value.utf8)
+    guard bytes.count.isMultiple(of: 2) else {
+      return nil
+    }
+    var output: [UInt8] = []
+    output.reserveCapacity(bytes.count / 2)
+    for index in stride(from: 0, to: bytes.count, by: 2) {
+      func nibble(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 0x30...0x39:
+          return byte - 0x30
+        case 0x61...0x66:
+          return byte - 0x61 + 10
+        default:
+          return nil
+        }
+      }
+      guard let high = nibble(bytes[index]), let low = nibble(bytes[index + 1])
+      else {
+        return nil
+      }
+      output.append((high << 4) | low)
+    }
+    return output
+  }
+
+  private static func isCanonicalDomain(_ domain: String) -> Bool {
+    let bytes = Array(domain.utf8)
+    guard
+      !bytes.isEmpty,
+      isLowercaseAsciiLetterOrDigit(bytes[0])
+    else {
+      return false
+    }
+
+    var colonIndex: Int?
+    for (index, byte) in bytes.enumerated() {
+      if colonIndex != nil {
+        if !(0x30...0x39).contains(byte) {
+          return false
+        }
+        continue
+      }
+      switch byte {
+      case 0x61...0x7a, 0x30...0x39, 0x2d, 0x2e:
+        break
+      case 0x3a:
+        if index == 0 {
+          return false
+        }
+        colonIndex = index
+      default:
+        return false
+      }
+    }
+
+    let hostEnd = colonIndex ?? bytes.count
+    guard
+      hostEnd > 0,
+      isLowercaseAsciiLetterOrDigit(bytes[hostEnd - 1])
+    else {
+      return false
+    }
+    guard let colonIndex else {
+      return true
+    }
+
+    let portBytes = bytes.dropFirst(colonIndex + 1)
+    guard
+      !portBytes.isEmpty,
+      portBytes.count <= 5,
+      portBytes.allSatisfy({ (0x30...0x39).contains($0) }),
+      (portBytes.count == 1 || portBytes.first != 0x30),
+      let port = UInt32(String(decoding: portBytes, as: UTF8.self)),
+      port <= 65_535
+    else {
+      return false
+    }
+    return true
+  }
+
+  private static func isLowercaseAsciiLetterOrDigit(_ byte: UInt8) -> Bool {
+    (0x61...0x7a).contains(byte) || (0x30...0x39).contains(byte)
+  }
+
+  private static func isCanonicalIssuedAt(_ value: String) -> Bool {
+    let bytes = Array(value.utf8)
+    guard
+      bytes.count == 20,
+      bytes[4] == 0x2d,
+      bytes[7] == 0x2d,
+      bytes[10] == 0x54,
+      bytes[13] == 0x3a,
+      bytes[16] == 0x3a,
+      bytes[19] == 0x5a
+    else {
+      return false
+    }
+    let digitPositions = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18]
+    guard digitPositions.allSatisfy({
+      (0x30...0x39).contains(bytes[$0])
+    }) else {
+      return false
+    }
+
+    func decimal(_ first: Int, _ second: Int) -> Int {
+      Int(bytes[first] - 0x30) * 10 + Int(bytes[second] - 0x30)
+    }
+    let year = decimal(0, 1) * 100 + decimal(2, 3)
+    let month = decimal(5, 6)
+    let day = decimal(8, 9)
+    let hour = decimal(11, 12)
+    let minute = decimal(14, 15)
+    let second = decimal(17, 18)
+    guard
+      (1...12).contains(month),
+      (0...23).contains(hour),
+      (0...59).contains(minute),
+      (0...59).contains(second)
+    else {
+      return false
+    }
+
+    var daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    let isLeapYear = year.isMultiple(of: 4)
+      && (!year.isMultiple(of: 100) || year.isMultiple(of: 400))
+    if isLeapYear {
+      daysInMonth[1] = 29
+    }
+    return (1...daysInMonth[month - 1]).contains(day)
+  }
+}

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCorePrimitives.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCorePrimitives.swift
@@ -1,6 +1,43 @@
 // Use of this source code is governed by a BSD-style license.
 
 enum BarnardCorePrimitives {
+  static func keccak256(_ input: [UInt8]) -> [UInt8] {
+    let rate = 136
+    var state = [UInt64](repeating: 0, count: 25)
+    var offset = 0
+
+    while input.count - offset >= rate {
+      absorbKeccakBlock(
+        Array(input[offset..<(offset + rate)]),
+        into: &state
+      )
+      keccakF1600(&state)
+      offset += rate
+    }
+
+    var finalBlock = [UInt8](repeating: 0, count: rate)
+    let remaining = input.count - offset
+    if remaining > 0 {
+      for index in 0..<remaining {
+        finalBlock[index] = input[offset + index]
+      }
+    }
+    finalBlock[remaining] ^= 0x01
+    finalBlock[rate - 1] ^= 0x80
+    absorbKeccakBlock(finalBlock, into: &state)
+    keccakF1600(&state)
+
+    var output: [UInt8] = []
+    output.reserveCapacity(32)
+    for byteIndex in 0..<32 {
+      let lane = state[byteIndex / 8]
+      output.append(
+        UInt8((lane >> UInt64(8 * (byteIndex % 8))) & 0xff)
+      )
+    }
+    return output
+  }
+
   static func sha256(_ input: [UInt8]) -> [UInt8] {
     let constants: [UInt32] = [
       0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
@@ -155,6 +192,88 @@ enum BarnardCorePrimitives {
 
   private static func rotateRight(_ value: UInt32, by count: UInt32) -> UInt32 {
     (value >> count) | (value << (32 - count))
+  }
+
+  private static func absorbKeccakBlock(
+    _ block: [UInt8],
+    into state: inout [UInt64]
+  ) {
+    for index in block.indices {
+      state[index / 8] ^=
+        UInt64(block[index]) << UInt64(8 * (index % 8))
+    }
+  }
+
+  private static func keccakF1600(_ state: inout [UInt64]) {
+    let roundConstants: [UInt64] = [
+      0x0000000000000001, 0x0000000000008082,
+      0x800000000000808a, 0x8000000080008000,
+      0x000000000000808b, 0x0000000080000001,
+      0x8000000080008081, 0x8000000000008009,
+      0x000000000000008a, 0x0000000000000088,
+      0x0000000080008009, 0x000000008000000a,
+      0x000000008000808b, 0x800000000000008b,
+      0x8000000000008089, 0x8000000000008003,
+      0x8000000000008002, 0x8000000000000080,
+      0x000000000000800a, 0x800000008000000a,
+      0x8000000080008081, 0x8000000000008080,
+      0x0000000080000001, 0x8000000080008008,
+    ]
+    let rotationOffsets: [Int] = [
+      0, 1, 62, 28, 27,
+      36, 44, 6, 55, 20,
+      3, 10, 43, 25, 39,
+      41, 45, 15, 21, 8,
+      18, 2, 61, 56, 14,
+    ]
+
+    for roundConstant in roundConstants {
+      var columns = [UInt64](repeating: 0, count: 5)
+      for x in 0..<5 {
+        columns[x] =
+          state[x]
+          ^ state[x + 5]
+          ^ state[x + 10]
+          ^ state[x + 15]
+          ^ state[x + 20]
+      }
+      for x in 0..<5 {
+        let delta =
+          columns[(x + 4) % 5]
+          ^ rotateLeft(columns[(x + 1) % 5], by: 1)
+        for y in 0..<5 {
+          state[x + 5 * y] ^= delta
+        }
+      }
+
+      var permuted = [UInt64](repeating: 0, count: 25)
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let source = x + 5 * y
+          let destination = y + 5 * ((2 * x + 3 * y) % 5)
+          permuted[destination] = rotateLeft(
+            state[source],
+            by: rotationOffsets[source]
+          )
+        }
+      }
+
+      for x in 0..<5 {
+        for y in 0..<5 {
+          let row = 5 * y
+          state[x + row] =
+            permuted[x + row]
+            ^ ((~permuted[(x + 1) % 5 + row])
+              & permuted[(x + 2) % 5 + row])
+        }
+      }
+      state[0] ^= roundConstant
+    }
+  }
+
+  private static func rotateLeft(_ value: UInt64, by count: Int) -> UInt64 {
+    guard count != 0 else { return value }
+    return (value << UInt64(count)) | (value >> UInt64(64 - count))
   }
 
   private static let aesSBox: [UInt8] = [

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreSigning.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreSigning.swift
@@ -3,12 +3,23 @@
 public struct BarnardCoreSigningKeyPair {
   public let privateKey: [UInt8]
   public let publicKeyCompressed: [UInt8]
+
+  public init(privateKey: [UInt8], publicKeyCompressed: [UInt8]) {
+    self.privateKey = privateKey
+    self.publicKeyCompressed = publicKeyCompressed
+  }
 }
 
 public struct BarnardCoreRecoverableSignature {
   public let r: [UInt8]
   public let s: [UInt8]
   public let v: Int
+
+  public init(r: [UInt8], s: [UInt8], v: Int) {
+    self.r = r
+    self.s = s
+    self.v = v
+  }
 }
 
 public struct BarnardCoreRpidOwnershipProof {
@@ -21,8 +32,14 @@ public struct BarnardCoreRpidOwnershipProof {
 
 public enum BarnardCoreSigning {
   public static let signingKeyInfo = "barnard-sign"
+  public static let ownerKeyInfo = "barnard-owner"
   public static let rpidProofDomainTag = "barnard-rpid-proof:v1"
   public static let keyBindingDomainTag = "barnard-key-binding:v1"
+  public static let selfProofDomainTag = "barnard-self-proof:v1"
+  public static let walletAcknowledgementDomainTag = "barnard-wallet-ack:v1"
+  public static let accountRotationDomainTag = "barnard-account-rotation:v1"
+  public static let accountUnbindingDomainTag = "barnard-account-unbinding:v1"
+  public static let accountBindingDomainTag = "barnard-account-binding:v1"
 
   public static func deriveSigningKeyPair(
     deviceSecret: [UInt8],
@@ -52,6 +69,86 @@ public enum BarnardCoreSigning {
       privateKey: privateKey.bytes,
       publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
     )
+  }
+
+  public static func deriveOwnerKeyPair(
+    accountSecret: [UInt8]
+  ) -> BarnardCoreSigningKeyPair {
+    precondition(accountSecret.count == 32, "accountSecret must be 32 bytes")
+    var seed = BarnardCorePrimitives.hkdfSha256(
+      inputKeyMaterial: accountSecret,
+      info: Array(ownerKeyInfo.utf8),
+      outputByteCount: 32
+    )
+    var privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+      BarnardCoreSecp256k1.UInt256(bytes: seed),
+      BarnardCoreSecp256k1.curveOrder
+    )
+    while privateKey.isZero {
+      seed = BarnardCorePrimitives.sha256(seed)
+      privateKey = BarnardCoreSecp256k1.Field.reduceOnce(
+        BarnardCoreSecp256k1.UInt256(bytes: seed),
+        BarnardCoreSecp256k1.curveOrder
+      )
+    }
+    let publicPoint = BarnardCoreSecp256k1.multiply(
+      privateKey,
+      BarnardCoreSecp256k1.generator
+    )
+    return BarnardCoreSigningKeyPair(
+      privateKey: privateKey.bytes,
+      publicKeyCompressed: BarnardCoreSecp256k1.compress(publicPoint)
+    )
+  }
+
+  public static func serializeUncompressedPublicKey(
+    _ compressedPublicKey: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      compressedPublicKey.count == 33,
+      compressedPublicKey[0] == 0x02 || compressedPublicKey[0] == 0x03
+    else {
+      return nil
+    }
+    let x = BarnardCoreSecp256k1.UInt256(
+      bytes: Array(compressedPublicKey.dropFirst())
+    )
+    guard
+      x < BarnardCoreSecp256k1.fieldPrime,
+      let point = BarnardCoreSecp256k1.decompress(
+        x: x,
+        yIsOdd: compressedPublicKey[0] == 0x03
+      )
+    else {
+      return nil
+    }
+    return BarnardCoreSecp256k1.serializeUncompressed(point)
+  }
+
+  public static func ethereumAddress(
+    publicKeyCompressed: [UInt8]
+  ) -> [UInt8]? {
+    guard
+      let uncompressed = serializeUncompressedPublicKey(publicKeyCompressed),
+      uncompressed.count == 65
+    else {
+      return nil
+    }
+    return Array(
+      BarnardCorePrimitives.keccak256(Array(uncompressed.dropFirst())).suffix(20)
+    )
+  }
+
+  public static func computeEip191Digest(text: String) -> [UInt8] {
+    computeEip191Digest(messageBytes: Array(text.utf8))
+  }
+
+  public static func computeEip191Digest(messageBytes: [UInt8]) -> [UInt8] {
+    let prefix =
+      [UInt8(0x19)]
+      + Array("Ethereum Signed Message:\n".utf8)
+      + Array(String(messageBytes.count).utf8)
+    return BarnardCorePrimitives.keccak256(prefix + messageBytes)
   }
 
   public static func signRecoverable(

--- a/packages/swift/barnard/Sources/BarnardCore/Secp256k1.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/Secp256k1.swift
@@ -300,6 +300,13 @@ enum BarnardCoreSecp256k1 {
     return [y.testBit(0) ? 0x03 : 0x02] + x.bytes
   }
 
+  static func serializeUncompressed(_ point: Point) -> [UInt8] {
+    guard let x = point.x, let y = point.y else {
+      return []
+    }
+    return [0x04] + x.bytes + y.bytes
+  }
+
   static func decompress(x: UInt256, yIsOdd: Bool) -> Point? {
     let xCubed = Field.multiplyMod(
       Field.multiplyMod(x, x, fieldPrime),

--- a/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
+++ b/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
@@ -8,6 +8,10 @@
 // purity contract as BarnardCore applies: Swift stdlib only. Callers own all
 // buffers; fixed-size outputs are documented per function. Functions return 0
 // on success and a negative value on invalid arguments.
+//
+// Every parameter named *_utf8 must be well-formed UTF-8. Functions with an
+// Int32 result return -1 for malformed UTF-8; the UInt8 policy predicate
+// treats it as absent and returns 0.
 
 import BarnardCore
 
@@ -16,11 +20,6 @@ private func bytes(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> [UInt8]?
   if count == 0 { return [] }
   guard let pointer else { return nil }
   return Array(UnsafeBufferPointer(start: pointer, count: Int(count)))
-}
-
-private func utf8String(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> String? {
-  guard let raw = bytes(pointer, count) else { return nil }
-  return String(decoding: raw, as: UTF8.self)
 }
 
 private func strictUtf8String(
@@ -40,32 +39,6 @@ private func write(_ output: [UInt8], _ expectedCount: Int, to pointer: UnsafeMu
   pointer.update(from: output, count: output.count)
 }
 
-/// The C boundary must be total: BarnardCore converts the derived window
-/// index with a trapping UInt32 cast, and a Swift trap is an uncatchable
-/// process abort for a JNI/C host. These guards mirror the core's own input
-/// clamps (see BarnardCoreCrypto.calculateEnin) purely to decide whether the
-/// core call is safe; in-domain results come from the core unchanged.
-private func eninDomain(
-  unixSeconds: Int64,
-  mode: Int32,
-  eninSeconds: Int64,
-  beaconGenesisUnixSeconds: Int64,
-  beaconSlotSeconds: Int64
-) -> (inDomain: Bool, saturated: UInt32) {
-  if mode == 1 {
-    let genesis = max(0, beaconGenesisUnixSeconds)
-    let slot = max(1, beaconSlotSeconds)
-    let elapsed = unixSeconds - genesis
-    if elapsed <= 0 { return (true, 0) }
-    if elapsed / slot > Int64(UInt32.max) { return (false, UInt32.max) }
-    return (true, 0)
-  }
-  if unixSeconds < 0 { return (false, 0) }
-  let effectiveSeconds = min(max(eninSeconds, 12), 3_600)
-  if unixSeconds / effectiveSeconds > Int64(UInt32.max) { return (false, UInt32.max) }
-  return (true, 0)
-}
-
 /// out_tek16: 16 bytes.
 @_cdecl("barnard_core_derive_tek_for_event")
 public func barnard_core_derive_tek_for_event(
@@ -77,7 +50,7 @@ public func barnard_core_derive_tek_for_event(
 ) -> Int32 {
   guard
     let secret = bytes(deviceSecret, deviceSecretLength),
-    let eventCode = utf8String(eventCodeUtf8, eventCodeLength),
+    let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength),
     let outTek16
   else { return -1 }
   write(
@@ -139,30 +112,19 @@ public func barnard_core_calculate_enin(
   _ beaconGenesisUnixSeconds: Int64,
   _ beaconSlotSeconds: Int64
 ) -> UInt32 {
-  let domain = eninDomain(
+  let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
+  let chain = BarnardCoreBeaconChain(
+    chainId: "c-abi",
+    genesisUnixSeconds: beaconGenesisUnixSeconds,
+    slotSeconds: beaconSlotSeconds
+  )
+  if let enin = BarnardCoreCrypto.calculateEninIfRepresentable(
     unixSeconds: unixSeconds,
-    mode: mode,
+    mode: coreMode,
     eninSeconds: eninSeconds,
-    beaconGenesisUnixSeconds: beaconGenesisUnixSeconds,
-    beaconSlotSeconds: beaconSlotSeconds
-  )
-  guard domain.inDomain else { return domain.saturated }
-  if mode == 1 {
-    return BarnardCoreCrypto.calculateEnin(
-      unixSeconds: unixSeconds,
-      mode: .beaconSlot,
-      beaconChain: BarnardCoreBeaconChain(
-        chainId: "c-abi",
-        genesisUnixSeconds: beaconGenesisUnixSeconds,
-        slotSeconds: beaconSlotSeconds
-      )
-    )
-  }
-  return BarnardCoreCrypto.calculateEnin(
-    unixSeconds: unixSeconds,
-    mode: .fixedLength,
-    eninSeconds: eninSeconds
-  )
+    beaconChain: chain
+  ) { return enin }
+  return mode == 1 || unixSeconds >= 0 ? .max : 0
 }
 
 /// Returns 1 and writes out_enin when the window is stable across both reads,
@@ -182,32 +144,25 @@ public func barnard_core_stable_read_enin(
   _ outEnin: UnsafeMutablePointer<UInt32>?
 ) -> Int32 {
   guard let outEnin else { return -1 }
-  for unixSeconds in [startedAtUnixSeconds, completedAtUnixSeconds]
-  where !eninDomain(
-    unixSeconds: unixSeconds,
-    mode: mode,
-    eninSeconds: eninSeconds,
-    beaconGenesisUnixSeconds: beaconGenesisUnixSeconds,
-    beaconSlotSeconds: beaconSlotSeconds
-  ).inDomain {
-    return -1
-  }
   let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
   let chain = BarnardCoreBeaconChain(
     chainId: "c-abi",
     genesisUnixSeconds: beaconGenesisUnixSeconds,
     slotSeconds: beaconSlotSeconds
   )
-  guard
-    let enin = BarnardCoreCrypto.stableReadEnin(
-      startedAtUnixSeconds: startedAtUnixSeconds,
-      completedAtUnixSeconds: completedAtUnixSeconds,
-      mode: coreMode,
-      eninSeconds: eninSeconds,
-      beaconChain: chain
-    )
-  else { return 0 }
-  outEnin.pointee = enin
+  guard let startedEnin = BarnardCoreCrypto.calculateEninIfRepresentable(
+    unixSeconds: startedAtUnixSeconds,
+    mode: coreMode,
+    eninSeconds: eninSeconds,
+    beaconChain: chain
+  ), let completedEnin = BarnardCoreCrypto.calculateEninIfRepresentable(
+    unixSeconds: completedAtUnixSeconds,
+    mode: coreMode,
+    eninSeconds: eninSeconds,
+    beaconChain: chain
+  ) else { return -1 }
+  guard startedEnin == completedEnin else { return 0 }
+  outEnin.pointee = completedEnin
   return 1
 }
 
@@ -218,7 +173,7 @@ public func barnard_core_compute_event_code_hash(
   _ eventCodeLength: Int32,
   _ outHash8: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
-  guard let eventCode = utf8String(eventCodeUtf8, eventCodeLength), let outHash8 else {
+  guard let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength), let outHash8 else {
     return -1
   }
   write(BarnardCoreCrypto.computeEventCodeHash(eventCode), 8, to: outHash8)
@@ -260,16 +215,20 @@ public func barnard_core_keccak256(
   return 0
 }
 
-/// Computes the EIP-191 personal_sign digest of message_utf8. out_digest32:
-/// 32 bytes. The caller is responsible for supplying UTF-8 canonical text;
-/// the digest operates on the byte sequence exactly as received.
+/// Computes the EIP-191 personal_sign digest of well-formed message_utf8.
+/// out_digest32: 32 bytes. The digest operates on the received UTF-8 byte
+/// sequence exactly as received.
 @_cdecl("barnard_core_eip191_digest")
 public func barnard_core_eip191_digest(
   _ messageUtf8: UnsafePointer<UInt8>?,
   _ messageLength: Int32,
   _ outDigest32: UnsafeMutablePointer<UInt8>?
 ) -> Int32 {
-  guard let message = bytes(messageUtf8, messageLength), let outDigest32 else {
+  guard
+    let message = bytes(messageUtf8, messageLength),
+    strictUtf8String(messageUtf8, messageLength) != nil,
+    let outDigest32
+  else {
     return -1
   }
   write(
@@ -292,7 +251,7 @@ public func barnard_core_derive_signing_keypair(
 ) -> Int32 {
   guard
     let secret = bytes(deviceSecret, deviceSecretLength),
-    let eventCode = utf8String(eventCodeUtf8, eventCodeLength),
+    let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength),
     let outPrivateKey32,
     let outPublicKeyCompressed33
   else { return -1 }
@@ -495,6 +454,6 @@ public func barnard_core_should_serve_gatt_display_id(
   _ eventCodeUtf8: UnsafePointer<UInt8>?,
   _ eventCodeLength: Int32
 ) -> UInt8 {
-  let eventCode = utf8String(eventCodeUtf8, eventCodeLength)
+  let eventCode = strictUtf8String(eventCodeUtf8, eventCodeLength)
   return BarnardCoreV2Policy.shouldServeGattDisplayId(eventCode: eventCode) ? 1 : 0
 }

--- a/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
+++ b/packages/swift/barnard/Sources/BarnardCoreC/CExports.swift
@@ -23,6 +23,15 @@ private func utf8String(_ pointer: UnsafePointer<UInt8>?, _ count: Int32) -> Str
   return String(decoding: raw, as: UTF8.self)
 }
 
+private func strictUtf8String(
+  _ pointer: UnsafePointer<UInt8>?,
+  _ count: Int32
+) -> String? {
+  guard let raw = bytes(pointer, count) else { return nil }
+  let value = String(decoding: raw, as: UTF8.self)
+  return Array(value.utf8) == raw ? value : nil
+}
+
 private func write(_ output: [UInt8], _ expectedCount: Int, to pointer: UnsafeMutablePointer<UInt8>) {
   precondition(
     output.count == expectedCount,
@@ -239,6 +248,38 @@ public func barnard_core_sha256(
   return 0
 }
 
+/// out_digest32: 32 bytes.
+@_cdecl("barnard_core_keccak256")
+public func barnard_core_keccak256(
+  _ input: UnsafePointer<UInt8>?,
+  _ inputLength: Int32,
+  _ outDigest32: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let raw = bytes(input, inputLength), let outDigest32 else { return -1 }
+  write(BarnardCoreCrypto.keccak256(raw), 32, to: outDigest32)
+  return 0
+}
+
+/// Computes the EIP-191 personal_sign digest of message_utf8. out_digest32:
+/// 32 bytes. The caller is responsible for supplying UTF-8 canonical text;
+/// the digest operates on the byte sequence exactly as received.
+@_cdecl("barnard_core_eip191_digest")
+public func barnard_core_eip191_digest(
+  _ messageUtf8: UnsafePointer<UInt8>?,
+  _ messageLength: Int32,
+  _ outDigest32: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard let message = bytes(messageUtf8, messageLength), let outDigest32 else {
+    return -1
+  }
+  write(
+    BarnardCoreSigning.computeEip191Digest(messageBytes: message),
+    32,
+    to: outDigest32
+  )
+  return 0
+}
+
 /// out_private_key32: 32 bytes. out_public_key_compressed33: 33 bytes.
 @_cdecl("barnard_core_derive_signing_keypair")
 public func barnard_core_derive_signing_keypair(
@@ -258,6 +299,29 @@ public func barnard_core_derive_signing_keypair(
   let keyPair = BarnardCoreSigning.deriveSigningKeyPair(
     deviceSecret: secret,
     eventCode: eventCode
+  )
+  write(keyPair.privateKey, 32, to: outPrivateKey32)
+  write(keyPair.publicKeyCompressed, 33, to: outPublicKeyCompressed33)
+  return 0
+}
+
+/// account_secret32: 32 bytes in. out_private_key32: 32 bytes.
+/// out_public_key_compressed33: 33 bytes.
+@_cdecl("barnard_core_derive_owner_keypair")
+public func barnard_core_derive_owner_keypair(
+  _ accountSecret32: UnsafePointer<UInt8>?,
+  _ outPrivateKey32: UnsafeMutablePointer<UInt8>?,
+  _ outPublicKeyCompressed33: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard
+    let accountSecret = bytes(accountSecret32, 32),
+    let outPrivateKey32,
+    let outPublicKeyCompressed33
+  else {
+    return -1
+  }
+  let keyPair = BarnardCoreSigning.deriveOwnerKeyPair(
+    accountSecret: accountSecret
   )
   write(keyPair.privateKey, 32, to: outPrivateKey32)
   write(keyPair.publicKeyCompressed, 33, to: outPublicKeyCompressed33)
@@ -289,6 +353,127 @@ public func barnard_core_sign_recoverable(
   write(signature.s, 32, to: outS32)
   outV.pointee = Int32(signature.v)
   return 0
+}
+
+/// Fixed inputs: event_id_hash32 (32), event_signing_public_key33 (33), and
+/// owner_public_key33 (33). out_message135: 135 bytes.
+@_cdecl("barnard_core_build_self_proof_message")
+public func barnard_core_build_self_proof_message(
+  _ eventIdHash32: UnsafePointer<UInt8>?,
+  _ eventSigningPublicKey33: UnsafePointer<UInt8>?,
+  _ eninStart: UInt64,
+  _ eninEnd: UInt64,
+  _ ownerPublicKey33: UnsafePointer<UInt8>?,
+  _ outMessage135: UnsafeMutablePointer<UInt8>?
+) -> Int32 {
+  guard
+    let eventIdHash = bytes(eventIdHash32, 32),
+    let eventSigningPublicKey = bytes(eventSigningPublicKey33, 33),
+    let ownerPublicKey = bytes(ownerPublicKey33, 33),
+    let outMessage135,
+    let message = BarnardCoreSigning.buildSelfProofMessage(
+      eventIdHash: eventIdHash,
+      eventSigningPublicKey: eventSigningPublicKey,
+      eninStart: eninStart,
+      eninEnd: eninEnd,
+      ownerPublicKey: ownerPublicKey
+    )
+  else {
+    return -1
+  }
+  write(message, 135, to: outMessage135)
+  return 0
+}
+
+/// Fixed key/hash/scalar inputs follow build_self_proof_message. Returns 1
+/// when valid, 0 when cryptographically invalid, and -1 for missing pointers.
+@_cdecl("barnard_core_verify_self_proof")
+public func barnard_core_verify_self_proof(
+  _ eventIdHash32: UnsafePointer<UInt8>?,
+  _ eventSigningPublicKey33: UnsafePointer<UInt8>?,
+  _ eninStart: UInt64,
+  _ eninEnd: UInt64,
+  _ ownerPublicKey33: UnsafePointer<UInt8>?,
+  _ signatureR32: UnsafePointer<UInt8>?,
+  _ signatureS32: UnsafePointer<UInt8>?,
+  _ signatureV: Int32
+) -> Int32 {
+  guard
+    let eventIdHash = bytes(eventIdHash32, 32),
+    let eventSigningPublicKey = bytes(eventSigningPublicKey33, 33),
+    let ownerPublicKey = bytes(ownerPublicKey33, 33),
+    let signatureR = bytes(signatureR32, 32),
+    let signatureS = bytes(signatureS32, 32)
+  else {
+    return -1
+  }
+  let signature = BarnardCoreRecoverableSignature(
+    r: signatureR,
+    s: signatureS,
+    v: Int(signatureV)
+  )
+  return BarnardCoreSigning.verifySelfProof(
+    eventIdHash: eventIdHash,
+    eventSigningPublicKey: eventSigningPublicKey,
+    eninStart: eninStart,
+    eninEnd: eninEnd,
+    ownerPublicKey: ownerPublicKey,
+    signature: signature
+  ) ? 1 : 0
+}
+
+/// Returns BarnardCoreWalletSignatureClassification raw values:
+/// 0 invalid, 1 EOA shape, 2 unsupported ERC-6492; -1 on invalid arguments.
+@_cdecl("barnard_core_classify_wallet_signature")
+public func barnard_core_classify_wallet_signature(
+  _ signature: UnsafePointer<UInt8>?,
+  _ signatureLength: Int32
+) -> Int32 {
+  guard let signatureBytes = bytes(signature, signatureLength) else {
+    return -1
+  }
+  return BarnardCoreSigning.classifyWalletSignature(signatureBytes).rawValue
+}
+
+/// Verifies one EOA wallet-binding record. Fixed inputs:
+/// expected_wallet_address20 (20), expected_owner_public_key33 (33),
+/// acknowledgement_r32/s32 (32 each). Returns
+/// BarnardCoreWalletBindingVerification raw values: 0 invalid, 1 valid,
+/// 2 unsupported ERC-6492; -1 on invalid arguments.
+@_cdecl("barnard_core_verify_wallet_binding")
+public func barnard_core_verify_wallet_binding(
+  _ bindingTextUtf8: UnsafePointer<UInt8>?,
+  _ bindingTextLength: Int32,
+  _ walletSignature: UnsafePointer<UInt8>?,
+  _ walletSignatureLength: Int32,
+  _ expectedWalletAddress20: UnsafePointer<UInt8>?,
+  _ expectedOwnerPublicKey33: UnsafePointer<UInt8>?,
+  _ acknowledgementR32: UnsafePointer<UInt8>?,
+  _ acknowledgementS32: UnsafePointer<UInt8>?,
+  _ acknowledgementV: Int32
+) -> Int32 {
+  guard
+    let text = strictUtf8String(bindingTextUtf8, bindingTextLength),
+    let signature = bytes(walletSignature, walletSignatureLength),
+    let address = bytes(expectedWalletAddress20, 20),
+    let ownerPublicKey = bytes(expectedOwnerPublicKey33, 33),
+    let acknowledgementR = bytes(acknowledgementR32, 32),
+    let acknowledgementS = bytes(acknowledgementS32, 32)
+  else {
+    return -1
+  }
+  let acknowledgement = BarnardCoreRecoverableSignature(
+    r: acknowledgementR,
+    s: acknowledgementS,
+    v: Int(acknowledgementV)
+  )
+  return BarnardCoreSigning.verifyWalletBinding(
+    text: text,
+    walletSignature: signature,
+    expectedWalletAddress: address,
+    expectedOwnerPublicKey: ownerPublicKey,
+    acknowledgement: acknowledgement
+  ).rawValue
 }
 
 /// Returns 1 when the RSSI update should be emitted, else 0.

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import XCTest
+import BarnardCore
 @testable import BarnardCoreC
 
 /// Replays the issue #80 golden behavior vector (BarnardBehaviorVectorTests)
@@ -115,6 +116,86 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(barnard_core_stable_read_enin(899, .max, 0, 300, 0, 0, &enin), -1)
     XCTAssertEqual(barnard_core_stable_read_enin(-1, -1, 1, 300, 0, 12, &enin), 1)
     XCTAssertEqual(enin, 0)
+  }
+
+  func testBeaconSlotMinimumTimestampHasStableZeroCAbiWindow() {
+    XCTAssertEqual(barnard_core_calculate_enin(.min, 1, 300, 1, 12), 0)
+
+    var enin: UInt32 = .max
+    XCTAssertEqual(barnard_core_stable_read_enin(.min, .min, 1, 300, 1, 12, &enin), 1)
+    XCTAssertEqual(enin, 0)
+  }
+
+  func testCAbiEninUsesCoreNonTrappingDomainGuard() {
+    let cases: [(Int64, Int32, Int64, Int64, Int64, UInt32)] = [
+      (1_700_000_123, 0, 300, 0, 0, 5_666_667),
+      (-1, 0, 300, 0, 0, 0),
+      (.max, 0, 300, 0, 0, .max),
+      (-400, 1, 300, 0, 12, 0),
+      (.max, 1, 300, 0, 1, .max),
+    ]
+
+    for (unixSeconds, mode, eninSeconds, genesis, slot, expectedCValue) in cases {
+      let coreMode: BarnardCoreEninMode = mode == 1 ? .beaconSlot : .fixedLength
+      let coreValue = BarnardCoreCrypto.calculateEninIfRepresentable(
+        unixSeconds: unixSeconds,
+        mode: coreMode,
+        eninSeconds: eninSeconds,
+        beaconChain: BarnardCoreBeaconChain(
+          chainId: "c-abi-test",
+          genesisUnixSeconds: genesis,
+          slotSeconds: slot
+        )
+      )
+      XCTAssertEqual(
+        barnard_core_calculate_enin(unixSeconds, mode, eninSeconds, genesis, slot),
+        coreValue ?? expectedCValue
+      )
+    }
+  }
+
+  func testUtf8InputsRejectMalformedSequences() {
+    let malformed: [UInt8] = [0xc3, 0x28]
+    let secret = [UInt8](repeating: 0, count: 32)
+    var output = [UInt8](repeating: 0, count: 33)
+    var privateKey = [UInt8](repeating: 0, count: 32)
+
+    XCTAssertEqual(
+      barnard_core_derive_tek_for_event(secret, 32, malformed, Int32(malformed.count), &output),
+      -1
+    )
+    XCTAssertEqual(
+      barnard_core_compute_event_code_hash(malformed, Int32(malformed.count), &output),
+      -1
+    )
+    XCTAssertEqual(
+      barnard_core_derive_signing_keypair(
+        secret, 32, malformed, Int32(malformed.count), &privateKey, &output
+      ),
+      -1
+    )
+    XCTAssertEqual(barnard_core_should_serve_gatt_display_id(malformed, Int32(malformed.count)), 0)
+    XCTAssertEqual(
+      barnard_core_eip191_digest(malformed, Int32(malformed.count), &output),
+      -1
+    )
+    let walletAddress = [UInt8](repeating: 0, count: 20)
+    let publicKey = [UInt8](repeating: 0, count: 33)
+    let scalar = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_verify_wallet_binding(
+        malformed,
+        Int32(malformed.count),
+        [],
+        0,
+        walletAddress,
+        publicKey,
+        scalar,
+        scalar,
+        0
+      ),
+      -1
+    )
   }
 
   func testOwnerKeyCAbiMatchesGoldenVectorsAndVerifiesProofs() {

--- a/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreCTests/BarnardCoreCTests.swift
@@ -117,6 +117,246 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(enin, 0)
   }
 
+  func testOwnerKeyCAbiMatchesGoldenVectorsAndVerifiesProofs() {
+    let accountSecret = [UInt8](repeating: 0, count: 32)
+    var ownerPrivateKey = [UInt8](repeating: 0, count: 32)
+    var ownerPublicKey = [UInt8](repeating: 0, count: 33)
+    XCTAssertEqual(
+      barnard_core_derive_owner_keypair(
+        accountSecret,
+        &ownerPrivateKey,
+        &ownerPublicKey
+      ),
+      0
+    )
+    XCTAssertEqual(
+      hex(ownerPrivateKey),
+      "46cbfd04992339fab4937354a6f24c115a238f4bd133a8c43b18162ab986bf27"
+    )
+    XCTAssertEqual(
+      hex(ownerPublicKey),
+      "03351e5165d083f53425fc4a51e7228d53e88eb2899bcb6a83368a8aafaa1de5f4"
+    )
+
+    let abc = Array("abc".utf8)
+    var digest = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(barnard_core_keccak256(abc, Int32(abc.count), &digest), 0)
+    XCTAssertEqual(
+      hex(digest),
+      "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"
+    )
+
+    let personalMessage = Array("Hello World".utf8)
+    XCTAssertEqual(
+      barnard_core_eip191_digest(
+        personalMessage,
+        Int32(personalMessage.count),
+        &digest
+      ),
+      0
+    )
+    XCTAssertEqual(
+      hex(digest),
+      "a1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2"
+    )
+
+    let eventHash = (0x00...0x1f).map(UInt8.init)
+    let eventPublicKey = decodeHex(
+      "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d"
+        + "959f2815b16f81798"
+    )
+    var selfProofMessage = [UInt8](repeating: 0, count: 135)
+    XCTAssertEqual(
+      barnard_core_build_self_proof_message(
+        eventHash,
+        eventPublicKey,
+        12,
+        34,
+        ownerPublicKey,
+        &selfProofMessage
+      ),
+      0
+    )
+    XCTAssertEqual(
+      Array(selfProofMessage.prefix(21)),
+      Array("barnard-self-proof:v1".utf8)
+    )
+    XCTAssertEqual(Array(selfProofMessage[53..<86]), eventPublicKey)
+    XCTAssertEqual(Array(selfProofMessage[102..<135]), ownerPublicKey)
+
+    var selfProofHash = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_sha256(
+        selfProofMessage,
+        Int32(selfProofMessage.count),
+        &selfProofHash
+      ),
+      0
+    )
+    var selfProofR = [UInt8](repeating: 0, count: 32)
+    var selfProofS = [UInt8](repeating: 0, count: 32)
+    var selfProofV: Int32 = -1
+    XCTAssertEqual(
+      barnard_core_sign_recoverable(
+        ownerPrivateKey,
+        selfProofHash,
+        &selfProofR,
+        &selfProofS,
+        &selfProofV
+      ),
+      0
+    )
+    XCTAssertEqual(
+      barnard_core_verify_self_proof(
+        eventHash,
+        eventPublicKey,
+        12,
+        34,
+        ownerPublicKey,
+        selfProofR,
+        selfProofS,
+        selfProofV
+      ),
+      1
+    )
+    XCTAssertEqual(
+      barnard_core_verify_self_proof(
+        eventHash,
+        eventPublicKey,
+        12,
+        35,
+        ownerPublicKey,
+        selfProofR,
+        selfProofS,
+        selfProofV
+      ),
+      0
+    )
+
+    let walletPrivateKey = [UInt8](repeating: 0, count: 31) + [1]
+    let walletAddress = decodeHex("7e5f4552091a69125d5dfcb7b8c2659029395bdf")
+    let bindingText = Array(
+      """
+      beid.levarac.org wants to bind this wallet to a Levarac owner key.
+
+      This signature authorizes no transaction and moves no assets.
+
+      Domain-Tag: barnard-account-binding:v1
+      Wallet: 0x\(hex(walletAddress))
+      Owner-Key: 0x\(hex(ownerPublicKey))
+      Chain-ID: eip155:1
+      Scope: global
+      Nonce: 0x000102030405060708090a0b0c0d0e0f
+      Issued-At: 2026-07-30T09:00:00Z
+      """.utf8
+    )
+    var bindingDigest = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_eip191_digest(
+        bindingText,
+        Int32(bindingText.count),
+        &bindingDigest
+      ),
+      0
+    )
+    var walletR = [UInt8](repeating: 0, count: 32)
+    var walletS = [UInt8](repeating: 0, count: 32)
+    var walletV: Int32 = -1
+    XCTAssertEqual(
+      barnard_core_sign_recoverable(
+        walletPrivateKey,
+        bindingDigest,
+        &walletR,
+        &walletS,
+        &walletV
+      ),
+      0
+    )
+    let walletSignature = walletR + walletS + [UInt8(walletV + 27)]
+    var walletSignatureHash = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_sha256(
+        walletSignature,
+        Int32(walletSignature.count),
+        &walletSignatureHash
+      ),
+      0
+    )
+    let acknowledgementMessage =
+      Array("barnard-wallet-ack:v1".utf8)
+      + walletAddress
+      + walletSignatureHash
+    var acknowledgementHash = [UInt8](repeating: 0, count: 32)
+    XCTAssertEqual(
+      barnard_core_sha256(
+        acknowledgementMessage,
+        Int32(acknowledgementMessage.count),
+        &acknowledgementHash
+      ),
+      0
+    )
+    var acknowledgementR = [UInt8](repeating: 0, count: 32)
+    var acknowledgementS = [UInt8](repeating: 0, count: 32)
+    var acknowledgementV: Int32 = -1
+    XCTAssertEqual(
+      barnard_core_sign_recoverable(
+        ownerPrivateKey,
+        acknowledgementHash,
+        &acknowledgementR,
+        &acknowledgementS,
+        &acknowledgementV
+      ),
+      0
+    )
+    XCTAssertEqual(
+      barnard_core_verify_wallet_binding(
+        bindingText,
+        Int32(bindingText.count),
+        walletSignature,
+        Int32(walletSignature.count),
+        walletAddress,
+        ownerPublicKey,
+        acknowledgementR,
+        acknowledgementS,
+        acknowledgementV
+      ),
+      1
+    )
+    XCTAssertEqual(
+      barnard_core_verify_wallet_binding(
+        personalMessage,
+        Int32(personalMessage.count),
+        walletSignature,
+        Int32(walletSignature.count),
+        walletAddress,
+        ownerPublicKey,
+        acknowledgementR,
+        acknowledgementS,
+        acknowledgementV
+      ),
+      0
+    )
+
+    let erc6492Magic = decodeHex(
+      "6492649264926492649264926492649264926492649264926492649264926492"
+    )
+    XCTAssertEqual(
+      barnard_core_classify_wallet_signature(
+        walletSignature,
+        Int32(walletSignature.count)
+      ),
+      1
+    )
+    XCTAssertEqual(
+      barnard_core_classify_wallet_signature(
+        erc6492Magic,
+        Int32(erc6492Magic.count)
+      ),
+      2
+    )
+    XCTAssertEqual(barnard_core_classify_wallet_signature(nil, 0), 0)
+  }
+
   func testInvalidArgumentsAreRejected() {
     var out = [UInt8](repeating: 0, count: 16)
     XCTAssertEqual(barnard_core_derive_tek_for_event(nil, 32, nil, 0, &out), -1)
@@ -125,5 +365,34 @@ final class BarnardCoreCTests: XCTestCase {
     XCTAssertEqual(barnard_core_sha256(nil, 4, &out), -1)
     XCTAssertEqual(barnard_core_stable_read_enin(0, 0, 0, 300, 0, 0, nil), -1)
     XCTAssertEqual(barnard_core_should_serve_gatt_display_id(nil, 5), 0)
+    XCTAssertEqual(barnard_core_derive_owner_keypair(nil, nil, nil), -1)
+    XCTAssertEqual(barnard_core_keccak256(nil, 1, nil), -1)
+    XCTAssertEqual(barnard_core_eip191_digest(nil, 1, nil), -1)
+    XCTAssertEqual(
+      barnard_core_build_self_proof_message(nil, nil, 0, 0, nil, nil),
+      -1
+    )
+    XCTAssertEqual(
+      barnard_core_verify_self_proof(
+        nil,
+        nil,
+        0,
+        0,
+        nil,
+        nil,
+        nil,
+        0
+      ),
+      -1
+    )
+    XCTAssertEqual(barnard_core_classify_wallet_signature(nil, 1), -1)
+  }
+
+  private func decodeHex(_ value: String) -> [UInt8] {
+    stride(from: 0, to: value.count, by: 2).map { offset in
+      let start = value.index(value.startIndex, offsetBy: offset)
+      let end = value.index(start, offsetBy: 2)
+      return UInt8(value[start..<end], radix: 16)!
+    }
   }
 }

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
@@ -1,0 +1,813 @@
+// Use of this source code is governed by a BSD-style license.
+
+import XCTest
+@testable import BarnardCore
+
+final class BarnardOwnerKeyMessageTests: XCTestCase {
+  private let scalarOne = [UInt8](repeating: 0, count: 31) + [1]
+  private let scalarTwo = [UInt8](repeating: 0, count: 31) + [2]
+  private let generatorCompressed = bytes(
+    "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+  )
+
+  func testCanonicalBindingTextMatchesPinnedBytesAndDigest() throws {
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: bytes("14791697260e4c9a71f18484c9f997b308e59325"),
+        ownerPublicKey: bytes(
+          "03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67"
+        ),
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+
+    XCTAssertEqual(
+      text,
+      """
+      beid.levarac.org wants to bind this wallet to a Levarac owner key.
+
+      This signature authorizes no transaction and moves no assets.
+
+      Domain-Tag: barnard-account-binding:v1
+      Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325
+      Owner-Key: 0x03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67
+      Chain-ID: eip155:1
+      Scope: global
+      Nonce: 0x000102030405060708090a0b0c0d0e0f
+      Issued-At: 2026-07-30T09:00:00Z
+      """
+    )
+    XCTAssertEqual(Array(text.utf8).count, 407)
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: text)),
+      "1aad6c43694a0e64bf3994959907b7392a590a1e7139bc9f52a86dc71709dc44"
+    )
+    XCTAssertFalse(text.hasSuffix("\n"))
+
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "BEID.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 15),
+        issuedAt: "2026-07-30T09:00:00+09:00"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org:00080",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org:65536",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-02-29T09:00:00Z"
+      )
+    )
+    XCTAssertNotNil(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org:65535",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: UInt64.max,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2024-02-29T09:00:00Z"
+      )
+    )
+  }
+
+  func testSelfProofBuilderSignerAndVerifier() throws {
+    let eventHash = (0x00...0x1f).map(UInt8.init)
+    let eventPublicKey = compressedPublicKey(privateKey: scalarTwo)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildSelfProofMessage(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 0x0102_0304_0506_0708,
+        eninEnd: 0x1112_1314_1516_1718,
+        ownerPublicKey: generatorCompressed
+      )
+    )
+
+    XCTAssertEqual(message.count, 135)
+    XCTAssertEqual(
+      Array(message.prefix(21)),
+      Array("barnard-self-proof:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[21..<53]), eventHash)
+    XCTAssertEqual(Array(message[53..<86]), eventPublicKey)
+    XCTAssertEqual(
+      Array(message[86..<102]),
+      bytes("01020304050607081112131415161718")
+    )
+    XCTAssertEqual(Array(message[102..<135]), generatorCompressed)
+    XCTAssertNil(
+      BarnardCoreSigning.buildSelfProofMessage(
+        eventIdHash: Array(eventHash.dropLast()),
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed
+      )
+    )
+
+    let signature = try XCTUnwrap(
+      BarnardCoreSigning.signSelfProof(
+        ownerPrivateKey: scalarOne,
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 35,
+        ownerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: BarnardCoreRecoverableSignature(
+          r: [UInt8](repeating: 0, count: 32),
+          s: signature.s,
+          v: signature.v
+        )
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: BarnardCoreRecoverableSignature(
+          r: signature.r,
+          s: signature.s,
+          v: 2
+        )
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 35,
+        eninEnd: 12,
+        ownerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+
+    let highS = BarnardCoreSecp256k1.curveOrder.subtracting(
+      BarnardCoreSecp256k1.UInt256(bytes: signature.s)
+    ).bytes
+    XCTAssertFalse(
+      BarnardCoreSigning.verifySelfProof(
+        eventIdHash: eventHash,
+        eventSigningPublicKey: eventPublicKey,
+        eninStart: 12,
+        eninEnd: 34,
+        ownerPublicKey: generatorCompressed,
+        signature: BarnardCoreRecoverableSignature(
+          r: signature.r,
+          s: highS,
+          v: signature.v ^ 1
+        )
+      )
+    )
+  }
+
+  func testWalletAcknowledgementBuilderSignerAndVerifier() throws {
+    let walletAddress = (0x20...0x33).map(UInt8.init)
+    let walletSignature = (0x40...0x80).map(UInt8.init)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildWalletAcknowledgementMessage(
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+
+    XCTAssertEqual(message.count, 73)
+    XCTAssertEqual(
+      Array(message.prefix(21)),
+      Array("barnard-wallet-ack:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[21..<41]), walletAddress)
+    XCTAssertEqual(
+      Array(message[41..<73]),
+      BarnardCoreCrypto.sha256(walletSignature)
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildWalletAcknowledgementMessage(
+        walletAddress: Array(walletAddress.dropLast()),
+        walletSignature: walletSignature
+      )
+    )
+
+    let signature = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: scalarOne,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyWalletAcknowledgement(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifyWalletAcknowledgement(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: Array(repeating: 0, count: 20),
+        walletSignature: walletSignature,
+        signature: signature
+      )
+    )
+  }
+
+  func testRotationBuilderSignerAndVerifier() throws {
+    let successorPublicKey = compressedPublicKey(privateKey: scalarTwo)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountRotationMessage(
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: successorPublicKey
+      )
+    )
+    XCTAssertEqual(message.count, 93)
+    XCTAssertEqual(
+      Array(message.prefix(27)),
+      Array("barnard-account-rotation:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[27..<60]), generatorCompressed)
+    XCTAssertEqual(Array(message[60..<93]), successorPublicKey)
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountRotationMessage(
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: generatorCompressed
+      )
+    )
+
+    let signature = try XCTUnwrap(
+      BarnardCoreSigning.signAccountRotation(
+        previousOwnerPrivateKey: scalarOne,
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: successorPublicKey
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyAccountRotation(
+        previousOwnerPublicKey: generatorCompressed,
+        successorOwnerPublicKey: successorPublicKey,
+        signature: signature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifyAccountRotation(
+        previousOwnerPublicKey: successorPublicKey,
+        successorOwnerPublicKey: generatorCompressed,
+        signature: signature
+      )
+    )
+  }
+
+  func testUnbindingBuilderAndBothSignerKinds() throws {
+    let walletPrivateKey = scalarTwo
+    let walletPublicKey = compressedPublicKey(privateKey: walletPrivateKey)
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(publicKeyCompressed: walletPublicKey)
+    )
+    let walletSignature = (0x40...0x80).map(UInt8.init)
+    let message = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountUnbindingMessage(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+
+    XCTAssertEqual(message.count, 113)
+    XCTAssertEqual(
+      Array(message.prefix(28)),
+      Array("barnard-account-unbinding:v1".utf8)
+    )
+    XCTAssertEqual(Array(message[28..<61]), generatorCompressed)
+    XCTAssertEqual(Array(message[61..<81]), walletAddress)
+    XCTAssertEqual(
+      Array(message[81..<113]),
+      BarnardCoreCrypto.sha256(walletSignature)
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountUnbindingMessage(
+        ownerPublicKey: generatorCompressed,
+        walletAddress: Array(walletAddress.dropLast()),
+        walletSignature: walletSignature
+      )
+    )
+
+    let ownerSignature = try XCTUnwrap(
+      BarnardCoreSigning.signAccountUnbinding(
+        signerPrivateKey: scalarOne,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        signer: .owner,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: ownerSignature
+      )
+    )
+    XCTAssertFalse(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        signer: .wallet,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: ownerSignature
+      )
+    )
+
+    let walletSigner = try XCTUnwrap(
+      BarnardCoreSigning.signAccountUnbinding(
+        signerPrivateKey: walletPrivateKey,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+    XCTAssertTrue(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        signer: .wallet,
+        ownerPublicKey: generatorCompressed,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature,
+        signature: walletSigner
+      )
+    )
+  }
+
+  func testWalletBindingRejectsNonGlobalScopeWithMatchingSignatures() throws {
+    let ownerPrivateKey = scalarTwo
+    let ownerPublicKey = compressedPublicKey(privateKey: ownerPrivateKey)
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(
+        publicKeyCompressed: generatorCompressed
+      )
+    )
+    let canonicalText = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let alteredScopeText = canonicalText.replacingOccurrences(
+      of: "Scope: global",
+      with: "Scope: event"
+    )
+    let alteredScopeEip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: alteredScopeText
+      )
+    )
+    let alteredScopeWalletSignature =
+      alteredScopeEip191Signature.r
+      + alteredScopeEip191Signature.s
+      + [UInt8(alteredScopeEip191Signature.v + 27)]
+    let alteredScopeAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: alteredScopeWalletSignature
+      )
+    )
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: alteredScopeText,
+        walletSignature: alteredScopeWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: alteredScopeAcknowledgement
+      ),
+      .invalid
+    )
+  }
+
+  func testWalletClassificationAndEoaBindingVerification() throws {
+    let magic = bytes(
+      "6492649264926492649264926492649264926492649264926492649264926492"
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature([UInt8](repeating: 0, count: 65)),
+      .validEoaShape
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature([0xaa] + magic),
+      .smartWalletUnsupported
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature(
+        [UInt8](repeating: 0xaa, count: 33) + magic
+      ),
+      .smartWalletUnsupported
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.classifyWalletSignature([]),
+      .invalid
+    )
+
+    let ownerPrivateKey = scalarTwo
+    let ownerPublicKey = compressedPublicKey(privateKey: ownerPrivateKey)
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(
+        publicKeyCompressed: generatorCompressed
+      )
+    )
+    let nonce = (0x00...0x0f).map(UInt8.init)
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: nonce,
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let eip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(text: text)
+    )
+    let walletSignature =
+      eip191Signature.r
+      + eip191Signature.s
+      + [UInt8(eip191Signature.v + 27)]
+    let acknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: walletSignature
+      )
+    )
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .valid
+    )
+
+    var nonCanonicalLines = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    nonCanonicalLines[6] =
+      "Owner-\u{212a}ey: " + nonCanonicalLines[6].dropFirst("Owner-Key: ".count)
+    let unicodeEquivalentLabelText = nonCanonicalLines.joined(separator: "\n")
+    XCTAssertNotEqual(
+      Array(unicodeEquivalentLabelText.utf8),
+      Array(text.utf8)
+    )
+    let unicodeEquivalentSignature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: unicodeEquivalentLabelText
+      )
+    )
+    let unicodeEquivalentWalletSignature =
+      unicodeEquivalentSignature.r
+      + unicodeEquivalentSignature.s
+      + [UInt8(unicodeEquivalentSignature.v + 27)]
+    let unicodeEquivalentAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: unicodeEquivalentWalletSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: unicodeEquivalentLabelText,
+        walletSignature: unicodeEquivalentWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: unicodeEquivalentAcknowledgement
+      ),
+      .invalid
+    )
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSignature,
+        expectedWalletAddress: [UInt8](repeating: 0, count: 20),
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: "Hello World",
+        walletSignature: walletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .invalid
+    )
+    let textNamingAnotherOwner = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: nonce,
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let anotherOwnerEip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: textNamingAnotherOwner
+      )
+    )
+    let anotherOwnerWalletSignature =
+      anotherOwnerEip191Signature.r
+      + anotherOwnerEip191Signature.s
+      + [UInt8(anotherOwnerEip191Signature.v + 27)]
+    let anotherOwnerAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: anotherOwnerWalletSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: textNamingAnotherOwner,
+        walletSignature: anotherOwnerWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: anotherOwnerAcknowledgement
+      ),
+      .invalid
+    )
+    let textNamingAnotherWallet = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: nonce,
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let anotherWalletEip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: scalarOne,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: textNamingAnotherWallet
+      )
+    )
+    let anotherWalletSignature =
+      anotherWalletEip191Signature.r
+      + anotherWalletEip191Signature.s
+      + [UInt8(anotherWalletEip191Signature.v + 27)]
+    let anotherWalletAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: anotherWalletSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: textNamingAnotherWallet,
+        walletSignature: anotherWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: anotherWalletAcknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: Array(walletSignature.dropLast()),
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .invalid
+    )
+
+    var invalidVSignature = walletSignature
+    invalidVSignature[64] = 2
+    let invalidVAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: invalidVSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: invalidVSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: invalidVAcknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: BarnardCoreRecoverableSignature(
+          r: [UInt8](repeating: 0, count: 32),
+          s: acknowledgement.s,
+          v: acknowledgement.v
+        )
+      ),
+      .invalid
+    )
+
+    var rawVSignature = walletSignature
+    rawVSignature[64] = UInt8(eip191Signature.v)
+    let rawVAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: rawVSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: rawVSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: rawVAcknowledgement
+      ),
+      .valid
+    )
+
+    var highSSignature = walletSignature
+    let highS = BarnardCoreSecp256k1.curveOrder.subtracting(
+      BarnardCoreSecp256k1.UInt256(bytes: eip191Signature.s)
+    ).bytes
+    highSSignature.replaceSubrange(
+      32..<64,
+      with: highS
+    )
+    highSSignature[64] = UInt8((eip191Signature.v ^ 1) + 27)
+    let highSAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: ownerPrivateKey,
+        walletAddress: walletAddress,
+        walletSignature: highSSignature
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: highSSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: highSAcknowledgement
+      ),
+      .invalid
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: [0xaa] + magic,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: acknowledgement
+      ),
+      .smartWalletUnsupported
+    )
+  }
+
+  func testWalletVerifierPortCarriesObservationTime() {
+    let verifier: any BarnardCoreWalletVerifier = FixedWalletVerifier()
+    XCTAssertEqual(
+      verifier.verify(
+        address: [UInt8](repeating: 0, count: 20),
+        digest: [UInt8](repeating: 0, count: 32),
+        signature: [1, 2, 3]
+      ),
+      .valid(verifiedAtUnixSeconds: 1_753_863_200)
+    )
+  }
+
+  private func compressedPublicKey(privateKey: [UInt8]) -> [UInt8] {
+    BarnardCoreSecp256k1.compress(
+      BarnardCoreSecp256k1.multiply(
+        BarnardCoreSecp256k1.UInt256(bytes: privateKey),
+        BarnardCoreSecp256k1.generator
+      )
+    )
+  }
+}
+
+private struct FixedWalletVerifier: BarnardCoreWalletVerifier {
+  func verify(
+    address: [UInt8],
+    digest: [UInt8],
+    signature: [UInt8]
+  ) -> BarnardCoreWalletVerifierVerdict {
+    .valid(verifiedAtUnixSeconds: 1_753_863_200)
+  }
+}
+
+private func bytes(_ hex: String) -> [UInt8] {
+  stride(from: 0, to: hex.count, by: 2).map { offset in
+    let start = hex.index(hex.startIndex, offsetBy: offset)
+    let end = hex.index(start, offsetBy: 2)
+    return UInt8(hex[start..<end], radix: 16)!
+  }
+}
+
+private func hex(_ bytes: [UInt8]) -> String {
+  bytes.map {
+    let value = String($0, radix: 16)
+    return value.count == 1 ? "0" + value : value
+  }.joined()
+}

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
@@ -422,7 +422,7 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
 
     let ownerSignature = try XCTUnwrap(
       BarnardCoreSigning.signAccountUnbinding(
-        signerPrivateKey: scalarOne,
+        ownerPrivateKey: scalarOne,
         ownerPublicKey: generatorCompressed,
         walletAddress: walletAddress,
         walletSignature: walletSignature
@@ -430,20 +430,18 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
     )
     XCTAssertTrue(
       BarnardCoreSigning.verifyAccountUnbinding(
-        signer: .owner,
         ownerPublicKey: generatorCompressed,
         walletAddress: walletAddress,
         walletSignature: walletSignature,
         signature: ownerSignature
       )
     )
-    XCTAssertFalse(
-      BarnardCoreSigning.verifyAccountUnbinding(
-        signer: .wallet,
+    XCTAssertNil(
+      BarnardCoreSigning.signAccountUnbinding(
+        ownerPrivateKey: walletPrivateKey,
         ownerPublicKey: generatorCompressed,
         walletAddress: walletAddress,
-        walletSignature: walletSignature,
-        signature: ownerSignature
+        walletSignature: walletSignature
       )
     )
   }
@@ -484,6 +482,57 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
         expectedOwnerPublicKey: ownerPublicKey
       ),
       .valid
+    )
+
+    func walletSignature(for candidate: String) -> [UInt8] {
+      let signature = BarnardCoreSigning.signRecoverable(
+        privateKey: walletPrivateKey,
+        messageHash32: BarnardCoreSigning.computeEip191Digest(text: candidate)
+      )
+      return signature.r + signature.s + [UInt8(signature.v + 27)]
+    }
+
+    func assertUnbindingRejected(
+      _ candidate: String,
+      file: StaticString = #filePath,
+      line: UInt = #line
+    ) {
+      XCTAssertEqual(
+        BarnardCoreSigning.verifyAccountUnbinding(
+          text: candidate,
+          walletSignature: walletSignature(for: candidate),
+          expectedWalletAddress: walletAddress,
+          expectedOwnerPublicKey: ownerPublicKey
+        ),
+        .invalid,
+        file: file,
+        line: line
+      )
+    }
+
+    assertUnbindingRejected(
+      text.replacingOccurrences(of: "\n", with: "\r\n")
+    )
+
+    var wrongLineCount = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    wrongLineCount.remove(at: 1)
+    assertUnbindingRejected(wrongLineCount.joined(separator: "\n"))
+
+    var reorderedFields = text.split(
+      separator: "\n",
+      omittingEmptySubsequences: false
+    ).map(String.init)
+    reorderedFields.swapAt(5, 6)
+    assertUnbindingRejected(reorderedFields.joined(separator: "\n"))
+
+    assertUnbindingRejected(
+      text.replacingOccurrences(
+        of: "This signature REVOKES a wallet binding and authorizes no transaction.",
+        with: "This signature authorizes no transaction and moves no assets."
+      )
     )
 
     var rawRecoveryIdSignature = walletSigner
@@ -578,26 +627,31 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
       .invalid
     )
 
-    let rawDigestSigner = try XCTUnwrap(
+    let unbindingAcknowledgement = try XCTUnwrap(
+      BarnardCoreSigning.signWalletAcknowledgement(
+        ownerPrivateKey: scalarTwo,
+        walletAddress: walletAddress,
+        walletSignature: walletSigner
+      )
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyWalletBinding(
+        text: text,
+        walletSignature: walletSigner,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey,
+        acknowledgement: unbindingAcknowledgement
+      ),
+      .invalid
+    )
+
+    XCTAssertNil(
       BarnardCoreSigning.signAccountUnbinding(
-        signerPrivateKey: walletPrivateKey,
+        ownerPrivateKey: walletPrivateKey,
         ownerPublicKey: ownerPublicKey,
         walletAddress: walletAddress,
         walletSignature: originalBindingSignature
       )
-    )
-    let rawDigestWalletSignature =
-      rawDigestSigner.r
-      + rawDigestSigner.s
-      + [UInt8(rawDigestSigner.v)]
-    XCTAssertEqual(
-      BarnardCoreSigning.verifyAccountUnbinding(
-        text: text,
-        walletSignature: rawDigestWalletSignature,
-        expectedWalletAddress: walletAddress,
-        expectedOwnerPublicKey: ownerPublicKey
-      ),
-      .invalid
     )
 
     let smartWalletMagic = bytes(

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyMessageTests.swift
@@ -109,6 +109,63 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
     )
   }
 
+  func testCanonicalUnbindingTextMatchesPinnedBytesAndDigest() throws {
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "beid.levarac.org",
+        walletAddress: bytes("7e5f4552091a69125d5dfcb7b8c2659029395bdf"),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+
+    XCTAssertEqual(
+      text,
+      """
+      beid.levarac.org wants to revoke this wallet's binding to a Levarac owner key.
+
+      This signature REVOKES a wallet binding and authorizes no transaction.
+
+      Domain-Tag: barnard-account-unbinding:v1
+      Wallet: 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+      Owner-Key: 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+      Chain-ID: eip155:1
+      Scope: global
+      Nonce: 0x000102030405060708090a0b0c0d0e0f
+      Issued-At: 2026-07-30T09:00:00Z
+      """
+    )
+    XCTAssertEqual(Array(text.utf8).count, 430)
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: text)),
+      "f11e3d04d85d6ac228dde88cebea4ba9554ed06b9c363d5a32f3e4fd89366929"
+    )
+    XCTAssertFalse(text.hasSuffix("\n"))
+
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "BEID.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 16),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "beid.levarac.org",
+        walletAddress: [UInt8](repeating: 0, count: 20),
+        ownerPublicKey: generatorCompressed,
+        chainId: 1,
+        nonce: [UInt8](repeating: 0, count: 15),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+  }
+
   func testSelfProofBuilderSignerAndVerifier() throws {
     let eventHash = (0x00...0x1f).map(UInt8.init)
     let eventPublicKey = compressedPublicKey(privateKey: scalarTwo)
@@ -329,7 +386,7 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
     )
   }
 
-  func testUnbindingBuilderAndBothSignerKinds() throws {
+  func testNativeUnbindingBuilderAndOwnerSigner() throws {
     let walletPrivateKey = scalarTwo
     let walletPublicKey = compressedPublicKey(privateKey: walletPrivateKey)
     let walletAddress = try XCTUnwrap(
@@ -389,23 +446,171 @@ final class BarnardOwnerKeyMessageTests: XCTestCase {
         signature: ownerSignature
       )
     )
+  }
 
-    let walletSigner = try XCTUnwrap(
-      BarnardCoreSigning.signAccountUnbinding(
-        signerPrivateKey: walletPrivateKey,
-        ownerPublicKey: generatorCompressed,
-        walletAddress: walletAddress,
-        walletSignature: walletSignature
+  func testWalletSignerUnbindingRequiresCanonicalEip191Text() throws {
+    let walletPrivateKey = scalarOne
+    let walletAddress = try XCTUnwrap(
+      BarnardCoreSigning.ethereumAddress(
+        publicKeyCompressed: generatorCompressed
       )
     )
-    XCTAssertTrue(
-      BarnardCoreSigning.verifyAccountUnbinding(
-        signer: .wallet,
-        ownerPublicKey: generatorCompressed,
+    let ownerPublicKey = compressedPublicKey(privateKey: scalarTwo)
+    let originalBindingSignature = (0x40...0x80).map(UInt8.init)
+    let text = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountUnbindingText(
+        domain: "beid.levarac.org",
         walletAddress: walletAddress,
-        walletSignature: walletSignature,
-        signature: walletSigner
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
       )
+    )
+    let eip191Signature = BarnardCoreSigning.signRecoverable(
+      privateKey: walletPrivateKey,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(text: text)
+    )
+    let walletSigner =
+      eip191Signature.r
+      + eip191Signature.s
+      + [UInt8(eip191Signature.v + 27)]
+
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: walletSigner,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .valid
+    )
+
+    var rawRecoveryIdSignature = walletSigner
+    rawRecoveryIdSignature[64] = UInt8(eip191Signature.v)
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: rawRecoveryIdSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .valid
+    )
+
+    var invalidRecoveryIdSignature = walletSigner
+    invalidRecoveryIdSignature[64] = 2
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: invalidRecoveryIdSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    var highSSignature = walletSigner
+    let highS = BarnardCoreSecp256k1.curveOrder.subtracting(
+      BarnardCoreSecp256k1.UInt256(bytes: eip191Signature.s)
+    ).bytes
+    highSSignature.replaceSubrange(32..<64, with: highS)
+    highSSignature[64] = UInt8((eip191Signature.v ^ 1) + 27)
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: highSSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let wrongDomainTagText = text.replacingOccurrences(
+      of: "Domain-Tag: barnard-account-unbinding:v1",
+      with: "Domain-Tag: barnard-account-binding:v1"
+    )
+    let wrongDomainTagSignature = BarnardCoreSigning.signRecoverable(
+      privateKey: walletPrivateKey,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(
+        text: wrongDomainTagText
+      )
+    )
+    let wrongDomainTagWalletSignature =
+      wrongDomainTagSignature.r
+      + wrongDomainTagSignature.s
+      + [UInt8(wrongDomainTagSignature.v)]
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: wrongDomainTagText,
+        walletSignature: wrongDomainTagWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let bindingText = try XCTUnwrap(
+      BarnardCoreSigning.buildAccountBindingText(
+        domain: "beid.levarac.org",
+        walletAddress: walletAddress,
+        ownerPublicKey: ownerPublicKey,
+        chainId: 1,
+        nonce: (0x00...0x0f).map(UInt8.init),
+        issuedAt: "2026-07-30T09:00:00Z"
+      )
+    )
+    let bindingSignature = BarnardCoreSigning.signRecoverable(
+      privateKey: walletPrivateKey,
+      messageHash32: BarnardCoreSigning.computeEip191Digest(text: bindingText)
+    )
+    let bindingWalletSignature =
+      bindingSignature.r
+      + bindingSignature.s
+      + [UInt8(bindingSignature.v)]
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: bindingText,
+        walletSignature: bindingWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let rawDigestSigner = try XCTUnwrap(
+      BarnardCoreSigning.signAccountUnbinding(
+        signerPrivateKey: walletPrivateKey,
+        ownerPublicKey: ownerPublicKey,
+        walletAddress: walletAddress,
+        walletSignature: originalBindingSignature
+      )
+    )
+    let rawDigestWalletSignature =
+      rawDigestSigner.r
+      + rawDigestSigner.s
+      + [UInt8(rawDigestSigner.v)]
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: rawDigestWalletSignature,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .invalid
+    )
+
+    let smartWalletMagic = bytes(
+      "6492649264926492649264926492649264926492649264926492649264926492"
+    )
+    XCTAssertEqual(
+      BarnardCoreSigning.verifyAccountUnbinding(
+        text: text,
+        walletSignature: [0xaa] + smartWalletMagic,
+        expectedWalletAddress: walletAddress,
+        expectedOwnerPublicKey: ownerPublicKey
+      ),
+      .smartWalletUnsupported
     )
   }
 

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyPrimitiveTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardOwnerKeyPrimitiveTests.swift
@@ -1,0 +1,141 @@
+// Use of this source code is governed by a BSD-style license.
+
+import XCTest
+@testable import BarnardCore
+
+final class BarnardOwnerKeyPrimitiveTests: XCTestCase {
+  func testDeriveOwnerKeyPairMatchesCrossImplementationVectors() {
+    let zeroPair = BarnardCoreSigning.deriveOwnerKeyPair(
+      accountSecret: [UInt8](repeating: 0, count: 32)
+    )
+    XCTAssertEqual(
+      hex(zeroPair.privateKey),
+      "46cbfd04992339fab4937354a6f24c115a238f4bd133a8c43b18162ab986bf27"
+    )
+    XCTAssertEqual(
+      hex(zeroPair.publicKeyCompressed),
+      "03351e5165d083f53425fc4a51e7228d53e88eb2899bcb6a83368a8aafaa1de5f4"
+    )
+
+    let sequentialPair = BarnardCoreSigning.deriveOwnerKeyPair(
+      accountSecret: (0..<32).map(UInt8.init)
+    )
+    XCTAssertEqual(
+      hex(sequentialPair.privateKey),
+      "3cfd4805b144d962c1cddccdf8452f02bfe022a867f550b0eb5ed8b2512ec758"
+    )
+    XCTAssertEqual(
+      hex(sequentialPair.publicKeyCompressed),
+      "03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67"
+    )
+  }
+
+  func testKeccak256MatchesEthereumVectorsIncludingRateBoundaries() {
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256([])),
+      "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256(Array("abc".utf8))),
+      "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256((0..<135).map { UInt8($0 & 0xff) })),
+      "cbdfd9dee5faad3818d6b06f95a219fd290b0e1706f6a82e5a595b9ce9faca62"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256((0..<136).map { UInt8($0 & 0xff) })),
+      "7ce759f1ab7f9ce437719970c26b0a66ff11fe3e38e17df89cf5d29c7d7f807e"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreCrypto.keccak256((0..<137).map { UInt8($0 & 0xff) })),
+      "ac73d4fae68b8453f764007c1a20ce95994187861f0c3227a3a8e99a73a3b1db"
+    )
+  }
+
+  func testUncompressedSec1SerializationAndEthereumAddressUseXYOnly() {
+    let generatorCompressed = bytes(
+      "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    )
+    let uncompressed = BarnardCoreSigning.serializeUncompressedPublicKey(
+      generatorCompressed
+    )
+
+    XCTAssertEqual(
+      hex(uncompressed ?? []),
+      "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        + "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.ethereumAddress(publicKeyCompressed: generatorCompressed) ?? []),
+      "7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.serializeUncompressedPublicKey(
+        [0x04] + [UInt8](repeating: 0, count: 32)
+      )
+    )
+    XCTAssertNil(
+      BarnardCoreSigning.serializeUncompressedPublicKey(
+        [0x02] + [UInt8](repeating: 0xff, count: 32)
+      )
+    )
+  }
+
+  func testEip191DigestUsesUtf8ByteLength() {
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: "")),
+      "5f35dce98ba4fba25530a026ed80b2cecdaa31091ba4958b99b52ea1d068adad"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: "Hello World")),
+      "a1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2"
+    )
+    XCTAssertEqual(
+      hex(BarnardCoreSigning.computeEip191Digest(text: "é")),
+      "ba8cc708d7c0ceccba0ed21ddc61b53a0db963cffb45659d761ff24f520f0a99"
+    )
+  }
+
+  func testEthersPersonalSignVectorRecoversExpectedAddress() {
+    let digest = BarnardCoreSigning.computeEip191Digest(text: "Hello World")
+    let recovered = BarnardCoreSigning.recoverPublicKey(
+      recoveryId: 0,
+      r: bytes(
+        "a617d0558818c7a479d5063987981b59d6e619332ef52249be8243572ef10868"
+      ),
+      s: bytes(
+        "07e381afe644d9bb56b213f6e08374c893db308ac1a5ae2bf8b33bcddcb0f76a"
+      ),
+      messageHash32: digest
+    )
+
+    XCTAssertEqual(
+      hex(recovered ?? []),
+      "035163ad559bf4672c2cb557e073c8de4edc4a92a8fb39634b30ca7005fbcb1f6c"
+    )
+    XCTAssertEqual(
+      hex(
+        BarnardCoreSigning.ethereumAddress(
+          publicKeyCompressed: recovered ?? []
+        ) ?? []
+      ),
+      "0a489345f9e9bc5254e18dd14fa7ecfdb2ce5f21"
+    )
+  }
+
+  private func hex(_ input: [UInt8]) -> String {
+    input.map {
+      let value = String($0, radix: 16)
+      return value.count == 1 ? "0" + value : value
+    }.joined()
+  }
+
+  private func bytes(_ hex: String) -> [UInt8] {
+    stride(from: 0, to: hex.count, by: 2).map { offset in
+      let start = hex.index(hex.startIndex, offsetBy: offset)
+      let end = hex.index(start, offsetBy: 2)
+      return UInt8(hex[start..<end], radix: 16)!
+    }
+  }
+}

--- a/schema/barnard/v1/README.md
+++ b/schema/barnard/v1/README.md
@@ -5,8 +5,9 @@ JSON Schema definitions for Barnard v1.
 This is the shared source of truth for:
 - Events (detection/state/constraint/error + debug events)
 - Config and capabilities
+- Holder-held owner self-proof records
+- Holder-held wallet binding, owner-key rotation, and unbinding records
 
 Notes
 - Terminology is not translated: **Scan / Advertise / Central / Peripheral / GATT / Transport**
 - `DetectionEvent` is based on receiver-observed facts: `rpid + rssi + timestamp`
-

--- a/schema/barnard/v1/self-proof.schema.json
+++ b/schema/barnard/v1/self-proof.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thegreeting.github.io/barnard/schema/barnard/v1/self-proof.schema.json",
+  "title": "Barnard Self-Proof Record (v1)",
+  "description": "Holder-held owner-key binding for one event signing key and ENIN range. This record is disclosed point-to-point and is never public or on-wire.",
+  "x-barnard-disclosure-scope": "holder-held",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "type": {
+      "const": "self-proof"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "eventIdHash": {
+      "description": "32-byte event identifier hash as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$",
+      "x-barnard-byte-length": 32
+    },
+    "eventSigningPublicKey": {
+      "description": "33-byte compressed SEC1 event signing public key as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+      "x-barnard-byte-length": 33
+    },
+    "eninStart": {
+      "description": "Inclusive unsigned ENIN range start.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 18446744073709551615
+    },
+    "eninEnd": {
+      "description": "Inclusive unsigned ENIN range end. It must be greater than or equal to eninStart.",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 18446744073709551615
+    },
+    "ownerPublicKey": {
+      "description": "33-byte compressed SEC1 owner public key as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+      "x-barnard-byte-length": 33
+    },
+    "signature": {
+      "description": "65-byte Barnard Recoverable secp256k1 Signature Profile v1 value r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{128}(?:00|01)$",
+      "x-barnard-byte-length": 65
+    }
+  },
+  "required": [
+    "type",
+    "schemaVersion",
+    "eventIdHash",
+    "eventSigningPublicKey",
+    "eninStart",
+    "eninEnd",
+    "ownerPublicKey",
+    "signature"
+  ]
+}

--- a/schema/barnard/v1/wallet-binding.schema.json
+++ b/schema/barnard/v1/wallet-binding.schema.json
@@ -65,6 +65,25 @@
         }
       ]
     },
+    "UnbindingMessage": {
+      "description": "Canonical UTF-8 wallet-authorized account-unbinding text with LF line endings and no trailing newline.",
+      "type": "string",
+      "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{1,5})? wants to revoke this wallet's binding to a Levarac owner key\\.\\n\\nThis signature REVOKES a wallet binding and authorizes no transaction\\.\\n\\nDomain-Tag: barnard-account-unbinding:v1\\nWallet: 0x[0-9a-f]{40}\\nOwner-Key: 0x(?:02|03)[0-9a-f]{64}\\nChain-ID: eip155:(?:0|[1-9][0-9]*)\\nScope: global\\nNonce: 0x[0-9a-f]{32}\\nIssued-At: [0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])",
+      "allOf": [
+        {
+          "description": "The optional decimal port is canonical and in the 0...65535 range.",
+          "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::(?:0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))? wants to revoke "
+        },
+        {
+          "description": "Chain-ID is in the UInt64 range used by BarnardCore.",
+          "pattern": "\\nChain-ID: eip155:(?:0|[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|18446744073709550[0-9]{3}|18446744073709551[0-5][0-9]{2}|1844674407370955160[0-9]|1844674407370955161[0-4]|18446744073709551615)\\n"
+        },
+        {
+          "description": "Issued-At is a valid proleptic-Gregorian date at UTC second precision.",
+          "pattern": "\\nIssued-At: (?:[0-9]{4}-(?:(?:01|03|05|07|08|10|12)-(?:0[1-9]|[12][0-9]|3[01])|(?:04|06|09|11)-(?:0[1-9]|[12][0-9]|30)|02-(?:0[1-9]|1[0-9]|2[0-8]))|(?:[0-9]{2}(?:0[48]|[2468][048]|[13579][26])|(?:[02468][048]|[13579][26])00)-02-29)T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])"
+        }
+      ]
+    },
     "WalletBindingRecord": {
       "type": "object",
       "additionalProperties": false,
@@ -122,6 +141,16 @@
       ]
     },
     "AccountUnbindingRecord": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/OwnerAccountUnbindingRecord"
+        },
+        {
+          "$ref": "#/$defs/WalletAccountUnbindingRecord"
+        }
+      ]
+    },
+    "OwnerAccountUnbindingRecord": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -141,11 +170,7 @@
           "$ref": "#/$defs/Hash32"
         },
         "signer": {
-          "type": "string",
-          "enum": [
-            "owner",
-            "wallet"
-          ]
+          "const": "owner"
         },
         "signature": {
           "$ref": "#/$defs/BarnardRecoverableSignature"
@@ -157,6 +182,34 @@
         "ownerPublicKey",
         "walletAddress",
         "walletSignatureHash",
+        "signer",
+        "signature"
+      ]
+    },
+    "WalletAccountUnbindingRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "account-unbinding"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "message": {
+          "$ref": "#/$defs/UnbindingMessage"
+        },
+        "signer": {
+          "const": "wallet"
+        },
+        "signature": {
+          "$ref": "#/$defs/WalletSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "message",
         "signer",
         "signature"
       ]

--- a/schema/barnard/v1/wallet-binding.schema.json
+++ b/schema/barnard/v1/wallet-binding.schema.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://thegreeting.github.io/barnard/schema/barnard/v1/wallet-binding.schema.json",
+  "title": "Barnard Wallet Binding and Owner-Key Lifecycle Records (v1)",
+  "description": "Holder-held wallet endorsement, owner-key rotation, and account-unbinding records. These records are disclosed point-to-point and are never public or on-wire.",
+  "x-barnard-disclosure-scope": "holder-held",
+  "oneOf": [
+    {
+      "$ref": "#/$defs/WalletBindingRecord"
+    },
+    {
+      "$ref": "#/$defs/AccountRotationRecord"
+    },
+    {
+      "$ref": "#/$defs/AccountUnbindingRecord"
+    }
+  ],
+  "$defs": {
+    "Hash32": {
+      "description": "32 bytes as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{64}$",
+      "x-barnard-byte-length": 32
+    },
+    "OwnerPublicKey": {
+      "description": "33-byte compressed SEC1 owner public key as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+      "x-barnard-byte-length": 33
+    },
+    "WalletAddress": {
+      "description": "20-byte EVM address as 0x-prefixed lowercase hex.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{40}$",
+      "x-barnard-byte-length": 20
+    },
+    "BarnardRecoverableSignature": {
+      "description": "65-byte Barnard Recoverable secp256k1 Signature Profile v1 value r || s || recoveryId as 0x-prefixed lowercase hex. recoveryId is 0 or 1.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{128}(?:00|01)$",
+      "x-barnard-byte-length": 65
+    },
+    "WalletSignature": {
+      "description": "65-byte EOA personal_sign signature r || s || v as 0x-prefixed lowercase hex. v is 0, 1, 27, or 28.",
+      "type": "string",
+      "pattern": "^0x[0-9a-f]{128}(?:00|01|1b|1c)$",
+      "x-barnard-byte-length": 65
+    },
+    "BindingMessage": {
+      "description": "Canonical UTF-8 account-binding text with LF line endings and no trailing newline.",
+      "type": "string",
+      "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{1,5})? wants to bind this wallet to a Levarac owner key\\.\\n\\nThis signature authorizes no transaction and moves no assets\\.\\n\\nDomain-Tag: barnard-account-binding:v1\\nWallet: 0x[0-9a-f]{40}\\nOwner-Key: 0x(?:02|03)[0-9a-f]{64}\\nChain-ID: eip155:(?:0|[1-9][0-9]*)\\nScope: global\\nNonce: 0x[0-9a-f]{32}\\nIssued-At: [0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])",
+      "allOf": [
+        {
+          "description": "The optional decimal port is canonical and in the 0...65535 range.",
+          "pattern": "^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::(?:0|[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))? wants "
+        },
+        {
+          "description": "Chain-ID is in the UInt64 range used by BarnardCore.",
+          "pattern": "\\nChain-ID: eip155:(?:0|[1-9][0-9]{0,18}|1[0-7][0-9]{18}|18[0-3][0-9]{17}|184[0-3][0-9]{16}|1844[0-5][0-9]{15}|18446[0-6][0-9]{14}|184467[0-3][0-9]{13}|1844674[0-3][0-9]{12}|184467440[0-6][0-9]{10}|1844674407[0-2][0-9]{9}|18446744073[0-6][0-9]{8}|1844674407370[0-8][0-9]{6}|18446744073709[0-4][0-9]{5}|184467440737095[0-4][0-9]{4}|18446744073709550[0-9]{3}|18446744073709551[0-5][0-9]{2}|1844674407370955160[0-9]|1844674407370955161[0-4]|18446744073709551615)\\n"
+        },
+        {
+          "description": "Issued-At is a valid proleptic-Gregorian date at UTC second precision.",
+          "pattern": "\\nIssued-At: (?:[0-9]{4}-(?:(?:01|03|05|07|08|10|12)-(?:0[1-9]|[12][0-9]|3[01])|(?:04|06|09|11)-(?:0[1-9]|[12][0-9]|30)|02-(?:0[1-9]|1[0-9]|2[0-8]))|(?:[0-9]{2}(?:0[48]|[2468][048]|[13579][26])|(?:[02468][048]|[13579][26])00)-02-29)T(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z(?![\\s\\S])"
+        }
+      ]
+    },
+    "WalletBindingRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "wallet-binding"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "message": {
+          "$ref": "#/$defs/BindingMessage"
+        },
+        "walletSignature": {
+          "$ref": "#/$defs/WalletSignature"
+        },
+        "ackSignature": {
+          "$ref": "#/$defs/BarnardRecoverableSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "message",
+        "walletSignature",
+        "ackSignature"
+      ]
+    },
+    "AccountRotationRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "account-rotation"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "previousOwnerPublicKey": {
+          "$ref": "#/$defs/OwnerPublicKey"
+        },
+        "successorOwnerPublicKey": {
+          "$ref": "#/$defs/OwnerPublicKey"
+        },
+        "signature": {
+          "$ref": "#/$defs/BarnardRecoverableSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "previousOwnerPublicKey",
+        "successorOwnerPublicKey",
+        "signature"
+      ]
+    },
+    "AccountUnbindingRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "account-unbinding"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "ownerPublicKey": {
+          "$ref": "#/$defs/OwnerPublicKey"
+        },
+        "walletAddress": {
+          "$ref": "#/$defs/WalletAddress"
+        },
+        "walletSignatureHash": {
+          "$ref": "#/$defs/Hash32"
+        },
+        "signer": {
+          "type": "string",
+          "enum": [
+            "owner",
+            "wallet"
+          ]
+        },
+        "signature": {
+          "$ref": "#/$defs/BarnardRecoverableSignature"
+        }
+      },
+      "required": [
+        "type",
+        "schemaVersion",
+        "ownerPublicKey",
+        "walletAddress",
+        "walletSignatureHash",
+        "signer",
+        "signature"
+      ]
+    }
+  }
+}

--- a/scripts/check-android-mirror.sh
+++ b/scripts/check-android-mirror.sh
@@ -1,45 +1,41 @@
 #!/usr/bin/env bash
 # Use of this source code is governed by the MIT license in /LICENSE.
 #
-# barnard#56: packages/android/barnard mirrors the Flutter-free crypto/RPID
-# sources from packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard
-# (byte-for-byte, not re-implemented) so the two packages cannot silently drift.
-# Fails with a diff if any mirrored file no longer matches its origin.
+# barnard#56 and #81: packages/android/barnard is the native origin for shared
+# Flutter-free crypto/RPID sources. The Flutter plugin keeps byte-for-byte
+# Dart-package mirrors so pub.dev releases remain self-contained. Fails with a
+# diff if any Dart mirror no longer matches its native origin.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-origin_dir="$repo_root/packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard"
-mirror_dir="$repo_root/packages/android/barnard/src/main/kotlin/org/levarac/barnard"
-
-mirrored_files=(
-  "BarnardCrypto.kt"
-  "BarnardSigning.kt"
-  "BarnardV2Policy.kt"
-  "BarnardIso8601.kt"
-)
+origin_dir="$repo_root/packages/android/barnard/src/main/kotlin/org/levarac/barnard"
+mirror_dir="$repo_root/packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard"
+source "$repo_root/scripts/mirror-manifest.sh"
 
 status=0
-for f in "${mirrored_files[@]}"; do
+for f in "${android_mirrored_files[@]}"; do
   origin_file="$origin_dir/$f"
   mirror_file="$mirror_dir/$f"
   if [[ ! -f "$origin_file" ]]; then
-    echo "MISSING origin: $origin_file"
+    echo "MISSING native origin: $origin_file"
     status=1
     continue
   fi
   if [[ ! -f "$mirror_file" ]]; then
-    echo "MISSING mirror: $mirror_file"
+    echo "MISSING Dart mirror: $mirror_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
     status=1
     continue
   fi
   if ! diff -q "$origin_file" "$mirror_file" >/dev/null 2>&1; then
-    echo "DRIFT: $origin_file != $mirror_file"
+    echo "DRIFT: Dart mirror $mirror_file differs from native origin $origin_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
     diff -u "$origin_file" "$mirror_file" || true
     status=1
   fi
 done
 
 if [[ $status -eq 0 ]]; then
-  echo "OK: packages/android/barnard mirrors match their origin byte-for-byte."
+  echo "OK: Dart Android mirrors match their native origins byte-for-byte."
 fi
-exit $status
+exit "$status"

--- a/scripts/check-schema-privacy-invariant.py
+++ b/scripts/check-schema-privacy-invariant.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Reject stable owner-key and wallet-address shapes in public/on-wire schemas."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urldefrag
+
+
+SCOPE_KEY = "x-barnard-disclosure-scope"
+PUBLIC_SCOPE = "public-on-wire"
+HOLDER_SCOPE = "holder-held"
+ALLOWED_SCOPES = {PUBLIC_SCOPE, HOLDER_SCOPE}
+FORBIDDEN_BYTE_LENGTHS = {20, 33}
+FORBIDDEN_HEX_LENGTHS = {40, 42, 66, 68}
+FORBIDDEN_BASE64_LENGTHS = {28, 44}
+SEMANTIC_FIELD_NAMES = {
+    "evmaddress",
+    "ownerpublickey",
+    "ownerpubkey",
+    "walletaddress",
+}
+HEX_PATTERN_LENGTH = re.compile(
+    r"(?:\{(?:40|42|66|68)\}"
+    r"|(?:02\|03|03\|02).*?\{64\})",
+    re.IGNORECASE,
+)
+PAIRED_BYTE_PATTERN_LENGTH = re.compile(
+    r"(?:"
+    r"\(\?:\[[^\]]+\]\{2\}\)\{(?:20|33)\}"
+    r"|(?:02\|03|03\|02).*?"
+    r"\(\?:\[[^\]]+\]\{2\}\)\{32\}"
+    r")",
+    re.IGNORECASE,
+)
+FORBIDDEN_DESCRIPTION = re.compile(
+    r"(?:33[\s-]*byte.*compressed.*(?:public[\s-]*key|pubkey)"
+    r"|20[\s-]*byte.*(?:evm|wallet)?\s*address)",
+    re.IGNORECASE,
+)
+
+
+def normalized_field_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def walk(value: Any, path: str = "$"):
+    yield path, value
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from walk(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from walk(child, f"{path}[{index}]")
+
+
+def shape_violations(document: dict[str, Any]) -> list[str]:
+    violations: list[str] = []
+    for path, node in walk(document):
+        if not isinstance(node, dict):
+            continue
+
+        byte_length = node.get("x-barnard-byte-length")
+        if byte_length in FORBIDDEN_BYTE_LENGTHS:
+            violations.append(
+                f"{path}: declares forbidden {byte_length}-byte stable identifier shape"
+            )
+
+        if (
+            node.get("type") == "array"
+            and node.get("minItems") == node.get("maxItems")
+            and node.get("minItems") in FORBIDDEN_BYTE_LENGTHS
+        ):
+            violations.append(
+                f"{path}: declares fixed {node['minItems']}-byte array shape"
+            )
+        prefix_items = node.get("prefixItems")
+        if (
+            node.get("type") == "array"
+            and isinstance(prefix_items, list)
+            and len(prefix_items) in FORBIDDEN_BYTE_LENGTHS
+            and node.get("items") is False
+        ):
+            violations.append(
+                f"{path}: declares fixed {len(prefix_items)}-byte prefixItems shape"
+            )
+
+        if node.get("type") == "string":
+            minimum = node.get("minLength")
+            maximum = node.get("maxLength")
+            if minimum == maximum and minimum in FORBIDDEN_HEX_LENGTHS:
+                violations.append(
+                    f"{path}: declares fixed {minimum}-character address/public-key shape"
+                )
+            if (
+                node.get("contentEncoding") == "base64"
+                and minimum == maximum
+                and minimum in FORBIDDEN_BASE64_LENGTHS
+            ):
+                violations.append(
+                    f"{path}: declares base64 length consistent with a 20/33-byte identifier"
+                )
+            pattern = node.get("pattern")
+            if isinstance(pattern, str) and HEX_PATTERN_LENGTH.search(pattern):
+                violations.append(
+                    f"{path}: declares exact hex length consistent with a 20/33-byte identifier"
+                )
+            if (
+                isinstance(pattern, str)
+                and PAIRED_BYTE_PATTERN_LENGTH.search(pattern)
+            ):
+                violations.append(
+                    f"{path}: declares paired-byte hex shape consistent with a 20/33-byte identifier"
+                )
+
+        properties = node.get("properties")
+        if isinstance(properties, dict):
+            for field_name in properties:
+                if normalized_field_name(field_name) in SEMANTIC_FIELD_NAMES:
+                    violations.append(
+                        f"{path}.properties.{field_name}: stable identifier field is public/on-wire"
+                    )
+
+        description = node.get("description")
+        if isinstance(description, str) and FORBIDDEN_DESCRIPTION.search(description):
+            violations.append(
+                f"{path}.description: describes a 20/33-byte stable identifier"
+            )
+    return violations
+
+
+def reference_violations(
+    schema_path: Path,
+    document: dict[str, Any],
+    scopes_by_path: dict[Path, str],
+    paths_by_id: dict[str, Path],
+) -> list[str]:
+    violations: list[str] = []
+    for path, node in walk(document):
+        if not isinstance(node, dict) or not isinstance(node.get("$ref"), str):
+            continue
+        reference, _ = urldefrag(node["$ref"])
+        if not reference:
+            continue
+        if reference in paths_by_id:
+            target = paths_by_id[reference]
+        else:
+            target = (schema_path.parent / reference).resolve()
+        if scopes_by_path.get(target) == HOLDER_SCOPE:
+            violations.append(
+                f"{path}.$ref: public/on-wire schema references holder-held schema {reference}"
+            )
+    return violations
+
+
+def check(schema_root: Path) -> tuple[list[str], int, int]:
+    failures: list[str] = []
+    documents: dict[Path, dict[str, Any]] = {}
+    scopes_by_path: dict[Path, str] = {}
+    paths_by_id: dict[str, Path] = {}
+
+    for schema_path in sorted(schema_root.rglob("*.schema.json")):
+        resolved_path = schema_path.resolve()
+        try:
+            raw = json.loads(schema_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            failures.append(f"{schema_path}: invalid JSON schema document: {error}")
+            continue
+        if not isinstance(raw, dict):
+            failures.append(f"{schema_path}: schema document root must be an object")
+            continue
+        scope = raw.get(SCOPE_KEY, PUBLIC_SCOPE)
+        if scope not in ALLOWED_SCOPES:
+            failures.append(
+                f"{schema_path}: {SCOPE_KEY} must be one of {sorted(ALLOWED_SCOPES)}"
+            )
+            continue
+        for path, node in walk(raw):
+            if (
+                path != "$"
+                and isinstance(node, dict)
+                and SCOPE_KEY in node
+            ):
+                failures.append(
+                    f"{schema_path}:{path}: {SCOPE_KEY} is valid only at the document root"
+                )
+        documents[resolved_path] = raw
+        scopes_by_path[resolved_path] = scope
+        schema_id = raw.get("$id")
+        if isinstance(schema_id, str):
+            paths_by_id[schema_id] = resolved_path
+
+    for schema_path, document in documents.items():
+        if scopes_by_path[schema_path] != PUBLIC_SCOPE:
+            continue
+        for violation in shape_violations(document):
+            failures.append(f"{schema_path}: {violation}")
+        for violation in reference_violations(
+            schema_path,
+            document,
+            scopes_by_path,
+            paths_by_id,
+        ):
+            failures.append(f"{schema_path}: {violation}")
+
+    public_count = sum(scope == PUBLIC_SCOPE for scope in scopes_by_path.values())
+    holder_count = sum(scope == HOLDER_SCOPE for scope in scopes_by_path.values())
+    return failures, public_count, holder_count
+
+
+def self_test() -> list[str]:
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        root = Path(temporary_directory)
+        holder = {
+            "$id": "https://example.invalid/holder.schema.json",
+            SCOPE_KEY: HOLDER_SCOPE,
+            "type": "string",
+            "pattern": "^0x(?:02|03)[0-9a-f]{64}$",
+            "x-barnard-byte-length": 33,
+        }
+        public_address = {
+            "type": "object",
+            "properties": {
+                "walletAddress": {
+                    "type": "string",
+                    "pattern": "^0x[0-9a-f]{40}$",
+                }
+            },
+        }
+        public_reference = {
+            "type": "object",
+            "properties": {
+                "leak": {"$ref": "https://example.invalid/holder.schema.json"}
+            },
+        }
+        public_paired_address = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "pattern": "^0x(?:[0-9a-f]{2}){20}$",
+                }
+            },
+        }
+        public_paired_public_key = {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "pattern": "^(?:02|03)(?:[0-9a-f]{2}){32}$",
+                }
+            },
+        }
+        byte_item = {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255,
+        }
+        public_prefix_items_20 = {
+            "type": "array",
+            "prefixItems": [byte_item] * 20,
+            "items": False,
+        }
+        public_prefix_items_33 = {
+            "type": "array",
+            "prefixItems": [byte_item] * 33,
+            "items": False,
+        }
+        (root / "holder.schema.json").write_text(
+            json.dumps(holder),
+            encoding="utf-8",
+        )
+        (root / "public-address.schema.json").write_text(
+            json.dumps(public_address),
+            encoding="utf-8",
+        )
+        (root / "public-reference.schema.json").write_text(
+            json.dumps(public_reference),
+            encoding="utf-8",
+        )
+        (root / "public-paired-address.schema.json").write_text(
+            json.dumps(public_paired_address),
+            encoding="utf-8",
+        )
+        (root / "public-paired-public-key.schema.json").write_text(
+            json.dumps(public_paired_public_key),
+            encoding="utf-8",
+        )
+        (root / "public-prefix-items-20.schema.json").write_text(
+            json.dumps(public_prefix_items_20),
+            encoding="utf-8",
+        )
+        (root / "public-prefix-items-33.schema.json").write_text(
+            json.dumps(public_prefix_items_33),
+            encoding="utf-8",
+        )
+
+        violations, public_count, holder_count = check(root)
+        joined = "\n".join(violations)
+        if "exact hex length" not in joined:
+            failures.append("self-test did not reject a public 20-byte hex shape")
+        if "stable identifier field" not in joined:
+            failures.append("self-test did not reject a public walletAddress field")
+        if "references holder-held schema" not in joined:
+            failures.append("self-test did not reject a public reference to holder-held data")
+        if joined.count("paired-byte hex shape") != 2:
+            failures.append(
+                "self-test did not reject both 20- and 33-byte paired-hex shapes"
+            )
+        if joined.count("prefixItems shape") != 2:
+            failures.append(
+                "self-test did not reject both 20- and 33-byte prefixItems shapes"
+            )
+        if public_count != 6 or holder_count != 1:
+            failures.append(
+                "self-test scope counts drifted "
+                f"(public={public_count}, holder={holder_count})"
+            )
+
+        positive_root = root / "holder-only"
+        positive_root.mkdir()
+        (positive_root / "holder.schema.json").write_text(
+            json.dumps(holder),
+            encoding="utf-8",
+        )
+        positive_violations, _, _ = check(positive_root)
+        if positive_violations:
+            failures.append(
+                "self-test rejected an explicitly holder-held identifier shape"
+            )
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    default_root = Path(__file__).resolve().parents[1] / "schema"
+    parser.add_argument(
+        "--schema-root",
+        type=Path,
+        default=default_root,
+        help="schema directory to scan (defaults to the repository schema directory)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="exercise synthetic forbidden and holder-held fixtures before scanning",
+    )
+    arguments = parser.parse_args()
+
+    if arguments.self_test:
+        self_test_failures = self_test()
+        if self_test_failures:
+            for failure in self_test_failures:
+                print(f"ERROR: {failure}", file=sys.stderr)
+            return 1
+        print("OK: schema privacy invariant self-tests passed.")
+
+    failures, public_count, holder_count = check(arguments.schema_root)
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+    print(
+        "OK: schema privacy invariant holds "
+        f"({public_count} public/on-wire, {holder_count} holder-held documents)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-swift-mirror.sh
+++ b/scripts/check-swift-mirror.sh
@@ -1,56 +1,44 @@
 #!/usr/bin/env bash
 # Use of this source code is governed by the MIT license in /LICENSE.
 #
-# barnard#56 and #80: packages/swift/barnard mirrors the Flutter-free
-# platform adapters and deterministic BarnardCore sources from
-# packages/dart/barnard/ios/barnard/Sources/barnard (byte-for-byte, not
-# re-implemented) so the two packages cannot silently drift.
-# Fails with a diff if any mirrored file no longer matches its origin.
+# barnard#56, #80, and #81: packages/swift/barnard is the native origin for
+# shared platform adapters and deterministic BarnardCore sources. The Flutter
+# plugin keeps byte-for-byte Dart-package mirrors so pub.dev releases remain
+# self-contained. Fails with a diff if any Dart mirror no longer matches its
+# native origin.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-plugin_dir="$repo_root/packages/dart/barnard/ios/barnard/Sources/barnard"
-package_dir="$repo_root/packages/swift/barnard/Sources"
-
-mirrored_pairs=(
-  "BarnardCrypto.swift|Barnard/BarnardCrypto.swift"
-  "Secp256k1.swift|Barnard/Secp256k1.swift"
-  "BarnardSigning.swift|Barnard/BarnardSigning.swift"
-  "BarnardRpidGenerator.swift|Barnard/BarnardRpidGenerator.swift"
-  "BarnardV2Policy.swift|Barnard/BarnardV2Policy.swift"
-  "BarnardPlatformDependencies.swift|Barnard/BarnardPlatformDependencies.swift"
-  "PrivacyInfo.xcprivacy|Barnard/PrivacyInfo.xcprivacy"
-  "BarnardCore/BarnardCoreCrypto.swift|BarnardCore/BarnardCoreCrypto.swift"
-  "BarnardCore/BarnardCorePolicy.swift|BarnardCore/BarnardCorePolicy.swift"
-  "BarnardCore/BarnardCorePrimitives.swift|BarnardCore/BarnardCorePrimitives.swift"
-  "BarnardCore/BarnardCoreSigning.swift|BarnardCore/BarnardCoreSigning.swift"
-  "BarnardCore/Secp256k1.swift|BarnardCore/Secp256k1.swift"
-)
+origin_dir="$repo_root/packages/swift/barnard/Sources"
+mirror_dir="$repo_root/packages/dart/barnard/ios/barnard/Sources/barnard"
+source "$repo_root/scripts/mirror-manifest.sh"
 
 status=0
-for pair in "${mirrored_pairs[@]}"; do
-  plugin_relative="${pair%%|*}"
-  package_relative="${pair#*|}"
-  plugin_file="$plugin_dir/$plugin_relative"
-  package_file="$package_dir/$package_relative"
-  if [[ ! -f "$plugin_file" ]]; then
-    echo "MISSING plugin source: $plugin_file"
+for pair in "${swift_mirrored_pairs[@]}"; do
+  origin_relative="${pair%%|*}"
+  mirror_relative="${pair#*|}"
+  origin_file="$origin_dir/$origin_relative"
+  mirror_file="$mirror_dir/$mirror_relative"
+  if [[ ! -f "$origin_file" ]]; then
+    echo "MISSING native origin: $origin_file"
     status=1
     continue
   fi
-  if [[ ! -f "$package_file" ]]; then
-    echo "MISSING package source: $package_file"
+  if [[ ! -f "$mirror_file" ]]; then
+    echo "MISSING Dart mirror: $mirror_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
     status=1
     continue
   fi
-  if ! diff -q "$plugin_file" "$package_file" >/dev/null 2>&1; then
-    echo "DRIFT: $plugin_file != $package_file"
-    diff -u "$plugin_file" "$package_file" || true
+  if ! diff -q "$origin_file" "$mirror_file" >/dev/null 2>&1; then
+    echo "DRIFT: Dart mirror $mirror_file differs from native origin $origin_file"
+    echo "Fix the native origin, then run ./scripts/sync-mirrors.sh; do not edit the Dart mirror directly."
+    diff -u "$origin_file" "$mirror_file" || true
     status=1
   fi
 done
 
 if [[ $status -eq 0 ]]; then
-  echo "OK: packages/swift/barnard mirrors match their origin byte-for-byte."
+  echo "OK: Dart Swift mirrors match their native origins byte-for-byte."
 fi
-exit $status
+exit "$status"

--- a/scripts/check-swift-package-manifest-mirror.sh
+++ b/scripts/check-swift-package-manifest-mirror.sh
@@ -40,6 +40,7 @@ for target in targets:
     target.pop("path", None)
 
 declarations = {
+    "dependencies": package["dependencies"],
     "platforms": package["platforms"],
     "products": package["products"],
     "targets": targets,

--- a/scripts/check-wallet-binding-schema.py
+++ b/scripts/check-wallet-binding-schema.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Exercise canonical wallet-binding schema boundaries without dependencies."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def binding_message_schema(schema_path: Path) -> dict[str, Any]:
+    document = json.loads(schema_path.read_text(encoding="utf-8"))
+    message = document.get("$defs", {}).get("BindingMessage")
+    if not isinstance(message, dict):
+        raise ValueError("$defs.BindingMessage is missing or is not an object")
+    return message
+
+
+def matches(schema: dict[str, Any], value: str) -> bool:
+    patterns = [schema.get("pattern")]
+    all_of = schema.get("allOf")
+    if not isinstance(all_of, list):
+        return False
+    patterns.extend(
+        constraint.get("pattern")
+        for constraint in all_of
+        if isinstance(constraint, dict)
+    )
+    return all(
+        isinstance(pattern, str) and re.search(pattern, value) is not None
+        for pattern in patterns
+    )
+
+
+def message(
+    *,
+    domain: str = "beid.levarac.org",
+    chain_id: str = "1",
+    issued_at: str = "2026-07-30T09:00:00Z",
+) -> str:
+    return "\n".join(
+        [
+            f"{domain} wants to bind this wallet to a Levarac owner key.",
+            "",
+            "This signature authorizes no transaction and moves no assets.",
+            "",
+            "Domain-Tag: barnard-account-binding:v1",
+            "Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325",
+            (
+                "Owner-Key: "
+                "0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d"
+                "959f2815b16f81798"
+            ),
+            f"Chain-ID: eip155:{chain_id}",
+            "Scope: global",
+            "Nonce: 0x000102030405060708090a0b0c0d0e0f",
+            f"Issued-At: {issued_at}",
+        ]
+    )
+
+
+def main() -> int:
+    schema_path = (
+        Path(__file__).resolve().parents[1]
+        / "schema"
+        / "barnard"
+        / "v1"
+        / "wallet-binding.schema.json"
+    )
+    try:
+        schema = binding_message_schema(schema_path)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
+        print(f"ERROR: cannot load binding-message schema: {error}", file=sys.stderr)
+        return 1
+
+    accepted = [
+        message(),
+        message(domain="beid.levarac.org:0"),
+        message(domain="beid.levarac.org:65535"),
+        message(chain_id="0"),
+        message(chain_id="18446744073709551615"),
+        message(issued_at="2024-02-29T23:59:59Z"),
+        message(issued_at="2000-02-29T00:00:00Z"),
+    ]
+    rejected = [
+        message(domain="beid.levarac.org:00080"),
+        message(domain="beid.levarac.org:65536"),
+        message(domain="beid.levarac.org:99999"),
+        message(chain_id="01"),
+        message(chain_id="18446744073709551616"),
+        message(issued_at="2026-02-29T09:00:00Z"),
+        message(issued_at="2026-02-31T09:00:00Z"),
+        message(issued_at="1900-02-29T09:00:00Z"),
+        message(issued_at="2026-04-31T09:00:00Z"),
+        message().replace("\nScope: global", ""),
+        message().replace("Scope: global", "Scope: event"),
+        message().replace(
+            (
+                "\nScope: global"
+                "\nNonce: 0x000102030405060708090a0b0c0d0e0f"
+            ),
+            (
+                "\nNonce: 0x000102030405060708090a0b0c0d0e0f"
+                "\nScope: global"
+            ),
+        ),
+        message() + "\n",
+        message().replace("\n", "\r\n"),
+    ]
+
+    failures: list[str] = []
+    for index, fixture in enumerate(accepted):
+        if not matches(schema, fixture):
+            failures.append(f"valid fixture {index} was rejected")
+    for index, fixture in enumerate(rejected):
+        if matches(schema, fixture):
+            failures.append(f"invalid fixture {index} was accepted")
+
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+    print(
+        "OK: wallet-binding schema accepts canonical boundary fixtures "
+        f"({len(accepted)} valid, {len(rejected)} invalid)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-wallet-binding-schema.py
+++ b/scripts/check-wallet-binding-schema.py
@@ -10,12 +10,45 @@ from pathlib import Path
 from typing import Any
 
 
-def binding_message_schema(schema_path: Path) -> dict[str, Any]:
+def message_schemas(
+    schema_path: Path,
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+]:
     document = json.loads(schema_path.read_text(encoding="utf-8"))
-    message = document.get("$defs", {}).get("BindingMessage")
-    if not isinstance(message, dict):
+    definitions = document.get("$defs", {})
+    binding_message = definitions.get("BindingMessage")
+    unbinding_message = definitions.get("UnbindingMessage")
+    unbinding_record = definitions.get("AccountUnbindingRecord")
+    owner_unbinding_record = definitions.get("OwnerAccountUnbindingRecord")
+    wallet_unbinding_record = definitions.get("WalletAccountUnbindingRecord")
+    if not isinstance(binding_message, dict):
         raise ValueError("$defs.BindingMessage is missing or is not an object")
-    return message
+    if not isinstance(unbinding_message, dict):
+        raise ValueError("$defs.UnbindingMessage is missing or is not an object")
+    if not isinstance(unbinding_record, dict):
+        raise ValueError(
+            "$defs.AccountUnbindingRecord is missing or is not an object"
+        )
+    if not isinstance(owner_unbinding_record, dict):
+        raise ValueError(
+            "$defs.OwnerAccountUnbindingRecord is missing or is not an object"
+        )
+    if not isinstance(wallet_unbinding_record, dict):
+        raise ValueError(
+            "$defs.WalletAccountUnbindingRecord is missing or is not an object"
+        )
+    return (
+        binding_message,
+        unbinding_message,
+        unbinding_record,
+        owner_unbinding_record,
+        wallet_unbinding_record,
+    )
 
 
 def matches(schema: dict[str, Any], value: str) -> bool:
@@ -36,17 +69,34 @@ def matches(schema: dict[str, Any], value: str) -> bool:
 
 def message(
     *,
+    ceremony: str = "binding",
     domain: str = "beid.levarac.org",
     chain_id: str = "1",
     issued_at: str = "2026-07-30T09:00:00Z",
 ) -> str:
+    if ceremony == "binding":
+        header = f"{domain} wants to bind this wallet to a Levarac owner key."
+        statement = "This signature authorizes no transaction and moves no assets."
+        domain_tag = "barnard-account-binding:v1"
+    elif ceremony == "unbinding":
+        header = (
+            f"{domain} wants to revoke this wallet's binding "
+            "to a Levarac owner key."
+        )
+        statement = (
+            "This signature REVOKES a wallet binding "
+            "and authorizes no transaction."
+        )
+        domain_tag = "barnard-account-unbinding:v1"
+    else:
+        raise ValueError(f"unsupported ceremony: {ceremony}")
     return "\n".join(
         [
-            f"{domain} wants to bind this wallet to a Levarac owner key.",
+            header,
             "",
-            "This signature authorizes no transaction and moves no assets.",
+            statement,
             "",
-            "Domain-Tag: barnard-account-binding:v1",
+            f"Domain-Tag: {domain_tag}",
             "Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325",
             (
                 "Owner-Key: "
@@ -70,12 +120,18 @@ def main() -> int:
         / "wallet-binding.schema.json"
     )
     try:
-        schema = binding_message_schema(schema_path)
+        (
+            binding_schema,
+            unbinding_schema,
+            unbinding_record,
+            owner_unbinding_record,
+            wallet_unbinding_record,
+        ) = message_schemas(schema_path)
     except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
         print(f"ERROR: cannot load binding-message schema: {error}", file=sys.stderr)
         return 1
 
-    accepted = [
+    binding_accepted = [
         message(),
         message(domain="beid.levarac.org:0"),
         message(domain="beid.levarac.org:65535"),
@@ -84,7 +140,7 @@ def main() -> int:
         message(issued_at="2024-02-29T23:59:59Z"),
         message(issued_at="2000-02-29T00:00:00Z"),
     ]
-    rejected = [
+    binding_rejected = [
         message(domain="beid.levarac.org:00080"),
         message(domain="beid.levarac.org:65536"),
         message(domain="beid.levarac.org:99999"),
@@ -109,22 +165,121 @@ def main() -> int:
         message() + "\n",
         message().replace("\n", "\r\n"),
     ]
+    unbinding_accepted = [
+        message(ceremony="unbinding"),
+        message(ceremony="unbinding", domain="beid.levarac.org:0"),
+        message(ceremony="unbinding", domain="beid.levarac.org:65535"),
+        message(ceremony="unbinding", chain_id="0"),
+        message(ceremony="unbinding", chain_id="18446744073709551615"),
+        message(
+            ceremony="unbinding",
+            issued_at="2024-02-29T23:59:59Z",
+        ),
+    ]
+    unbinding_rejected = [
+        message(ceremony="unbinding").replace(
+            "Domain-Tag: barnard-account-unbinding:v1",
+            "Domain-Tag: barnard-account-binding:v1",
+        ),
+        message(),
+        message(ceremony="unbinding", domain="beid.levarac.org:00080"),
+        message(ceremony="unbinding", domain="beid.levarac.org:65536"),
+        message(ceremony="unbinding", chain_id="01"),
+        message(ceremony="unbinding", chain_id="18446744073709551616"),
+        message(ceremony="unbinding", issued_at="2026-02-29T09:00:00Z"),
+        message(ceremony="unbinding").replace(
+            "This signature REVOKES a wallet binding "
+            "and authorizes no transaction.",
+            "This signature authorizes no transaction and moves no assets.",
+        ),
+        message(ceremony="unbinding") + "\n",
+        message(ceremony="unbinding").replace("\n", "\r\n"),
+    ]
 
     failures: list[str] = []
-    for index, fixture in enumerate(accepted):
-        if not matches(schema, fixture):
-            failures.append(f"valid fixture {index} was rejected")
-    for index, fixture in enumerate(rejected):
-        if matches(schema, fixture):
-            failures.append(f"invalid fixture {index} was accepted")
+    for name, schema, accepted, rejected in [
+        (
+            "binding",
+            binding_schema,
+            binding_accepted,
+            binding_rejected,
+        ),
+        (
+            "unbinding",
+            unbinding_schema,
+            unbinding_accepted,
+            unbinding_rejected,
+        ),
+    ]:
+        for index, fixture in enumerate(accepted):
+            if not matches(schema, fixture):
+                failures.append(f"valid {name} fixture {index} was rejected")
+        for index, fixture in enumerate(rejected):
+            if matches(schema, fixture):
+                failures.append(f"invalid {name} fixture {index} was accepted")
+
+    expected_variant_refs = {
+        "#/$defs/OwnerAccountUnbindingRecord",
+        "#/$defs/WalletAccountUnbindingRecord",
+    }
+    actual_variant_refs = {
+        variant.get("$ref")
+        for variant in unbinding_record.get("oneOf", [])
+        if isinstance(variant, dict)
+    }
+    if actual_variant_refs != expected_variant_refs:
+        failures.append("account-unbinding record does not define both signer variants")
+
+    record_expectations = [
+        (
+            "owner",
+            owner_unbinding_record,
+            {
+                "type",
+                "schemaVersion",
+                "ownerPublicKey",
+                "walletAddress",
+                "walletSignatureHash",
+                "signer",
+                "signature",
+            },
+            "#/$defs/BarnardRecoverableSignature",
+        ),
+        (
+            "wallet",
+            wallet_unbinding_record,
+            {"type", "schemaVersion", "message", "signer", "signature"},
+            "#/$defs/WalletSignature",
+        ),
+    ]
+    for signer, record, required, signature_ref in record_expectations:
+        properties = record.get("properties", {})
+        if (
+            record.get("additionalProperties") is not False
+            or set(record.get("required", [])) != required
+            or properties.get("signer", {}).get("const") != signer
+            or properties.get("signature", {}).get("$ref") != signature_ref
+        ):
+            failures.append(
+                f"{signer} account-unbinding record shape is not canonical"
+            )
+    if (
+        wallet_unbinding_record.get("properties", {})
+        .get("message", {})
+        .get("$ref")
+        != "#/$defs/UnbindingMessage"
+    ):
+        failures.append("wallet account-unbinding record does not use UnbindingMessage")
 
     if failures:
         for failure in failures:
             print(f"ERROR: {failure}", file=sys.stderr)
         return 1
     print(
-        "OK: wallet-binding schema accepts canonical boundary fixtures "
-        f"({len(accepted)} valid, {len(rejected)} invalid)."
+        "OK: wallet-binding schema accepts canonical binding and unbinding "
+        "boundary fixtures "
+        f"({len(binding_accepted) + len(unbinding_accepted)} valid, "
+        f"{len(binding_rejected) + len(unbinding_rejected)} invalid)."
     )
     return 0
 

--- a/scripts/mirror-manifest.sh
+++ b/scripts/mirror-manifest.sh
@@ -16,6 +16,7 @@ swift_mirrored_pairs=(
   "BarnardCore/BarnardCoreCrypto.swift|BarnardCore/BarnardCoreCrypto.swift"
   "BarnardCore/BarnardCorePolicy.swift|BarnardCore/BarnardCorePolicy.swift"
   "BarnardCore/BarnardCorePrimitives.swift|BarnardCore/BarnardCorePrimitives.swift"
+  "BarnardCore/BarnardCoreOwnerKey.swift|BarnardCore/BarnardCoreOwnerKey.swift"
   "BarnardCore/BarnardCoreSigning.swift|BarnardCore/BarnardCoreSigning.swift"
   "BarnardCore/Secp256k1.swift|BarnardCore/Secp256k1.swift"
 )

--- a/scripts/mirror-manifest.sh
+++ b/scripts/mirror-manifest.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Use of this source code is governed by the MIT license in /LICENSE.
+#
+# Explicit allowlists shared by the mirror checks and sync helper. Each Swift
+# pair is ordered native-origin-relative|Dart-mirror-relative.
+
+# shellcheck disable=SC2034  # This file is sourced by the check and sync scripts.
+swift_mirrored_pairs=(
+  "Barnard/BarnardCrypto.swift|BarnardCrypto.swift"
+  "Barnard/Secp256k1.swift|Secp256k1.swift"
+  "Barnard/BarnardSigning.swift|BarnardSigning.swift"
+  "Barnard/BarnardRpidGenerator.swift|BarnardRpidGenerator.swift"
+  "Barnard/BarnardV2Policy.swift|BarnardV2Policy.swift"
+  "Barnard/BarnardPlatformDependencies.swift|BarnardPlatformDependencies.swift"
+  "Barnard/PrivacyInfo.xcprivacy|PrivacyInfo.xcprivacy"
+  "BarnardCore/BarnardCoreCrypto.swift|BarnardCore/BarnardCoreCrypto.swift"
+  "BarnardCore/BarnardCorePolicy.swift|BarnardCore/BarnardCorePolicy.swift"
+  "BarnardCore/BarnardCorePrimitives.swift|BarnardCore/BarnardCorePrimitives.swift"
+  "BarnardCore/BarnardCoreSigning.swift|BarnardCore/BarnardCoreSigning.swift"
+  "BarnardCore/Secp256k1.swift|BarnardCore/Secp256k1.swift"
+)
+
+android_mirrored_files=(
+  "BarnardCrypto.kt"
+  "BarnardSigning.kt"
+  "BarnardV2Policy.kt"
+  "BarnardIso8601.kt"
+)

--- a/scripts/sync-mirrors.sh
+++ b/scripts/sync-mirrors.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Use of this source code is governed by the MIT license in /LICENSE.
+#
+# Regenerates the Flutter plugin's referencing mirror copies from the canonical
+# native Swift and Android packages.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+# shellcheck source=scripts/mirror-manifest.sh
+source "$script_dir/mirror-manifest.sh"
+
+swift_origin_dir="$repo_root/packages/swift/barnard/Sources"
+swift_mirror_dir="$repo_root/packages/dart/barnard/ios/barnard/Sources/barnard"
+android_origin_dir="$repo_root/packages/android/barnard/src/main/kotlin/org/levarac/barnard"
+android_mirror_dir="$repo_root/packages/dart/barnard/android/src/main/kotlin/org/levarac/barnard"
+
+require_origin() {
+  local origin_file="$1"
+  if [[ ! -f "$origin_file" ]]; then
+    echo "MISSING native origin: $origin_file" >&2
+    return 1
+  fi
+}
+
+# Validate the complete source set before copying so a missing later origin
+# cannot leave the Dart mirrors partially synchronized.
+for pair in "${swift_mirrored_pairs[@]}"; do
+  require_origin "$swift_origin_dir/${pair%%|*}"
+done
+for relative_path in "${android_mirrored_files[@]}"; do
+  require_origin "$android_origin_dir/$relative_path"
+done
+
+synced_count=0
+
+sync_file() {
+  local origin_file="$1"
+  local mirror_file="$2"
+
+  if cmp -s "$origin_file" "$mirror_file"; then
+    return
+  fi
+
+  mkdir -p "$(dirname "$mirror_file")"
+  cp "$origin_file" "$mirror_file"
+  echo "SYNCED: $origin_file -> $mirror_file"
+  synced_count=$((synced_count + 1))
+}
+
+for pair in "${swift_mirrored_pairs[@]}"; do
+  origin_relative="${pair%%|*}"
+  mirror_relative="${pair#*|}"
+  sync_file \
+    "$swift_origin_dir/$origin_relative" \
+    "$swift_mirror_dir/$mirror_relative"
+done
+
+for relative_path in "${android_mirrored_files[@]}"; do
+  sync_file \
+    "$android_origin_dir/$relative_path" \
+    "$android_mirror_dir/$relative_path"
+done
+
+if [[ $synced_count -eq 0 ]]; then
+  echo "OK: Dart mirrors already match their native origins."
+else
+  echo "OK: synchronized $synced_count Dart mirror file(s) from native origins."
+fi

--- a/specs/092-owner-key/spec.md
+++ b/specs/092-owner-key/spec.md
@@ -1,0 +1,520 @@
+# Owner Key and Optional Wallet Endorsement
+
+## Problem statement
+
+Barnard has per-event signing keys and RPID-ownership proofs, but it has no
+long-lived identity anchor. A holder therefore cannot selectively prove that
+multiple pseudonymous event histories belong to the same persona. Requiring an
+EVM wallet as that anchor would exclude wallet-less participants and would
+couple the protocol to wallet software and RPC availability.
+
+This specification adds an **owner key**: a deterministic, long-lived
+secp256k1 key pair derived from an independently generated `AccountSecret`.
+Every participant can use the owner key without a wallet (Tier 0). An EVM
+wallet may optionally endorse the owner key through a human-readable
+`personal_sign` ceremony (Tier 1).
+
+Key generation entropy, secret custody, backup, migration, wallet transport,
+and user-interface flows remain host responsibilities. Barnard provides only
+pure, deterministic formats, builders, signing, and verification.
+
+## Goals
+
+- Define a long-lived owner key that is independent of `DeviceSecret`.
+- Bind an event signing key to an owner key without disclosing TEK or RPIK.
+- Define an optional, mutually authenticated EVM wallet endorsement.
+- Define deterministic rotation and unbinding formats before host UX ships.
+- Keep every operation in `BarnardCore` free of randomness, clock access,
+  storage, wallet SDKs, and RPC configuration.
+- Preserve full protocol capability for wallet-less Tier 0 holders.
+- Keep all stable owner and wallet identifiers out of public and on-wire
+  artifacts.
+
+## Non-goals
+
+- Generating, storing, backing up, or migrating `AccountSecret`.
+- Wallet discovery, connection, SDK integration, or transaction signing.
+- ERC-1271 or ERC-6492 RPC verification in v1.
+- Presentation-time challenge-response or credential-transfer resistance.
+- Changing Scan, Advertise, Central, Peripheral, GATT, Transport, RPID,
+  event-signing, or existing RPID-ownership-proof behavior.
+- Adding Kotlin or React Native implementations.
+
+## Glossary
+
+- **owner key**: a long-lived secp256k1 key pair anchoring one holder-chosen
+  persona. Its compressed public key is 33-byte SEC1.
+- **AccountSecret**: an independently generated 32-byte random seed and the
+  sole input to owner-key derivation.
+- **event signing key**: the per-event secp256k1 key pair derived from
+  `DeviceSecret` and `EventCode`.
+- **self-proof**: an owner-key signature binding one event signing public key
+  and ENIN range to the owner key.
+- **wallet endorsement / account binding**: an EIP-191 `personal_sign`
+  signature by an EVM account over the canonical binding text, plus a
+  mandatory owner-key acknowledgement.
+- **EOA**: an externally owned EVM account whose signature can be verified by
+  public-key recovery without RPC.
+- **smart wallet**: an account requiring contract-aware verification such as
+  ERC-1271 or ERC-6492.
+- **Tier 0 / Tier 1**: owner-key identity without / with a wallet endorsement.
+- **holder-held artifact**: a record retained by the holder and disclosed
+  point-to-point, never placed in Advertise, GATT, anchors, or witness blobs.
+
+## Key hierarchy
+
+```text
+DeviceSecret (device-scoped random seed)
+├─ TEK = HKDF(DeviceSecret || EventCode)
+│  └─ RPID = f(TEK, ENIN)
+└─ event signing key = KDF(DeviceSecret, EventCode)
+
+AccountSecret (independent 32-byte random seed)
+└─ owner key = ownerKDF(AccountSecret)
+   └─ signs self-proofs for event signing keys
+
+wallet EOA -- personal_sign --> endorses the owner public key
+owner key  -- SHA-256/ECDSA --> acknowledges the exact wallet endorsement
+```
+
+`AccountSecret` MUST NOT be derived from `DeviceSecret`. The owner key needs an
+independent backup and migration lifetime; `DeviceSecret` remains
+device-scoped.
+
+### Owner-key derivation
+
+`deriveOwnerKeyPair` accepts exactly 32 bytes and follows the existing
+`deriveSigningKeyPair` scalar convention:
+
+1. Compute HKDF-SHA256 with:
+   - IKM = `AccountSecret`
+   - salt = 32 zero bytes (the existing omitted-salt convention)
+   - info = UTF-8 `barnard-owner`
+   - output length = 32 bytes
+2. Interpret the output as one unsigned big-endian integer.
+3. Reduce once modulo the secp256k1 curve order `n`.
+4. If the result is zero, set `seed = SHA256(seed)` and repeat steps 2–4.
+5. Serialize the private scalar as 32-byte big-endian and the public key as
+   33-byte compressed SEC1.
+
+The same `AccountSecret` MUST produce the same key pair on every platform.
+The `AccountSecret` itself is never used directly as a private key.
+
+## Barnard-native signature rules
+
+All four binary message families below use secp256k1 with deterministic
+RFC 6979 signing over `SHA256(message)`. Signers emit low-S signatures.
+This 65-byte format is named the **Barnard Recoverable secp256k1 Signature
+Profile v1**. Signatures in this profile serialize as:
+
+```text
+r (32-byte unsigned big-endian)
+|| s (32-byte unsigned big-endian)
+|| recoveryId (1 byte, 0x00 or 0x01)
+```
+
+The Barnard profile is not ES256K. ES256K, as specified by RFC 8812, is a
+64-octet `R || S` ECDSA signature over SHA-256 and has no recovery byte.
+Implementations, schemas, and documentation MUST NOT label a Barnard
+`r || s || recoveryId` signature as ES256K.
+
+Every verifier MUST reject:
+
+- a field whose byte length does not match its layout;
+- `r` or `s` equal to zero or greater than or equal to curve order `n`;
+- `s > n / 2`;
+- a recovery ID other than `0` or `1`;
+- a recovered key that does not match the required signer.
+
+Domain tags are raw UTF-8 bytes. All following fields have fixed widths; a
+variable input is converted to a fixed 32-byte digest before inclusion. No
+delimiter or implicit host-language encoding is present.
+
+## Message formats and behavior
+
+### 1. Self-proof
+
+Domain tag: `barnard-self-proof:v1`
+
+```text
+offset  size  value
+0       21    UTF-8 "barnard-self-proof:v1"
+21      32    eventIdHash
+53      33    eventSigningPublicKey (compressed SEC1)
+86       8    eninStart (unsigned big-endian)
+94       8    eninEnd (unsigned big-endian)
+102     33    ownerPublicKey (compressed SEC1)
+total  135
+```
+
+`eninStart` MUST be less than or equal to `eninEnd`. The owner private key signs
+the 135-byte message. Verification hashes the message with SHA-256, recovers
+the signer, and requires it to equal `ownerPublicKey`.
+
+The self-proof binds control of the owner key to the named event signing key
+for the stated ENIN range. It does not contain TEK, RPIK, or an RPID.
+
+The self-proof maps to the typed-envelope fields as follows: envelope `type`
+is represented by the `barnard-self-proof` domain tag, `protocolVersion` by
+its `:v1` suffix, `eventIdHash` by the same-named message field,
+`signingPubkey` by `eventSigningPublicKey`, the ENIN window by `eninStart` and
+`eninEnd`, and `ownerPubkey` by `ownerPublicKey`. Reporting-layer
+`eventDefinitionDigest` and `reportDigest` fields are deliberately outside
+the self-proof signature scope. The SCITT RFCs listed under References are
+prior art for that separate reporting layer.
+
+### 2. Wallet acknowledgement
+
+Domain tag: `barnard-wallet-ack:v1`
+
+```text
+offset  size  value
+0       21    UTF-8 "barnard-wallet-ack:v1"
+21      20    walletAddress
+41      32    SHA256(walletSignatureBytes)
+total   73
+```
+
+The owner private key signs this message. Verification recovers the signer and
+requires it to equal the owner public key from the canonical binding text.
+Hashing the exact wallet signature makes the acknowledgement specific to one
+endorsement, rather than merely to an address.
+
+### 3. Owner-key rotation
+
+Domain tag: `barnard-account-rotation:v1`
+
+```text
+offset  size  value
+0       27    UTF-8 "barnard-account-rotation:v1"
+27      33    previousOwnerPublicKey (compressed SEC1)
+60      33    successorOwnerPublicKey (compressed SEC1)
+total   93
+```
+
+The previous owner key signs this message. Verification recovers the signer
+and requires it to equal `previousOwnerPublicKey`. Including both keys makes
+the direction of succession explicit. The previous and successor keys MUST
+be distinct; a same-key rotation is invalid. A Tier 1 holder MUST run a new
+wallet binding ceremony for the successor; wallet endorsements do not
+transfer implicitly.
+
+### 4. Account unbinding
+
+Domain tag: `barnard-account-unbinding:v1`
+
+```text
+offset  size  value
+0       28    UTF-8 "barnard-account-unbinding:v1"
+28      33    ownerPublicKey (compressed SEC1)
+61      20    walletAddress
+81      32    walletSignatureHash = SHA256(walletSignatureBytes)
+total  113
+```
+
+The digest identifies one exact wallet-binding record. Either the owner key or
+the EOA key controlling `walletAddress` may sign the SHA-256 digest of this
+Barnard-native message. Verification therefore takes an explicit signer kind:
+
+- `owner`: the recovered compressed key MUST equal `ownerPublicKey`;
+- `wallet`: the recovered key is decompressed, its Ethereum address is
+  derived, and that address MUST equal `walletAddress`.
+
+The wallet-signing host UX for this reserved lifecycle format is not part of
+v1. It is not the account-binding `personal_sign` ceremony and MUST NOT be
+silently substituted for it.
+
+## Canonical wallet-binding text
+
+Open question 2 from the issue is resolved here. v1 includes the drafted
+human-readable authorization statement but omits the unrelated URI, request,
+resource, and expiration fields from full EIP-4361. This is the smallest field
+set that identifies the protocol, account, owner key, chain context, global
+scope, ceremony, and issuance time while stating that no transaction is
+authorized.
+
+The exact text is:
+
+```text
+{domain} wants to bind this wallet to a Levarac owner key.
+
+This signature authorizes no transaction and moves no assets.
+
+Domain-Tag: barnard-account-binding:v1
+Wallet: 0x{walletAddress lowercase hex}
+Owner-Key: 0x{compressed owner public key lowercase hex}
+Chain-ID: eip155:{chainId unsigned decimal}
+Scope: global
+Nonce: 0x{16-byte nonce lowercase hex}
+Issued-At: {issuedAt}
+```
+
+Canonical encoding rules are normative:
+
+- Encode the complete text as UTF-8.
+- Use LF (`0x0a`) only; CR is forbidden.
+- Preserve the exact field names, punctuation, capitalization, blank lines,
+  and order shown above.
+- Do not append a trailing LF or any other trailing byte.
+- `domain` is an already-normalized, lowercase ASCII authority (host or host
+  plus a decimal port in the range 0 through 65535) with no whitespace, slash,
+  CR, or LF. A port has no leading zero unless it is exactly `0`. Lowercase is
+  pinned so two hosts cannot produce different signatures by varying DNS
+  casing; Barnard emits the validated value exactly as supplied.
+- `walletAddress` is exactly 20 bytes and is emitted as `0x` plus 40 lowercase
+  hexadecimal digits.
+- `ownerPublicKey` is exactly 33-byte compressed SEC1, begins with `0x02` or
+  `0x03`, and is emitted as `0x` plus 66 lowercase hexadecimal digits.
+- `chainId` is an unsigned 64-bit integer in the range 0 through
+  18446744073709551615, emitted in base 10 with no leading zero, except that
+  zero is emitted as `0`.
+- `Scope` is the literal ASCII value `global` in v1. A scoped binding requires
+  a future versioned domain tag and MUST NOT be represented by changing this
+  line.
+- `nonce` is exactly 16 bytes and is emitted as `0x` plus 32 lowercase
+  hexadecimal digits.
+- `issuedAt` is supplied by the host as a valid proleptic-Gregorian calendar
+  date in RFC 3339 UTC, second precision: `YYYY-MM-DDTHH:MM:SSZ`. Barnard does
+  not read a clock.
+- No Unicode normalization, address checksum casing, JSON serialization, or
+  locale-sensitive formatting is applied.
+
+`nonce` and `issuedAt` make ceremonies unique and referenceable. They are not
+a replay-prevention promise: a valid binding remains an idempotent long-lived
+fact until an account-unbinding record revokes it. `Chain-ID` is context and
+policy metadata; EIP-191 `personal_sign` itself is chain-agnostic.
+
+### Example
+
+For domain `beid.levarac.org`, the EOA derived from private scalar 1, the
+compressed generator owner key, chain ID 1, nonce bytes `00` through `0f`, and
+issuance at 2026-07-30 09:00 UTC, the byte-exact text is:
+
+```text
+beid.levarac.org wants to bind this wallet to a Levarac owner key.
+
+This signature authorizes no transaction and moves no assets.
+
+Domain-Tag: barnard-account-binding:v1
+Wallet: 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+Owner-Key: 0x0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
+Chain-ID: eip155:1
+Scope: global
+Nonce: 0x000102030405060708090a0b0c0d0e0f
+Issued-At: 2026-07-30T09:00:00Z
+```
+
+## EIP-191 and Ethereum address derivation
+
+`computeEip191Digest(text)` computes:
+
+```text
+keccak256(
+  0x19
+  || UTF-8 "Ethereum Signed Message:\n"
+  || ASCII decimal(UTF8(text).count)
+  || UTF8(text)
+)
+```
+
+The length is the UTF-8 byte count, not a character count. `keccak256` is the
+Ethereum Keccak-256 variant with rate 136 bytes and domain/padding bytes
+`0x01 ... 0x80`. NIST SHA3-256 (`0x06 ... 0x80`) is incompatible and MUST NOT
+be substituted.
+
+To derive an EVM address from a recovered compressed public key:
+
+1. Parse the 33-byte compressed SEC1 point and serialize it as uncompressed
+   SEC1 `0x04 || x32 || y32`.
+2. Hash `x32 || y32` with Ethereum Keccak-256; do not hash the `0x04` prefix.
+3. Take the last 20 bytes.
+
+## Wallet signature classification
+
+Classification is a pure shape check and returns a typed result:
+
+1. If the byte string ends with the 32-byte ERC-6492 magic suffix
+   `0x6492` repeated 16 times, return `smartWalletUnsupported`. Suffix
+   detection has priority over length.
+2. Otherwise, if its length is exactly 65 bytes, return `validEoaShape`.
+3. Otherwise return `invalid`.
+
+`validEoaShape` does not mean cryptographically valid. Scalar, low-S,
+recovery-ID, recovered-address, and acknowledgement checks occur during
+verification.
+
+## EOA wallet-binding verification
+
+`verifyWalletBinding` verifies one record only. It takes the byte-exact
+canonical text, wallet signature, expected 20-byte wallet address, expected
+33-byte owner public key, and owner acknowledgement signature.
+
+1. Parse the supplied text under the canonical grammar, reconstruct it
+   byte-for-byte, and require its `Wallet:` and `Owner-Key:` fields to equal
+   `expectedWalletAddress` and `expectedOwnerPublicKey`. Reject any
+   noncanonical text, field mismatch, CR, or trailing LF before treating the
+   signature as an endorsement.
+2. Classify the wallet signature.
+   - `smartWalletUnsupported` returns an unverified smart-wallet result.
+   - `invalid` returns an invalid-shape result.
+3. Parse `r || s || v` from the 65-byte signature.
+4. Normalize `v = 27` to recovery ID 0 and `v = 28` to recovery ID 1. Raw
+   `v = 0` and `v = 1` are also accepted. Reject every other value.
+5. Require valid non-zero `r` and `s` scalars and low-S.
+6. Compute the EIP-191 digest and recover the public key with the existing
+   recovery primitive. Recovery IDs 2 and 3 remain unsupported deliberately.
+7. Derive the recovered Ethereum address and compare it byte-for-byte with
+   `expectedWalletAddress`. Human-readable hex comparisons at API boundaries
+   are case-insensitive, then decoded to these 20 bytes.
+8. Rebuild `barnard-wallet-ack:v1` from the expected address and exact wallet
+   signature bytes. Verify its SHA-256 signature, including scalar and low-S
+   rules, against `expectedOwnerPublicKey`.
+9. Only if the canonical binding and both signatures pass, return `valid`.
+
+The API does not aggregate endorsements and does not query RPC.
+
+## Smart-wallet verifier port
+
+Barnard defines a host-implemented port only:
+
+```text
+verify(address20, digest32, signatureBytes) -> verdict
+```
+
+The verdict is one of:
+
+- `valid(verifiedAtUnixSeconds)`;
+- `invalid(verifiedAtUnixSeconds)`;
+- `unverified`.
+
+No RPC client, endpoint, credential, retry, timeout, cache, or chain-selection
+code belongs in Barnard. v2 hosts may implement the port with ERC-1271/6492
+RPC. Contract state is time-dependent, so every valid or invalid RPC verdict
+MUST record the observation time. A verifier without RPC returns `unverified`;
+the endorsement then contributes no Tier 1 claim and the holder retains normal
+Tier 0 semantics.
+
+## Multi-wallet and persona rules
+
+The model is **N wallets to one owner key**. Every wallet independently signs a
+binding text for the same owner public key and receives its own owner
+acknowledgement.
+
+- Verifiers MUST NOT require disclosure of every endorsement.
+- Verification APIs MUST remain per-record and MUST NOT offer aggregate
+  all-wallet verification.
+- Choosing another wallet endorsement changes only what the holder discloses;
+  it MUST NOT create or rotate an owner key.
+- Multiple owner keys (personas) are legal only through explicit user action.
+- Hosts manage endorsement collections and disclosure choices outside
+  BarnardCore.
+
+## Tier 0 guarantee
+
+| Capability | Tier 0 (no wallet) | Tier 1 (wallet-bound) |
+|---|---|---|
+| Within-event RPID ownership | Full | Same |
+| Three-leg credential | Full, using the local owner key | Same |
+| Cross-event selective disclosure | Full, same owner-key algorithm | Same plus optional wallet check |
+| Device-loss continuity | Requires `AccountSecret` backup | Wallet may endorse a successor after rotation |
+| External identity bridge | None by design | EVM address endorsement |
+
+Loss of an unbacked-up `AccountSecret` orphans cross-event linkage. Existing
+per-event artifacts remain independently verifiable; Barnard does not invent a
+custodial recovery service.
+
+## Compatibility
+
+- All schemas and APIs in this specification are additive.
+- No existing public schema or on-wire format changes.
+- Existing Advertise, Scan, Central, Peripheral, GATT, Transport, RPID,
+  event-signing, and RPID-proof behavior remains unchanged.
+- New domain tags are disjoint from existing Barnard tags.
+- EIP-191 prefixing and Ethereum Keccak keep wallet signatures in a different
+  hash universe from Barnard-native SHA-256 signatures.
+
+## Security and privacy
+
+**No device-unique persistent identifiers are added on-wire.** Owner public
+keys, wallet addresses, self-proofs, wallet bindings, rotations, and
+unbindings are holder-held artifacts disclosed point-to-point. They MUST NOT
+appear in Advertise data, GATT values, public anchors, or witness blobs.
+
+The schema privacy invariant treats every schema as public/on-wire unless its
+document root explicitly declares holder-held disclosure scope. Public/on-wire
+schemas MUST NOT define a 33-byte compressed-public-key shape, a 20-byte
+address shape, or references into holder-held schemas.
+
+The wallet ceremony has three domain-separation layers:
+
+1. EIP-191 prevents cross-use as a transaction or Barnard-native signature.
+2. `Domain-Tag: barnard-account-binding:v1` prevents cross-protocol reuse.
+3. The visible domain and no-assets statement reduce blind-signing risk.
+
+Wallet linkage intentionally connects disclosed event history to a public
+address. Hosts MUST request explicit consent and MUST NOT auto-prompt binding.
+Using a fresh wallet address remains valid.
+
+## Errors and retry behavior
+
+- Pure builders are deterministic and perform no retries.
+- Invalid fixed-length inputs are rejected before hashing or recovery.
+- Cryptographically invalid signatures return typed invalid verdicts and do
+  not throw or trap.
+- ERC-6492 is classified before EOA validation and returns
+  `smartWalletUnsupported` in v1.
+- Owner-key zero-scalar derivation is the only retry loop and re-hashes the
+  32-byte seed deterministically as specified above.
+- RPC retry, timeout, and backoff are outside Barnard and belong to a future
+  host implementation of the verifier port.
+
+## Rejected alternatives
+
+- Using `AccountSecret` directly as the private key: rejected to preserve
+  domain separation and sibling-key derivation headroom.
+- Deriving the owner key from `DeviceSecret`: rejected because device and
+  identity migration lifetimes differ.
+- P-256 Secure Enclave / StrongBox or passkeys: rejected because
+  non-exportable keys conflict with the required backup and migration model,
+  and passkeys cannot sign arbitrary protocol payloads.
+- Ed25519: rejected to avoid a third signature stack with no protocol benefit.
+- BLAKE3: rejected because SHA-256 matches the existing portable Barnard stack.
+- Full EIP-4361 login fields: rejected because this is an endorsement, not an
+  authentication session; unused URI/resource/expiration fields add canonical
+  inputs without improving the binding.
+- An `expiresAt` binding field: rejected because a binding is a long-lived,
+  idempotent fact, revocation occurs through account unbinding, and v1 defines
+  no expiry semantics.
+- A binding text without the no-assets statement: rejected because the
+  ceremony must remain human-readable and explicitly non-transactional.
+
+## Future work
+
+- ERC-1271/6492 verification through the verifier port.
+- EIP-712 binding under `barnard-account-binding:v2`.
+- A versioned COSE/CBOR interoperability profile in v2.
+- Host UX for account rotation and wallet-authorized unbinding.
+- Presentation-time challenge-response.
+- Post-quantum migration through versioned domain tags and rotation records.
+
+## References
+
+- [RFC 8812: CBOR Object Signing and Encryption (COSE) and JSON Object
+  Signing and Encryption (JOSE) Registrations for
+  secp256k1](https://www.rfc-editor.org/rfc/rfc8812.html)
+- [RFC 9942: An Information Model for Supply Chain Integrity,
+  Transparency, and Trust](https://www.rfc-editor.org/rfc/rfc9942.html)
+- [RFC 9943: An Architecture for Trustworthy and Transparent Digital Supply
+  Chains](https://www.rfc-editor.org/rfc/rfc9943.html)
+
+## Validation
+
+- Cross-implementation HKDF owner-key vectors.
+- Standard Ethereum Keccak-256 vectors, including empty input and `abc`.
+- EIP-191 digest and `personal_sign` fixtures generated outside BarnardCore.
+- Unit tests for every builder, signer, verifier, malformed scalar, high-S
+  signature, recovery-ID normalization, address mismatch, acknowledgement
+  mismatch, ERC-6492 suffix, and canonical text byte.
+- C ABI tests for all exported owner-key functions and invalid arguments.
+- Schema syntax and privacy-invariant CI.
+- Existing Swift package and mirror checks remain green.

--- a/specs/092-owner-key/spec.md
+++ b/specs/092-owner-key/spec.md
@@ -216,7 +216,10 @@ total  113
 
 The digest identifies one exact wallet-binding record. The owner key signs the
 SHA-256 digest of this message. Verification recovers the compressed key and
-requires it to equal `ownerPublicKey`.
+requires it to equal `ownerPublicKey`. The BarnardCore signer is owner-only:
+it accepts `ownerPrivateKey`, requires that key to derive `ownerPublicKey`,
+and rejects a mismatched key rather than minting an unverifiable signature.
+The corresponding verifier has no signer-kind parameter.
 
 The EOA-authorized path MUST NOT sign this raw digest. It uses the canonical
 human-readable account-unbinding text defined below, signs it through
@@ -224,6 +227,16 @@ EIP-191 `personal_sign`, and verifies the recovered Ethereum address against
 `walletAddress`. The two signer paths deliberately retain different message
 formats because owner-key signatures are Barnard-native while wallet
 signatures must remain human-readable.
+
+The two paths also have deliberately different revocation granularity. An
+owner-key-authorized unbinding revokes one exact binding record, identified by
+`walletSignatureHash`. The wallet-authorized ceremony carries no wallet
+signature hash and revokes at `(walletAddress, ownerPublicKey, chainId)`
+granularity. A valid wallet-authorized unbinding therefore revokes the binding
+fact for that tuple, not merely one encoding or signature of it. This follows
+from treating a binding as an idempotent, long-lived fact: repeating the same
+binding ceremony MUST NOT bypass an existing revocation by producing different
+signature bytes.
 
 ## Canonical wallet-binding text
 
@@ -413,6 +426,36 @@ canonical text, wallet signature, expected 20-byte wallet address, expected
 9. Only if the canonical binding and both signatures pass, return `valid`.
 
 The API does not aggregate endorsements and does not query RPC.
+
+## Wallet-authorized unbinding verification
+
+`verifyAccountUnbinding` verifies one wallet-authorized unbinding ceremony
+only. It takes the byte-exact canonical unbinding text, wallet signature,
+expected 20-byte wallet address, and expected 33-byte owner public key.
+
+1. Parse the supplied text under the canonical unbinding grammar, reconstruct
+   it byte-for-byte, and require its `Wallet:` and `Owner-Key:` fields to equal
+   `expectedWalletAddress` and `expectedOwnerPublicKey`. Reject any
+   noncanonical text, field mismatch, CR, trailing LF, binding statement, or
+   binding domain tag before treating the signature as a revocation.
+2. Classify the wallet signature.
+   - `smartWalletUnsupported` returns an unverified smart-wallet result.
+   - `invalid` returns an invalid-shape result.
+3. Parse `r || s || v` from the 65-byte signature.
+4. Normalize `v = 27` to recovery ID 0 and `v = 28` to recovery ID 1. Raw
+   `v = 0` and `v = 1` are also accepted. Reject every other value.
+5. Require valid non-zero `r` and `s` scalars and low-S.
+6. Compute the EIP-191 digest and recover the public key with the existing
+   recovery primitive. Recovery IDs 2 and 3 remain unsupported deliberately.
+7. Derive the recovered Ethereum address and compare it byte-for-byte with
+   `expectedWalletAddress`.
+8. Only if the canonical unbinding and wallet signature pass, return `valid`.
+
+The wallet-signed unbinding has no owner-acknowledgement step. A conforming
+verifier MUST NOT require an owner signature or owner cooperation: a wallet
+can unilaterally revoke its binding to an owner key.
+
+The API does not aggregate revocations and does not query RPC.
 
 ## Smart-wallet verifier port
 

--- a/specs/092-owner-key/spec.md
+++ b/specs/092-owner-key/spec.md
@@ -203,6 +203,8 @@ transfer implicitly.
 
 Domain tag: `barnard-account-unbinding:v1`
 
+The owner-key-authorized path remains a Barnard-native message:
+
 ```text
 offset  size  value
 0       28    UTF-8 "barnard-account-unbinding:v1"
@@ -212,17 +214,16 @@ offset  size  value
 total  113
 ```
 
-The digest identifies one exact wallet-binding record. Either the owner key or
-the EOA key controlling `walletAddress` may sign the SHA-256 digest of this
-Barnard-native message. Verification therefore takes an explicit signer kind:
+The digest identifies one exact wallet-binding record. The owner key signs the
+SHA-256 digest of this message. Verification recovers the compressed key and
+requires it to equal `ownerPublicKey`.
 
-- `owner`: the recovered compressed key MUST equal `ownerPublicKey`;
-- `wallet`: the recovered key is decompressed, its Ethereum address is
-  derived, and that address MUST equal `walletAddress`.
-
-The wallet-signing host UX for this reserved lifecycle format is not part of
-v1. It is not the account-binding `personal_sign` ceremony and MUST NOT be
-silently substituted for it.
+The EOA-authorized path MUST NOT sign this raw digest. It uses the canonical
+human-readable account-unbinding text defined below, signs it through
+EIP-191 `personal_sign`, and verifies the recovered Ethereum address against
+`walletAddress`. The two signer paths deliberately retain different message
+formats because owner-key signatures are Barnard-native while wallet
+signatures must remain human-readable.
 
 ## Canonical wallet-binding text
 
@@ -302,6 +303,46 @@ Chain-ID: eip155:1
 Scope: global
 Nonce: 0x000102030405060708090a0b0c0d0e0f
 Issued-At: 2026-07-30T09:00:00Z
+```
+
+## Canonical wallet-authorized unbinding text
+
+An EOA revokes its wallet binding by signing this exact 11-line text:
+
+```text
+{domain} wants to revoke this wallet's binding to a Levarac owner key.
+
+This signature REVOKES a wallet binding and authorizes no transaction.
+
+Domain-Tag: barnard-account-unbinding:v1
+Wallet: 0x{walletAddress lowercase hex}
+Owner-Key: 0x{compressed owner public key lowercase hex}
+Chain-ID: eip155:{chainId unsigned decimal}
+Scope: global
+Nonce: 0x{16-byte nonce lowercase hex}
+Issued-At: {issuedAt}
+```
+
+The canonical encoding rules are identical to the wallet-binding text rules:
+UTF-8, LF only, exact field names and order, no trailing newline, normalized
+lowercase ASCII authority with a canonical optional port, lowercase fixed-size
+hex fields, unsigned 64-bit decimal `chainId`, literal `Scope: global`,
+16-byte `nonce`, and valid RFC 3339 UTC `issuedAt` at second precision. The
+host supplies `nonce` and `issuedAt`; Barnard reads neither randomness nor a
+clock. No Unicode normalization, checksum casing, JSON serialization, or
+locale-sensitive formatting is applied.
+
+The unbinding parser reconstructs the text byte-for-byte and requires the
+`Wallet:` and `Owner-Key:` fields to match the verifier's expected values.
+Binding text, another domain tag, CR, a trailing LF, a reordered field, or a
+noncanonical value is invalid even when the signature matches the altered
+bytes.
+
+For the same example values as the binding ceremony, the EIP-191 digest of the
+430-byte unbinding text is:
+
+```text
+f11e3d04d85d6ac228dde88cebea4ba9554ed06b9c363d5a32f3e4fd89366929
 ```
 
 ## EIP-191 and Ethereum address derivation
@@ -425,13 +466,20 @@ custodial recovery service.
 
 ## Compatibility
 
-- All schemas and APIs in this specification are additive.
-- No existing public schema or on-wire format changes.
+- The wallet-authorized unbinding format and verification semantics are
+  corrected before their first release tag; no previously tagged contract
+  accepts the superseded raw-digest wallet signature.
+- The owner-key-authorized unbinding shape and verification behavior remain
+  unchanged. The canonical wallet text builder and verifier are additive.
+- The holder-held account-unbinding schema is amended before the v0.2.0 tag.
+  No public/on-wire schema or format changes.
 - Existing Advertise, Scan, Central, Peripheral, GATT, Transport, RPID,
   event-signing, and RPID-proof behavior remains unchanged.
 - New domain tags are disjoint from existing Barnard tags.
-- EIP-191 prefixing and Ethereum Keccak keep wallet signatures in a different
-  hash universe from Barnard-native SHA-256 signatures.
+- Wallet-authorized binding and unbinding signatures use EIP-191 plus Ethereum
+  Keccak; owner-key acknowledgements, rotations, and unbindings use
+  Barnard-native SHA-256. No verification path accepts one signature class as
+  the other.
 
 ## Security and privacy
 
@@ -445,11 +493,14 @@ document root explicitly declares holder-held disclosure scope. Public/on-wire
 schemas MUST NOT define a 33-byte compressed-public-key shape, a 20-byte
 address shape, or references into holder-held schemas.
 
-The wallet ceremony has three domain-separation layers:
+The wallet ceremonies have three domain-separation layers:
 
 1. EIP-191 prevents cross-use as a transaction or Barnard-native signature.
-2. `Domain-Tag: barnard-account-binding:v1` prevents cross-protocol reuse.
-3. The visible domain and no-assets statement reduce blind-signing risk.
+2. Distinct `barnard-account-binding:v1` and
+   `barnard-account-unbinding:v1` domain tags prevent cross-protocol and
+   bind-versus-revoke reuse.
+3. The visible domain and explicit non-transaction statements reduce
+   blind-signing risk.
 
 Wallet linkage intentionally connects disclosed event history to a public
 address. Hosts MUST request explicit consent and MUST NOT auto-prompt binding.
@@ -487,6 +538,9 @@ Using a fresh wallet address remains valid.
   no expiry semantics.
 - A binding text without the no-assets statement: rejected because the
   ceremony must remain human-readable and explicitly non-transactional.
+- Raw-digest wallet-authorized unbinding: rejected because `eth_sign`-style
+  blind signing contradicts the readable wallet ceremony; EIP-191
+  `personal_sign` is required.
 
 ## Future work
 


### PR DESCRIPTION
Integrates `release/0.2.0` into `main` for the v0.2.0 release, per RELEASING.md.

**Milestone 0.2.0 contents** (every PR gated: CI + maker≠checker + CodeRabbit where post-install):

| Issue | PR | Squash SHA |
|---|---|---|
| #81 mirror canonicality flip | #91 | 95cf83f |
| #76 Android RPID memoization | #93 | d258f18 |
| #92 owner key spec + implementation | #96 | df06501 |
| #97 unbinding EIP-191 ceremony | #101 | d7badaf |
| #89 manifest guard + podspec | #99 | 8c33663 |
| #103 pre-tag spec/API polish | #106 | 32dbcc4 |
| #86 C ABI follow-ups | #100 | 7b8f620 |

Infra on the branch: #94 release-branch CI, #95 concurrency+timeouts, #98 timeout 50m, #102 CodeRabbit config (+#105 already on main).

Branch tip 7b8f620 is fully green (Dart 4m30s / Swift-Android 1m27s / Native SDK 37m29s). Tag `v0.2.0` will be pushed on the merge commit. #90 (Maven Central publication of the tagged version) follows post-tag per maintainer ruling.

This is a MERGE (not squash) to preserve the release history on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added owner-key generation, self-proofs, wallet binding, account rotation, and unbinding support.
  * Added Keccak-256 and EIP-191 digest capabilities.
  * Added strict schemas for self-proof and wallet-account records.
  * Added safer ENIN handling for values outside supported ranges.

* **Performance**
  * Improved Android payload generation by reusing results when event state is unchanged.

* **Bug Fixes**
  * Improved malformed input handling and Android packaging checks.

* **Documentation**
  * Clarified native package sources and synchronized Flutter mirrors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->