### PR TITLE
ci: allow build.gradle.kts to differ in the tag-identity guard

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -44,7 +44,14 @@ jobs:
           git rev-parse -q --verify "refs/tags/$tag" >/dev/null || { echo "tag $tag does not exist" >&2; exit 1; }
           nearest="$(git describe --tags --match 'v[0-9]*' --abbrev=0)"
           [ "$nearest" = "$tag" ] || { echo "nearest release tag is $nearest, not $tag - version derivation would mismatch the requested tag" >&2; exit 1; }
-          git diff --quiet "$tag" HEAD -- packages/android/barnard || { echo "library sources differ between $tag and the build tree - refusing to publish non-tag content under the tag's version" >&2; git diff --stat "$tag" HEAD -- packages/android/barnard >&2; exit 1; }
+          # build.gradle.kts is allowed to differ: the publishing config itself
+          # postdates v0.2.0. Everything else under the library must be identical.
+          changed="$(git diff --name-only "$tag" HEAD -- packages/android/barnard | grep -v '^packages/android/barnard/build.gradle.kts$' || true)"
+          if [ -n "$changed" ]; then
+            echo "library sources differ between $tag and the build tree - refusing to publish non-tag content under the tag's version" >&2
+            printf '%s\n' "$changed" >&2
+            exit 1
+          fi
       - name: Set up JDK 17
         uses: actions/setup-java@d7793b545071e98d581d3bf084a51c3213318a07
         with:


### PR DESCRIPTION
The guard from #111 fired on its own enabling change: the only diff between v0.2.0 and main under packages/android/barnard is build.gradle.kts (+50, the publishing config added by #108). Refine: every file except the build script must be byte-identical to the tag. Also observed on the same dispatch and being fixed separately: the signing key secret appears to be EMPTY (env rendered blank instead of masked) - being re-loaded by the maintainer. Milestone 0.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release validation to allow expected build configuration differences when checking tagged sources.
  * Release checks now identify each unexpected file difference before failing, making validation results clearer and easier to troubleshoot.
  * No changes were made to exported or public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->