### PR TITLE
ci: dispatch publish workflow from main with a tag input

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -2,9 +2,13 @@ name: Publish Maven Central
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (vX.Y.Z)"
+        required: true
 
 concurrency:
-  group: publish-maven-${{ github.ref }}
+  group: publish-maven-${{ inputs.tag }}
   cancel-in-progress: false
 
 permissions:
@@ -12,7 +16,6 @@ permissions:
 
 jobs:
   publish:
-    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -23,8 +26,16 @@ jobs:
       ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKey }}
       ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingInMemoryKeyPassword }}
     steps:
+      - name: Validate tag input
+        working-directory: .
+        run: |
+          case "${{ inputs.tag }}" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "tag must look like vX.Y.Z" >&2; exit 1 ;;
+          esac
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
+          ref: ${{ inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
       - name: Set up JDK 17


### PR DESCRIPTION
First publish attempt hit 'Workflow does not exist or does not have a workflow_dispatch trigger in this tag' — `workflow_dispatch` runs the workflow file at the SELECTED ref, and `v0.2.0` predates the workflow (#108 landed after the tag). Fix: dispatch from `main` with a required `tag` input (shape-validated), `actions/checkout` at that tag. The deliberate-publish property is preserved (manual dispatch + explicit tag input); version derivation from the checked-out tag is unchanged. Masking/credential logic untouched. Milestone 0.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Maven publishing can now be started manually with a specified release tag.
  * Added validation to ensure the provided tag uses the expected format.
  * Publishing runs are grouped by tag to help prevent overlapping releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->