### PR TITLE
ci(android): wire Maven Central publishing

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -152,6 +152,8 @@ jobs:
     # independently").
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: packages/android/barnard
@@ -159,6 +161,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -193,6 +196,8 @@ jobs:
   android-native-example:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: examples/android-native
@@ -200,6 +205,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -168,8 +168,17 @@ jobs:
         run: ./gradlew assembleDebug assembleRelease
       - name: gradle test (crypto/TEK/RPID + signing + engine/identity unit tests)
         run: ./gradlew test
-      - name: gradle Maven-local publication dry run
-        run: ./gradlew publishToMavenLocal
+      - name: gradle Maven-local publication and POM validation
+        run: |
+          ./gradlew publishToMavenLocal -Dmaven.repo.local="$GITHUB_WORKSPACE/.m2/repository"
+          version="$(git describe --tags --match 'v[0-9]*' --abbrev=0 | sed 's/^v//')"
+          pom="$GITHUB_WORKSPACE/.m2/repository/org/levarac/barnard/$version/barnard-$version.pom"
+          test -f "$pom"
+          grep -F '<groupId>org.levarac</groupId>' "$pom"
+          grep -F '<artifactId>barnard</artifactId>' "$pom"
+          grep -F "<version>$version</version>" "$pom"
+          grep -F '<name>MIT License</name>' "$pom"
+          grep -F '<connection>scm:git:git://github.com/levarac/barnard.git</connection>' "$pom"
 
   android-mirror-sync-check:
     # packages/android/barnard is the origin for Flutter-free

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -166,6 +166,8 @@ jobs:
         run: ./gradlew assembleDebug assembleRelease
       - name: gradle test (crypto/TEK/RPID + signing + engine/identity unit tests)
         run: ./gradlew test
+      - name: gradle Maven-local publication dry run
+        run: ./gradlew publishToMavenLocal
 
   android-mirror-sync-check:
     # packages/android/barnard is the origin for Flutter-free

--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -157,6 +157,8 @@ jobs:
         working-directory: packages/android/barnard
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -187,6 +189,8 @@ jobs:
         working-directory: examples/android-native
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -22,11 +23,12 @@ jobs:
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@d7793b545071e98d581d3bf084a51c3213318a07
         with:
           distribution: temurin
           java-version: "17"
@@ -45,5 +47,5 @@ jobs:
             echo "ORG_GRADLE_PROJECT_mavenCentralUsername=$username"
             echo "ORG_GRADLE_PROJECT_mavenCentralPassword=$password"
           } >> "$GITHUB_ENV"
-      - name: Publish release to Maven Central
+      - name: Publish and release to Maven Central
         run: ./gradlew publishToMavenCentral

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,0 +1,49 @@
+name: Publish Maven Central
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: publish-maven-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: packages/android/barnard
+    env:
+      MAVEN_CENTRAL_TOKEN_B64: ${{ secrets.MAVEN_CENTRAL_TOKEN_B64 }}
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Configure Maven Central credentials
+        run: |
+          token="$(printf '%s' "$MAVEN_CENTRAL_TOKEN_B64" | base64 --decode)"
+          username="${token%%:*}"
+          password="${token#*:}"
+          if [ "$username" = "$token" ] || [ -z "$username" ] || [ -z "$password" ]; then
+            echo "MAVEN_CENTRAL_TOKEN_B64 must decode to username:password" >&2
+            exit 1
+          fi
+          printf '::add-mask::%s\n' "$username"
+          printf '::add-mask::%s\n' "$password"
+          {
+            echo "ORG_GRADLE_PROJECT_mavenCentralUsername=$username"
+            echo "ORG_GRADLE_PROJECT_mavenCentralPassword=$password"
+          } >> "$GITHUB_ENV"
+      - name: Publish release to Maven Central
+        run: ./gradlew publishToMavenCentral

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,6 +13,23 @@ git tag vX.Y.Z && git push origin vX.Y.Z
 The first `v0.1.0` tag will be cut by the project lead after the root Swift
 package manifest is merged.
 
