### PR TITLE
ci: strip whitespace before decoding the Maven Central token

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -45,7 +45,7 @@ jobs:
           java-version: "17"
       - name: Configure Maven Central credentials
         run: |
-          token="$(printf '%s' "$MAVEN_CENTRAL_TOKEN_B64" | base64 --decode)"
+          token="$(printf '%s' "$MAVEN_CENTRAL_TOKEN_B64" | tr -d '[:space:]' | base64 --decode)"
           username="${token%%:*}"
           password="${token#*:}"
           if [ "$username" = "$token" ] || [ -z "$username" ] || [ -z "$password" ]; then


### PR DESCRIPTION
One line: `tr -d '[:space:]'` before `base64 --decode`. Pasted secrets routinely carry trailing newlines or line-wrap whitespace, and GNU base64 rejects them with the exact 'invalid input' seen on the first publish dispatch (run 30675311310). Whitespace is never legitimate inside a base64 payload, so stripping is safe. Milestone 0.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Maven Central publishing reliability by handling whitespace in encoded credentials correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->