### PR TITLE
ci: build publish artifacts from main, guard tag identity

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -35,9 +35,16 @@ jobs:
           esac
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: ${{ inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Verify tag and library-source identity
+        working-directory: .
+        run: |
+          tag="${{ inputs.tag }}"
+          git rev-parse -q --verify "refs/tags/$tag" >/dev/null || { echo "tag $tag does not exist" >&2; exit 1; }
+          nearest="$(git describe --tags --match 'v[0-9]*' --abbrev=0)"
+          [ "$nearest" = "$tag" ] || { echo "nearest release tag is $nearest, not $tag - version derivation would mismatch the requested tag" >&2; exit 1; }
+          git diff --quiet "$tag" HEAD -- packages/android/barnard || { echo "library sources differ between $tag and the build tree - refusing to publish non-tag content under the tag's version" >&2; git diff --stat "$tag" HEAD -- packages/android/barnard >&2; exit 1; }
       - name: Set up JDK 17
         uses: actions/setup-java@d7793b545071e98d581d3bf084a51c3213318a07
         with:


### PR DESCRIPTION
Second time-paradox fix: the publishing config itself postdates v0.2.0, so checking out the tag has no publishToMavenCentral task (dispatch 30677508980). Build from the dispatch ref (main) — version derivation already resolves to the nearest v-tag — and make the `tag` input enforce three guards: tag exists; `git describe --abbrev=0` == input (derived version matches the request, also blocks accidentally republishing an old version after a newer tag exists); `git diff --quiet <tag> HEAD -- packages/android/barnard` (published content is byte-identical to the tag). Milestone 0.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing validation to ensure the requested tag is valid, current, and matches the library source before publishing.
  * Reduced the risk of publishing artifacts from an incorrect or outdated release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->