+## Publishing the Android library to Maven Central
+
+After the release tag is pushed and the one Maven Central credential secret
+(`MAVEN_CENTRAL_TOKEN_B64`, base64-encoded `username:password`) plus the two GPG
+signing secrets are configured, open **Actions**, select **Publish Maven
+Central**, choose that release tag in **Run workflow**, and run it. The workflow publishes
+`org.levarac:barnard` using the version derived from the selected `vX.Y.Z` tag.
+
+After the workflow succeeds, open [Maven Central](https://central.sonatype.com/)
+and verify that the deployment contains the expected version, POM metadata, AAR,
+sources JAR, javadoc JAR, and signatures before publishing the deployment there.
+
+For a local fallback, put `mavenCentralUsername`, `mavenCentralPassword`,
+`signingInMemoryKey`, and `signingInMemoryKeyPassword` in
+`~/.gradle/gradle.properties`. Then run the manual Maven Central publish command
+from `packages/android/barnard`.
+
 Revisit whole-monorepo versioning if repository size grows enough to hurt
 consumer fetches or if platforms genuinely need divergent versioning. At that
 point, evaluate a CI-published distribution repository.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,12 +23,13 @@ Central**, choose that release tag in **Run workflow**, and run it. The workflow
 
 After the workflow succeeds, open [Maven Central](https://central.sonatype.com/)
 and verify that the deployment contains the expected version, POM metadata, AAR,
-sources JAR, javadoc JAR, and signatures before publishing the deployment there.
+sources JAR, javadoc JAR, and signatures. The workflow automatically releases
+the validated deployment; no further Central Portal publish action is required.
 
 For a local fallback, put `mavenCentralUsername`, `mavenCentralPassword`,
 `signingInMemoryKey`, and `signingInMemoryKeyPassword` in
 `~/.gradle/gradle.properties`. Then run the manual Maven Central publish command
-from `packages/android/barnard`.
+from `packages/android/barnard`; it uses the same automatic release behavior.
 
 Revisit whole-monorepo versioning if repository size grows enough to hurt
 consumer fetches or if platforms genuinely need divergent versioning. At that

--- a/packages/android/barnard/build.gradle.kts
+++ b/packages/android/barnard/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 mavenPublishing {
     coordinates("org.levarac", "barnard", version.toString())
 
-    publishToMavenCentral()
+    publishToMavenCentral(automaticRelease = true)
     if (providers.gradleProperty("signingInMemoryKey").isPresent) {
         signAllPublications()
     }

--- a/packages/android/barnard/build.gradle.kts
+++ b/packages/android/barnard/build.gradle.kts
@@ -2,11 +2,22 @@
 
 plugins {
     id("com.android.library") version "8.11.1"
+    id("com.vanniktech.maven.publish") version "0.34.0"
     id("org.jetbrains.kotlin.android") version "2.2.20"
 }
 
-group = "org.levarac.barnard"
-version = "1.0-SNAPSHOT"
+val releaseVersion = providers.exec {
+    commandLine("git", "describe", "--tags", "--match", "v[0-9]*", "--abbrev=0")
+}.standardOutput.asText.map { tag ->
+    tag.trim().also {
+        require(Regex("v\\d+\\.\\d+\\.\\d+").matches(it)) {
+            "Expected the nearest release tag to match vX.Y.Z, but found $it"
+        }
+    }.removePrefix("v")
+}
+
+group = "org.levarac"
+version = releaseVersion.get()
 
 android {
     namespace = "org.levarac.barnard"
@@ -46,4 +57,41 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.test:core:1.5.0")
     testImplementation("org.robolectric:robolectric:4.11.1")
+}
+
+mavenPublishing {
+    coordinates("org.levarac", "barnard", version.toString())
+
+    publishToMavenCentral()
+    if (providers.gradleProperty("signingInMemoryKey").isPresent) {
+        signAllPublications()
+    }
+
+    pom {
+        name.set("Barnard")
+        description.set("Barnard protocol SDK for Android")
+        url.set("https://github.com/levarac/barnard")
+
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://github.com/levarac/barnard/blob/main/LICENSE")
+                distribution.set("repo")
+            }
+        }
+
+        developers {
+            developer {
+                id.set("levarac")
+                name.set("Levarac")
+                url.set("https://github.com/levarac/barnard/issues")
+            }
+        }
+
+        scm {
+            url.set("https://github.com/levarac/barnard")
+            connection.set("scm:git:git://github.com/levarac/barnard.git")
+            developerConnection.set("scm:git:ssh://git@github.com/levarac/barnard.git")
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- configure the Android AAR for Maven Central as `org.levarac:barnard`, with version derived from the nearest `vX.Y.Z` tag
- add a manual-only Maven Central workflow that masks and exports decoded Portal credentials before publishing
- prove the release publication with `publishToMavenLocal` in Native SDK CI and document the maintainer runbook

## Validation

- `./gradlew publishToMavenLocal` (with a workspace-local Maven repository)
- generated POM inspection

Refs #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for publishing Android releases to Maven Central.
  * Added release versioning based on Git tags, including format validation and Maven package metadata.
  * Added optional package signing for secure publication.
  * Added validation for local Maven publication during CI.

* **Documentation**
  * Added instructions for publishing Android releases, managing credentials, verifying deployments, and using a local fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->