### PR TITLE
feat(event-info): add B005 GATT discovery

### DIFF
--- a/examples/android-native/app/src/androidTest/kotlin/org/levarac/barnard/example/devicelab/BarnardDeviceLabTest.kt
+++ b/examples/android-native/app/src/androidTest/kotlin/org/levarac/barnard/example/devicelab/BarnardDeviceLabTest.kt
@@ -184,6 +184,9 @@ class BarnardScannerDeviceLabTest {
                     is BarnardEvent.Error -> marker(
                         "BARNARD_EVT error code=${event.error.code} message=${event.error.message}",
                     )
+                    is BarnardEvent.EventInfoHint -> marker(
+                        "BARNARD_EVT event_info_hint name=${event.hint.eventInfo.eventDisplayName}",
+                    )
                 }
             }
         }

--- a/examples/android-native/app/src/androidTest/kotlin/org/levarac/barnard/example/devicelab/BarnardDeviceLabTest.kt
+++ b/examples/android-native/app/src/androidTest/kotlin/org/levarac/barnard/example/devicelab/BarnardDeviceLabTest.kt
@@ -185,7 +185,9 @@ class BarnardScannerDeviceLabTest {
                         "BARNARD_EVT error code=${event.error.code} message=${event.error.message}",
                     )
                     is BarnardEvent.EventInfoHint -> marker(
-                        "BARNARD_EVT event_info_hint name=${event.hint.eventInfo.eventDisplayName}",
+                        "BARNARD_EVT event_info_hint name=${event.hint.eventInfo.eventDisplayName} " +
+                            "additionalNamesOmitted=${event.hint.additionalNamesOmitted} " +
+                            "additionalEventsOmitted=${event.hint.additionalEventsOmitted}",
                     )
                 }
             }

--- a/examples/android-native/app/src/main/kotlin/org/levarac/barnard/example/MainActivity.kt
+++ b/examples/android-native/app/src/main/kotlin/org/levarac/barnard/example/MainActivity.kt
@@ -101,6 +101,11 @@ class MainActivity : AppCompatActivity() {
             is BarnardEvent.Constraint -> {
                 append("constraint: ${event.constraint.code} ${event.constraint.message ?: ""}")
             }
+            is BarnardEvent.EventInfoHint -> {
+                val hint = event.hint
+                append("event_info_hint: name=${hint.eventInfo.eventDisplayName} " +
+                    "additionalNamesOmitted=${hint.additionalNamesOmitted} additionalEventsOmitted=${hint.additionalEventsOmitted}")
+            }
         }
     }
 

--- a/examples/ios-native/BarnardNativeExample/ContentView.swift
+++ b/examples/ios-native/BarnardNativeExample/ContentView.swift
@@ -37,6 +37,8 @@ final class BarnardExampleModel: ObservableObject {
       append("error: \(error.code) \(error.message)")
     case .constraint(let constraint):
       append("constraint: \(constraint.code) \(constraint.message ?? "")")
+    case .eventInfoHint(let hint):
+      append("event_info_hint: name=\(hint.eventInfo.eventDisplayName) additionalNamesOmitted=\(hint.additionalNamesOmitted) additionalEventsOmitted=\(hint.additionalEventsOmitted)")
     }
   }
 

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -124,7 +124,8 @@ public class BarnardEngine(private val appContext: Context) {
     private var eventInfoServePolicy = BarnardEventInfoServePolicy()
     @Volatile
     private var eventInfoDisplayName: String? = null
-    private data class EventInfoSnapshot(val value: ByteArray, var lastRequestAtMs: Long)
+    private data class EventInfoSnapshot(val value: ByteArray, @Volatile var lastRequestAtMs: Long)
+    private val eventInfoStateLock = Any()
     private val eventInfoConnectionEpochs: MutableMap<String, Long> = ConcurrentHashMap()
     private val eventInfoSnapshots: MutableMap<String, EventInfoSnapshot> = ConcurrentHashMap()
     private val eventInfoRetryBudget = BarnardEventInfoRetryBudget()
@@ -393,8 +394,10 @@ public class BarnardEngine(private val appContext: Context) {
 
     public fun startScan(allowDuplicates: Boolean = true) {
         if (!isScanning) {
-            eventInfoRetryBudget.clearAll()
-            eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(System.currentTimeMillis())
+            synchronized(eventInfoStateLock) {
+                eventInfoRetryBudget.clearAll()
+                eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(System.currentTimeMillis())
+            }
         }
         this.allowDuplicates = allowDuplicates
         startScanInternal()
@@ -590,8 +593,10 @@ public class BarnardEngine(private val appContext: Context) {
         resolutionBackoffUntilMs.clear()
         pendingBoundaryRetryDevices.clear()
         boundaryRetryBudget.clearAll()
-        eventInfoRetryBudget.clearAll()
-        eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(System.currentTimeMillis())
+        synchronized(eventInfoStateLock) {
+            eventInfoRetryBudget.clearAll()
+            eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(System.currentTimeMillis())
+        }
         peripheralReadValues.clear()
         knownPeers.clear()
 
@@ -691,8 +696,10 @@ public class BarnardEngine(private val appContext: Context) {
         isAdvertising = false
         gattServer?.close()
         gattServer = null
-        eventInfoConnectionEpochs.clear()
-        eventInfoSnapshots.clear()
+        synchronized(eventInfoStateLock) {
+            eventInfoConnectionEpochs.clear()
+            eventInfoSnapshots.clear()
+        }
         emitState("advertise_stop")
         emitDebug("info", "advertise_stop", null)
     }
@@ -817,7 +824,9 @@ public class BarnardEngine(private val appContext: Context) {
     }
 
     private fun emitEventInfoHint(address: String, eventInfo: BarnardEventInfo) {
-        val observation = eventInfoDiscoverySession.observe(eventInfo, System.currentTimeMillis())
+        val observation = synchronized(eventInfoStateLock) {
+            eventInfoDiscoverySession.observe(eventInfo, System.currentTimeMillis())
+        }
         val hint = BarnardEventInfoHintEvent(
             peripheralId = address,
             eventInfo = eventInfo,
@@ -1637,9 +1646,11 @@ public class BarnardEngine(private val appContext: Context) {
         @SuppressLint("MissingPermission")
         override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
             val address = device.address ?: return
-            eventInfoSnapshots.keys.removeAll { it.startsWith("$address:") }
-            if (newState == BluetoothProfile.STATE_CONNECTED) {
-                eventInfoConnectionEpochs[address] = (eventInfoConnectionEpochs[address] ?: 0L) + 1L
+            synchronized(eventInfoStateLock) {
+                eventInfoSnapshots.keys.removeAll { it.startsWith("$address:") }
+                if (newState == BluetoothProfile.STATE_CONNECTED) {
+                    eventInfoConnectionEpochs[address] = (eventInfoConnectionEpochs[address] ?: 0L) + 1L
+                }
             }
         }
 
@@ -1737,39 +1748,41 @@ public class BarnardEngine(private val appContext: Context) {
 
     @SuppressLint("MissingPermission")
     private fun respondEventInfoRead(server: BluetoothGattServer, device: BluetoothDevice, requestId: Int, offset: Int) {
-        val now = System.currentTimeMillis()
-        eventInfoSnapshots.entries.removeIf { now - it.value.lastRequestAtMs > 30_000L }
-        val address = device.address ?: ""
-        val key = "$address:${eventInfoConnectionEpochs[address] ?: 0L}"
-        if (offset == 0) {
-            val payload = try {
-                BarnardEventInfoCodec.payloadIfServing(
-                    eventInfoServePolicy,
-                    eventCode,
-                    eventInfoDisplayName,
-                    getEventCodeHash(),
-                )
-            } catch (_: IllegalArgumentException) {
-                null
+        synchronized(eventInfoStateLock) {
+            val now = System.currentTimeMillis()
+            eventInfoSnapshots.entries.removeIf { now - it.value.lastRequestAtMs > 30_000L }
+            val address = device.address ?: ""
+            val key = "$address:${eventInfoConnectionEpochs[address] ?: 0L}"
+            if (offset == 0) {
+                val payload = try {
+                    BarnardEventInfoCodec.payloadIfServing(
+                        eventInfoServePolicy,
+                        eventCode,
+                        eventInfoDisplayName,
+                        getEventCodeHash(),
+                    )
+                } catch (_: IllegalArgumentException) {
+                    null
+                }
+                if (payload == null) {
+                    server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+                    return
+                }
+                eventInfoSnapshots[key] = EventInfoSnapshot(payload, now)
             }
-            if (payload == null) {
-                server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+            val snapshot = eventInfoSnapshots[key]
+            if (snapshot == null) {
+                server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
                 return
             }
-            eventInfoSnapshots[key] = EventInfoSnapshot(payload, now)
+            if (offset > snapshot.value.size) {
+                eventInfoSnapshots.remove(key)
+                server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
+                return
+            }
+            val slice = if (offset == snapshot.value.size) ByteArray(0) else snapshot.value.copyOfRange(offset, snapshot.value.size)
+            server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+            if (offset == snapshot.value.size) eventInfoSnapshots.remove(key) else snapshot.lastRequestAtMs = now
         }
-        val snapshot = eventInfoSnapshots[key]
-        if (snapshot == null) {
-            server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
-            return
-        }
-        if (offset > snapshot.value.size) {
-            eventInfoSnapshots.remove(key)
-            server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
-            return
-        }
-        val slice = if (offset == snapshot.value.size) ByteArray(0) else snapshot.value.copyOfRange(offset, snapshot.value.size)
-        server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
-        if (offset == snapshot.value.size) eventInfoSnapshots.remove(key) else snapshot.lastRequestAtMs = now
     }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -291,6 +291,7 @@ public class BarnardEngine(private val appContext: Context) {
         eventActiveForDiscovery: Boolean = false,
         eventDisplayName: String? = null,
     ) {
+        eventDisplayName?.let(BarnardEventInfoCodec::validateEventDisplayName)
         eventInfoServePolicy = BarnardEventInfoServePolicy(organizerDesignated, eventActiveForDiscovery)
         eventInfoDisplayName = eventDisplayName
     }
@@ -679,6 +680,8 @@ public class BarnardEngine(private val appContext: Context) {
         isAdvertising = false
         gattServer?.close()
         gattServer = null
+        eventInfoConnectionEpochs.clear()
+        eventInfoSnapshots.clear()
         emitState("advertise_stop")
         emitDebug("info", "advertise_stop", null)
     }
@@ -1349,8 +1352,7 @@ public class BarnardEngine(private val appContext: Context) {
             // B005 is read before, but never gated by, B004 same-event resolution.
             val eventInfoCh = svc.getCharacteristic(eventInfoCharUuid)
             if (eventInfoCh != null && hasConnectPermission()) {
-                gatt.readCharacteristic(eventInfoCh)
-                return
+                if (gatt.readCharacteristic(eventInfoCh)) return
             }
             readB004ForResolution(gatt, svc)
         }
@@ -1359,7 +1361,13 @@ public class BarnardEngine(private val appContext: Context) {
         private fun readB004ForResolution(gatt: BluetoothGatt, svc: BluetoothGattService) {
             val eventCodeHashCh = svc.getCharacteristic(eventCodeHashCharUuid)
             if (eventCodeHashCh != null && hasConnectPermission()) {
-                gatt.readCharacteristic(eventCodeHashCh)
+                if (gatt.readCharacteristic(eventCodeHashCh)) return
+                markGattResolutionFailed(
+                    address = gatt.device?.address ?: "",
+                    reason = "b004_read_not_started",
+                    recoverable = true
+                )
+                finishConnection(gatt)
             } else {
                 markGattResolutionFailed(
                     address = gatt.device?.address ?: "",
@@ -1432,9 +1440,8 @@ public class BarnardEngine(private val appContext: Context) {
                         val hint = BarnardEventInfoCodec.parse(value)
                         emitDebug("info", "gatt_event_info_hint", mapOf(
                             "address" to address,
-                            "displayName" to hint.eventDisplayName,
                             "eventCodeHash" to hint.eventCodeHash.toHex(),
-                        ))
+                        ) + if (isDebugBuild()) mapOf("displayName" to hint.eventDisplayName) else emptyMap())
                     } catch (_: IllegalArgumentException) {
                         emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address))
                     }
@@ -1564,8 +1571,12 @@ public class BarnardEngine(private val appContext: Context) {
         @SuppressLint("MissingPermission")
         override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
             val address = device.address ?: return
-            eventInfoConnectionEpochs[address] = (eventInfoConnectionEpochs[address] ?: 0L) + 1L
             eventInfoSnapshots.keys.removeAll { it.startsWith("$address:") }
+            if (newState == BluetoothProfile.STATE_CONNECTED) {
+                eventInfoConnectionEpochs[address] = (eventInfoConnectionEpochs[address] ?: 0L) + 1L
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                eventInfoConnectionEpochs.remove(address)
+            }
         }
 
         @SuppressLint("MissingPermission")

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -36,6 +36,7 @@ import android.util.Base64
 import android.util.Log
 import org.levarac.barnard.BarnardCrypto.toHex
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 private const val TAG = "BarnardEngine"
 
@@ -119,11 +120,15 @@ public class BarnardEngine(private val appContext: Context) {
     // MARK: - Event Mode
 
     private var eventCode: String? = null
+    @Volatile
     private var eventInfoServePolicy = BarnardEventInfoServePolicy()
+    @Volatile
     private var eventInfoDisplayName: String? = null
     private data class EventInfoSnapshot(val value: ByteArray, var lastRequestAtMs: Long)
-    private val eventInfoConnectionEpochs: MutableMap<String, Long> = mutableMapOf()
-    private val eventInfoSnapshots: MutableMap<String, EventInfoSnapshot> = mutableMapOf()
+    private val eventInfoConnectionEpochs: MutableMap<String, Long> = ConcurrentHashMap()
+    private val eventInfoSnapshots: MutableMap<String, EventInfoSnapshot> = ConcurrentHashMap()
+    private val eventInfoRetryBudget = BarnardEventInfoRetryBudget()
+    private var eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(System.currentTimeMillis())
     @Volatile
     private var currentTek: ByteArray = ByteArray(16)
 
@@ -387,6 +392,10 @@ public class BarnardEngine(private val appContext: Context) {
     }
 
     public fun startScan(allowDuplicates: Boolean = true) {
+        if (!isScanning) {
+            eventInfoRetryBudget.clearAll()
+            eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(System.currentTimeMillis())
+        }
         this.allowDuplicates = allowDuplicates
         startScanInternal()
     }
@@ -581,6 +590,8 @@ public class BarnardEngine(private val appContext: Context) {
         resolutionBackoffUntilMs.clear()
         pendingBoundaryRetryDevices.clear()
         boundaryRetryBudget.clearAll()
+        eventInfoRetryBudget.clearAll()
+        eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(System.currentTimeMillis())
         peripheralReadValues.clear()
         knownPeers.clear()
 
@@ -803,6 +814,17 @@ public class BarnardEngine(private val appContext: Context) {
     private fun emitError(code: String, message: String, recoverable: Boolean? = null) {
         val error = BarnardErrorEvent(code = code, message = message, recoverable = recoverable)
         mainHandler.post { onEvent?.invoke(BarnardEvent.Error(error)) }
+    }
+
+    private fun emitEventInfoHint(address: String, eventInfo: BarnardEventInfo) {
+        val observation = eventInfoDiscoverySession.observe(eventInfo, System.currentTimeMillis())
+        val hint = BarnardEventInfoHintEvent(
+            peripheralId = address,
+            eventInfo = eventInfo,
+            additionalNamesOmitted = observation.additionalNamesOmitted,
+            additionalEventsOmitted = observation.additionalEventsOmitted,
+        )
+        mainHandler.post { onEvent?.invoke(BarnardEvent.EventInfoHint(hint)) }
     }
 
     /**
@@ -1349,11 +1371,6 @@ public class BarnardEngine(private val appContext: Context) {
                 return
             }
 
-            // B005 is read before, but never gated by, B004 same-event resolution.
-            val eventInfoCh = svc.getCharacteristic(eventInfoCharUuid)
-            if (eventInfoCh != null && hasConnectPermission()) {
-                if (gatt.readCharacteristic(eventInfoCh)) return
-            }
             readB004ForResolution(gatt, svc)
         }
 
@@ -1378,6 +1395,40 @@ public class BarnardEngine(private val appContext: Context) {
                     "address" to (gatt.device?.address ?: "")
                 ))
                 finishConnection(gatt)
+            }
+        }
+
+        @SuppressLint("MissingPermission")
+        private fun readEventInfoAfterResolution(gatt: BluetoothGatt, svc: BluetoothGattService) {
+            val address = gatt.device?.address ?: ""
+            val eventInfoCh = svc.getCharacteristic(eventInfoCharUuid)
+            if (eventInfoCh == null || !hasConnectPermission()) {
+                eventInfoRetryBudget.recordSemanticUnavailable(address)
+                emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address, "reason" to "missing"))
+                finishConnection(gatt)
+                return
+            }
+            if (!eventInfoRetryBudget.canStart(address, System.currentTimeMillis())) {
+                finishConnection(gatt)
+                return
+            }
+            if (!gatt.readCharacteristic(eventInfoCh)) retryEventInfoRead(gatt, "read_not_started")
+        }
+
+        private fun retryEventInfoRead(gatt: BluetoothGatt, reason: String) {
+            val address = gatt.device?.address ?: ""
+            val nowMs = System.currentTimeMillis()
+            val deadlineMs = eventInfoRetryBudget.recordRecoverableFailure(address, nowMs)
+            emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address, "reason" to reason))
+            val device = gatt.device
+            finishConnection(gatt)
+            if (deadlineMs != null && device != null) {
+                mainHandler.postDelayed({
+                    if (isScanning) {
+                        lastConnectAttemptAtMs.remove(address)
+                        enqueueConnect(device)
+                    }
+                }, deadlineMs - nowMs)
             }
         }
 
@@ -1407,8 +1458,13 @@ public class BarnardEngine(private val appContext: Context) {
             // with detectedDisplayId=null. B002/B004 failures still drop.
             if (status != BluetoothGatt.GATT_SUCCESS) {
                 if (uuid == eventInfoCharUuid) {
-                    emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address))
-                    readB004ForResolution(gatt, svc)
+                    if (status == BluetoothGatt.GATT_READ_NOT_PERMITTED) {
+                        eventInfoRetryBudget.recordSemanticUnavailable(address)
+                        emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address, "reason" to "read_not_permitted"))
+                        finishConnection(gatt)
+                    } else {
+                        retryEventInfoRead(gatt, "status=$status")
+                    }
                     return
                 }
                 if (uuid == displayIdCharUuid) {
@@ -1442,10 +1498,13 @@ public class BarnardEngine(private val appContext: Context) {
                             "address" to address,
                             "eventCodeHash" to hint.eventCodeHash.toHex(),
                         ) + if (isDebugBuild()) mapOf("displayName" to hint.eventDisplayName) else emptyMap())
+                        eventInfoRetryBudget.clear(address)
+                        emitEventInfoHint(address, hint)
                     } catch (_: IllegalArgumentException) {
+                        eventInfoRetryBudget.recordSemanticUnavailable(address)
                         emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address))
                     }
-                    readB004ForResolution(gatt, svc)
+                    finishConnection(gatt)
                 }
                 eventCodeHashCharUuid -> {
                     peripheralReadValues[address]?.eventCodeHash = value
@@ -1467,7 +1526,7 @@ public class BarnardEngine(private val appContext: Context) {
                             "address" to address,
                             "bytes" to value.size
                         ))
-                        finishConnection(gatt)
+                        readEventInfoAfterResolution(gatt, svc)
                         return
                     }
                     val rpidCh = svc.getCharacteristic(rpidCharUuid)
@@ -1480,7 +1539,7 @@ public class BarnardEngine(private val appContext: Context) {
                             reason = "b002_missing",
                             recoverable = true
                         )
-                        finishConnection(gatt)
+                        readEventInfoAfterResolution(gatt, svc)
                     }
                 }
 
@@ -1561,7 +1620,8 @@ public class BarnardEngine(private val appContext: Context) {
                 }
             }
 
-            finishConnection(gatt)
+            val svc = gatt.getService(serviceUuid)
+            if (svc == null) finishConnection(gatt) else readEventInfoAfterResolution(gatt, svc)
         }
     }
 
@@ -1574,8 +1634,6 @@ public class BarnardEngine(private val appContext: Context) {
             eventInfoSnapshots.keys.removeAll { it.startsWith("$address:") }
             if (newState == BluetoothProfile.STATE_CONNECTED) {
                 eventInfoConnectionEpochs[address] = (eventInfoConnectionEpochs[address] ?: 0L) + 1L
-            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
-                eventInfoConnectionEpochs.remove(address)
             }
         }
 

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -94,6 +94,7 @@ public class BarnardEngine(private val appContext: Context) {
     private val rpidCharUuid: UUID = UUID.fromString("0000B002-0000-1000-8000-00805F9B34FB")
     private val displayIdCharUuid: UUID = UUID.fromString("0000B003-0000-1000-8000-00805F9B34FB")
     private val eventCodeHashCharUuid: UUID = UUID.fromString("0000B004-0000-1000-8000-00805F9B34FB")
+    private val eventInfoCharUuid: UUID = UUID.fromString("0000B005-0000-1000-8000-00805F9B34FB")
 
     // MARK: - Bluetooth
 
@@ -118,6 +119,11 @@ public class BarnardEngine(private val appContext: Context) {
     // MARK: - Event Mode
 
     private var eventCode: String? = null
+    private var eventInfoServePolicy = BarnardEventInfoServePolicy()
+    private var eventInfoDisplayName: String? = null
+    private data class EventInfoSnapshot(val value: ByteArray, var lastRequestAtMs: Long)
+    private val eventInfoConnectionEpochs: MutableMap<String, Long> = mutableMapOf()
+    private val eventInfoSnapshots: MutableMap<String, EventInfoSnapshot> = mutableMapOf()
     @Volatile
     private var currentTek: ByteArray = ByteArray(16)
 
@@ -277,6 +283,16 @@ public class BarnardEngine(private val appContext: Context) {
             "eninSeconds" to this.eninSeconds,
             "beaconChain" to this.beaconChain.chainId,
         ))
+    }
+
+    /** Sets B005 serving state. This is local host state and defaults to off. */
+    public fun configureEventInfoServing(
+        organizerDesignated: Boolean = false,
+        eventActiveForDiscovery: Boolean = false,
+        eventDisplayName: String? = null,
+    ) {
+        eventInfoServePolicy = BarnardEventInfoServePolicy(organizerDesignated, eventActiveForDiscovery)
+        eventInfoDisplayName = eventDisplayName
     }
 
     public fun getCurrentEventCode(): String? = eventCode
@@ -720,10 +736,17 @@ public class BarnardEngine(private val appContext: Context) {
         )
         service.addCharacteristic(eventCodeHashCh)
 
+        val eventInfoCh = BluetoothGattCharacteristic(
+            eventInfoCharUuid,
+            BluetoothGattCharacteristic.PROPERTY_READ,
+            BluetoothGattCharacteristic.PERMISSION_READ,
+        )
+        service.addCharacteristic(eventInfoCh)
+
         server.addService(service)
         gattServer = server
         emitDebug("info", "gatt_server_started", mapOf(
-            "characteristics" to listOf("RPID", "displayId", "EventCodeHash")
+            "characteristics" to listOf("RPID", "displayId", "EventCodeHash", "eventInfo")
         ))
     }
 
@@ -1323,7 +1346,17 @@ public class BarnardEngine(private val appContext: Context) {
                 return
             }
 
-            // v2 flow: B004 gates B002 -> B003
+            // B005 is read before, but never gated by, B004 same-event resolution.
+            val eventInfoCh = svc.getCharacteristic(eventInfoCharUuid)
+            if (eventInfoCh != null && hasConnectPermission()) {
+                gatt.readCharacteristic(eventInfoCh)
+                return
+            }
+            readB004ForResolution(gatt, svc)
+        }
+
+        @SuppressLint("MissingPermission")
+        private fun readB004ForResolution(gatt: BluetoothGatt, svc: BluetoothGattService) {
             val eventCodeHashCh = svc.getCharacteristic(eventCodeHashCharUuid)
             if (eventCodeHashCh != null && hasConnectPermission()) {
                 gatt.readCharacteristic(eventCodeHashCh)
@@ -1365,6 +1398,11 @@ public class BarnardEngine(private val appContext: Context) {
             // v2 failure policy: B003 read failure keeps the detection flow alive
             // with detectedDisplayId=null. B002/B004 failures still drop.
             if (status != BluetoothGatt.GATT_SUCCESS) {
+                if (uuid == eventInfoCharUuid) {
+                    emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address))
+                    readB004ForResolution(gatt, svc)
+                    return
+                }
                 if (uuid == displayIdCharUuid) {
                     emitDebug("warn", "gatt_b003_read_failed", mapOf(
                         "address" to address,
@@ -1389,6 +1427,19 @@ public class BarnardEngine(private val appContext: Context) {
             }
 
             when (uuid) {
+                eventInfoCharUuid -> {
+                    try {
+                        val hint = BarnardEventInfoCodec.parse(value)
+                        emitDebug("info", "gatt_event_info_hint", mapOf(
+                            "address" to address,
+                            "displayName" to hint.eventDisplayName,
+                            "eventCodeHash" to hint.eventCodeHash.toHex(),
+                        ))
+                    } catch (_: IllegalArgumentException) {
+                        emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address))
+                    }
+                    readB004ForResolution(gatt, svc)
+                }
                 eventCodeHashCharUuid -> {
                     peripheralReadValues[address]?.eventCodeHash = value
                     val matches = eventCodeHashMatches(value)
@@ -1511,6 +1562,13 @@ public class BarnardEngine(private val appContext: Context) {
 
     private val gattServerCallback = object : BluetoothGattServerCallback() {
         @SuppressLint("MissingPermission")
+        override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
+            val address = device.address ?: return
+            eventInfoConnectionEpochs[address] = (eventInfoConnectionEpochs[address] ?: 0L) + 1L
+            eventInfoSnapshots.keys.removeAll { it.startsWith("$address:") }
+        }
+
+        @SuppressLint("MissingPermission")
         override fun onCharacteristicReadRequest(
             device: BluetoothDevice,
             requestId: Int,
@@ -1571,6 +1629,10 @@ public class BarnardEngine(private val appContext: Context) {
                     ))
                 }
 
+                eventInfoCharUuid -> {
+                    respondEventInfoRead(server, device, requestId, offset)
+                }
+
                 else -> {
                     server.sendResponse(device, requestId, BluetoothGatt.GATT_REQUEST_NOT_SUPPORTED, offset, null)
                 }
@@ -1596,5 +1658,43 @@ public class BarnardEngine(private val appContext: Context) {
                 "uuid" to characteristic.uuid.toString(),
             ))
         }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun respondEventInfoRead(server: BluetoothGattServer, device: BluetoothDevice, requestId: Int, offset: Int) {
+        val now = System.currentTimeMillis()
+        eventInfoSnapshots.entries.removeIf { now - it.value.lastRequestAtMs > 30_000L }
+        val address = device.address ?: ""
+        val key = "$address:${eventInfoConnectionEpochs[address] ?: 0L}"
+        if (offset == 0) {
+            val payload = try {
+                BarnardEventInfoCodec.payloadIfServing(
+                    eventInfoServePolicy,
+                    eventCode,
+                    eventInfoDisplayName,
+                    getEventCodeHash(),
+                )
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+            if (payload == null) {
+                server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
+                return
+            }
+            eventInfoSnapshots[key] = EventInfoSnapshot(payload, now)
+        }
+        val snapshot = eventInfoSnapshots[key]
+        if (snapshot == null) {
+            server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
+            return
+        }
+        if (offset > snapshot.value.size) {
+            eventInfoSnapshots.remove(key)
+            server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
+            return
+        }
+        val slice = if (offset == snapshot.value.size) ByteArray(0) else snapshot.value.copyOfRange(offset, snapshot.value.size)
+        server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
+        if (offset == snapshot.value.size) eventInfoSnapshots.remove(key) else snapshot.lastRequestAtMs = now
     }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -1494,6 +1494,12 @@ public class BarnardEngine(private val appContext: Context) {
                 eventInfoCharUuid -> {
                     try {
                         val hint = BarnardEventInfoCodec.parse(value)
+                        if (!BarnardEventInfoCodec.matchesB004(hint, peripheralReadValues[address]?.eventCodeHash ?: ByteArray(0))) {
+                            eventInfoRetryBudget.recordSemanticUnavailable(address)
+                            emitDebug("info", "gatt_event_info_unavailable", mapOf("address" to address, "reason" to "b004_mismatch"))
+                            finishConnection(gatt)
+                            return
+                        }
                         emitDebug("info", "gatt_event_info_hint", mapOf(
                             "address" to address,
                             "eventCodeHash" to hint.eventCodeHash.toHex(),

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -1748,7 +1748,8 @@ public class BarnardEngine(private val appContext: Context) {
 
     @SuppressLint("MissingPermission")
     private fun respondEventInfoRead(server: BluetoothGattServer, device: BluetoothDevice, requestId: Int, offset: Int) {
-        synchronized(eventInfoStateLock) {
+        data class Outcome(val status: Int, val value: ByteArray?)
+        val outcome = synchronized(eventInfoStateLock) {
             val now = System.currentTimeMillis()
             eventInfoSnapshots.entries.removeIf { now - it.value.lastRequestAtMs > 30_000L }
             val address = device.address ?: ""
@@ -1765,24 +1766,22 @@ public class BarnardEngine(private val appContext: Context) {
                     null
                 }
                 if (payload == null) {
-                    server.sendResponse(device, requestId, BluetoothGatt.GATT_READ_NOT_PERMITTED, offset, null)
-                    return
+                    return@synchronized Outcome(BluetoothGatt.GATT_READ_NOT_PERMITTED, null)
                 }
                 eventInfoSnapshots[key] = EventInfoSnapshot(payload, now)
             }
             val snapshot = eventInfoSnapshots[key]
             if (snapshot == null) {
-                server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
-                return
+                return@synchronized Outcome(BluetoothGatt.GATT_INVALID_OFFSET, null)
             }
             if (offset > snapshot.value.size) {
                 eventInfoSnapshots.remove(key)
-                server.sendResponse(device, requestId, BluetoothGatt.GATT_INVALID_OFFSET, offset, null)
-                return
+                return@synchronized Outcome(BluetoothGatt.GATT_INVALID_OFFSET, null)
             }
             val slice = if (offset == snapshot.value.size) ByteArray(0) else snapshot.value.copyOfRange(offset, snapshot.value.size)
-            server.sendResponse(device, requestId, BluetoothGatt.GATT_SUCCESS, offset, slice)
             if (offset == snapshot.value.size) eventInfoSnapshots.remove(key) else snapshot.lastRequestAtMs = now
+            Outcome(BluetoothGatt.GATT_SUCCESS, slice)
         }
+        server.sendResponse(device, requestId, outcome.status, offset, outcome.value)
     }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngineTypes.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngineTypes.kt
@@ -144,12 +144,21 @@ public data class BarnardConstraintEvent(
     val requiredAction: String?,
 )
 
+/** Parsed B005 hint retained only for the current discovery session. */
+public data class BarnardEventInfoHintEvent(
+    val peripheralId: String,
+    val eventInfo: BarnardEventInfo,
+    val additionalNamesOmitted: Boolean,
+    val additionalEventsOmitted: Boolean,
+)
+
 public sealed class BarnardEvent {
     public data class State(val state: BarnardState) : BarnardEvent()
     public data class Constraint(val constraint: BarnardConstraintEvent) : BarnardEvent()
     public data class Error(val error: BarnardErrorEvent) : BarnardEvent()
     public data class Detection(val detection: BarnardDetectionEvent) : BarnardEvent()
     public data class RssiUpdate(val update: BarnardRssiUpdateEvent) : BarnardEvent()
+    public data class EventInfoHint(val hint: BarnardEventInfoHintEvent) : BarnardEvent()
 }
 
 public data class BarnardDebugEvent(

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -176,8 +176,9 @@ public class BarnardEventInfoDiscoverySession(startedAtMs: Long) {
         private set
     public var additionalEventsOmitted: Boolean = false
         private set
-    public val retainedHashCount: Int get() = namesByHash.size
+    public val retainedHashCount: Int get() = synchronized(this) { namesByHash.size }
 
+    @Synchronized
     public fun observe(info: BarnardEventInfo, nowMs: Long): BarnardEventInfoDiscoveryObservation {
         if (nowMs - startedAtMs >= 300_000L) {
             startedAtMs = nowMs
@@ -203,28 +204,50 @@ public class BarnardEventInfoRetryBudget {
     private val attempts = mutableMapOf<String, Int>()
     private val retryAfterMs = mutableMapOf<String, Long>()
     private val semanticUnavailable = mutableSetOf<String>()
+    private val lastSeenMs = mutableMapOf<String, Long>()
 
-    public fun canStart(peer: String, nowMs: Long): Boolean =
-        peer !in semanticUnavailable && (attempts[peer] ?: 0) < 2 && nowMs >= (retryAfterMs[peer] ?: 0L)
+    @Synchronized
+    public fun canStart(peer: String, nowMs: Long): Boolean {
+        prune(nowMs)
+        lastSeenMs[peer] = nowMs
+        return peer !in semanticUnavailable && (attempts[peer] ?: 0) < 2 && nowMs >= (retryAfterMs[peer] ?: 0L)
+    }
 
+    @Synchronized
     public fun recordRecoverableFailure(peer: String, nowMs: Long): Long? {
+        prune(nowMs)
+        lastSeenMs[peer] = nowMs
         val count = (attempts[peer] ?: 0) + 1
         attempts[peer] = count
         if (count >= 2) return null
         return (nowMs + 30_000L).also { retryAfterMs[peer] = it }
     }
 
-    public fun recordSemanticUnavailable(peer: String) { semanticUnavailable += peer }
+    @Synchronized
+    public fun recordSemanticUnavailable(peer: String, nowMs: Long = System.currentTimeMillis()) {
+        prune(nowMs)
+        lastSeenMs[peer] = nowMs
+        semanticUnavailable += peer
+    }
 
+    @Synchronized
     public fun clear(peer: String) {
         attempts.remove(peer)
         retryAfterMs.remove(peer)
         semanticUnavailable.remove(peer)
+        lastSeenMs.remove(peer)
     }
 
+    @Synchronized
     public fun clearAll() {
         attempts.clear()
         retryAfterMs.clear()
         semanticUnavailable.clear()
+        lastSeenMs.clear()
+    }
+
+    private fun prune(nowMs: Long) {
+        val stalePeers = lastSeenMs.filterValues { seenAt -> nowMs >= seenAt && nowMs - seenAt >= 300_000L }.keys
+        stalePeers.forEach(::clear)
     }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -41,6 +41,11 @@ public object BarnardEventInfoCodec {
     }
 
     @JvmStatic
+    public fun validateEventDisplayName(eventDisplayName: String) {
+        canonicalDisplayNameBytes(eventDisplayName)
+    }
+
+    @JvmStatic
     public fun serialize(eventCode: String, eventDisplayName: String, b004EventCodeHash: ByteArray): ByteArray {
         val displayNameBytes = canonicalDisplayNameBytes(eventDisplayName)
         val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
@@ -170,4 +175,16 @@ public class BarnardEventInfoRetryBudget {
     }
 
     public fun recordSemanticUnavailable(peer: String) { semanticUnavailable += peer }
+
+    public fun clear(peer: String) {
+        attempts.remove(peer)
+        retryAfterMs.remove(peer)
+        semanticUnavailable.remove(peer)
+    }
+
+    public fun clearAll() {
+        attempts.clear()
+        retryAfterMs.clear()
+        semanticUnavailable.clear()
+    }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -13,7 +13,32 @@ public class BarnardEventInfo(
     eventCodeHash: ByteArray,
 ) {
     public val eventCodeHash: ByteArray = eventCodeHash.copyOf()
+
+    override fun equals(other: Any?): Boolean =
+        other is BarnardEventInfo &&
+            eventDisplayName == other.eventDisplayName &&
+            eventCodeHash.contentEquals(other.eventCodeHash)
+
+    override fun hashCode(): Int = 31 * eventDisplayName.hashCode() + eventCodeHash.contentHashCode()
 }
+
+/** Kotlin mirror of Swift's [BarnardEventInfoError] reasons. */
+public enum class BarnardEventInfoError {
+    INVALID_PAYLOAD_LENGTH,
+    UNSUPPORTED_FORMAT_VERSION,
+    TRUNCATED_TLV,
+    ZERO_TLV_TYPE,
+    UNORDERED_TLV_TYPES,
+    MISSING_DISPLAY_NAME,
+    MISSING_EVENT_CODE_HASH,
+    INVALID_DISPLAY_NAME,
+    INVALID_EVENT_CODE_HASH,
+    EVENT_CODE_HASH_MISMATCH,
+}
+
+public class BarnardEventInfoException(
+    public val reason: BarnardEventInfoError,
+) : IllegalArgumentException(reason.name)
 
 /** Local serving state only; neither flag is present in B005 bytes. */
 public data class BarnardEventInfoServePolicy(
@@ -49,9 +74,7 @@ public object BarnardEventInfoCodec {
     public fun serialize(eventCode: String, eventDisplayName: String, b004EventCodeHash: ByteArray): ByteArray {
         val displayNameBytes = canonicalDisplayNameBytes(eventDisplayName)
         val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
-        require(eventCodeHash.size == 8 && eventCodeHash.contentEquals(b004EventCodeHash)) {
-            "B005 EventCodeHash must equal B004"
-        }
+        requireEventInfo(eventCodeHash.size == 8 && eventCodeHash.contentEquals(b004EventCodeHash), BarnardEventInfoError.EVENT_CODE_HASH_MISMATCH)
         val payload = ByteBuffer.allocate(1 + 3 + displayNameBytes.size + 3 + eventCodeHash.size)
             .put(FORMAT_VERSION.toByte())
             .put(0x01)
@@ -61,50 +84,50 @@ public object BarnardEventInfoCodec {
             .putShort(eventCodeHash.size.toShort())
             .put(eventCodeHash)
             .array()
-        require(payload.size in 16..MAXIMUM_PAYLOAD_BYTES) { "B005 payload length is invalid" }
+        requireEventInfo(payload.size in 16..MAXIMUM_PAYLOAD_BYTES, BarnardEventInfoError.INVALID_PAYLOAD_LENGTH)
         return payload
     }
 
     @JvmStatic
     public fun parse(payload: ByteArray): BarnardEventInfo {
-        require(payload.size in 16..MAXIMUM_PAYLOAD_BYTES) { "B005 payload length is invalid" }
-        require((payload[0].toInt() and 0xff) == FORMAT_VERSION) { "Unsupported B005 format version" }
+        requireEventInfo(payload.size in 16..MAXIMUM_PAYLOAD_BYTES, BarnardEventInfoError.INVALID_PAYLOAD_LENGTH)
+        requireEventInfo((payload[0].toInt() and 0xff) == FORMAT_VERSION, BarnardEventInfoError.UNSUPPORTED_FORMAT_VERSION)
         var offset = 1
         var previousType = 0
         var displayName: String? = null
         var eventCodeHash: ByteArray? = null
         while (offset < payload.size) {
-            require(offset + 3 <= payload.size) { "Truncated B005 TLV header" }
+            requireEventInfo(offset + 3 <= payload.size, BarnardEventInfoError.TRUNCATED_TLV)
             val type = payload[offset].toInt() and 0xff
             val length = ((payload[offset + 1].toInt() and 0xff) shl 8) or (payload[offset + 2].toInt() and 0xff)
             offset += 3
-            require(type != 0) { "B005 TLV type zero is invalid" }
-            require(type > previousType) { "B005 TLV types must be strictly ordered" }
+            requireEventInfo(type != 0, BarnardEventInfoError.ZERO_TLV_TYPE)
+            requireEventInfo(type > previousType, BarnardEventInfoError.UNORDERED_TLV_TYPES)
             previousType = type
-            require(length <= payload.size - offset) { "Truncated B005 TLV value" }
+            requireEventInfo(length <= payload.size - offset, BarnardEventInfoError.TRUNCATED_TLV)
             val value = payload.copyOfRange(offset, offset + length)
             offset += length
             when (type) {
                 0x01 -> {
-                    require(displayName == null) { "Duplicate B005 display name" }
+                    requireEventInfo(displayName == null, BarnardEventInfoError.UNORDERED_TLV_TYPES)
                     displayName = validatedDisplayName(value)
                 }
                 0x02 -> {
-                    require(eventCodeHash == null && value.size == 8) { "Invalid B005 EventCodeHash" }
+                    requireEventInfo(eventCodeHash == null && value.size == 8, BarnardEventInfoError.INVALID_EVENT_CODE_HASH)
                     eventCodeHash = value
                 }
             }
         }
-        require(displayName != null) { "B005 display name is required" }
-        require(eventCodeHash != null) { "B005 EventCodeHash is required" }
-        return BarnardEventInfo(displayName, eventCodeHash)
+        val resolvedDisplayName = displayName ?: throw BarnardEventInfoException(BarnardEventInfoError.MISSING_DISPLAY_NAME)
+        val resolvedEventCodeHash = eventCodeHash ?: throw BarnardEventInfoException(BarnardEventInfoError.MISSING_EVENT_CODE_HASH)
+        return BarnardEventInfo(resolvedDisplayName, resolvedEventCodeHash)
     }
 
     private fun canonicalDisplayNameBytes(displayName: String): ByteArray {
-        require(Normalizer.normalize(displayName, Normalizer.Form.NFC) == displayName) { "B005 display name must be NFC" }
+        requireEventInfo(Normalizer.normalize(displayName, Normalizer.Form.NFC) == displayName, BarnardEventInfoError.INVALID_DISPLAY_NAME)
         val bytes = displayName.toByteArray(StandardCharsets.UTF_8)
-        require(bytes.size in 1..MAXIMUM_DISPLAY_NAME_BYTES) { "B005 display name length is invalid" }
-        require(displayName.codePoints().allMatch { it > 0x1f && it != 0x7f }) { "B005 display name contains a control" }
+        requireEventInfo(bytes.size in 1..MAXIMUM_DISPLAY_NAME_BYTES, BarnardEventInfoError.INVALID_DISPLAY_NAME)
+        requireEventInfo(displayName.codePoints().allMatch { it > 0x1f && it != 0x7f }, BarnardEventInfoError.INVALID_DISPLAY_NAME)
         return bytes
     }
 
@@ -116,10 +139,14 @@ public object BarnardEventInfoCodec {
                 .decode(ByteBuffer.wrap(bytes))
                 .toString()
         } catch (_: Exception) {
-            throw IllegalArgumentException("B005 display name is not valid UTF-8")
+            throw BarnardEventInfoException(BarnardEventInfoError.INVALID_DISPLAY_NAME)
         }
         canonicalDisplayNameBytes(displayName)
         return displayName
+    }
+
+    private fun requireEventInfo(condition: Boolean, reason: BarnardEventInfoError) {
+        if (!condition) throw BarnardEventInfoException(reason)
     }
 }
 

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -3,6 +3,7 @@ package org.levarac.barnard
 import org.levarac.barnard.BarnardCrypto.toHex
 
 import java.nio.ByteBuffer
+import java.nio.CharBuffer
 import java.nio.charset.CodingErrorAction
 import java.nio.charset.StandardCharsets
 import java.text.Normalizer
@@ -123,9 +124,21 @@ public object BarnardEventInfoCodec {
         return BarnardEventInfo(resolvedDisplayName, resolvedEventCodeHash)
     }
 
+    @JvmStatic
+    public fun matchesB004(info: BarnardEventInfo, b004EventCodeHash: ByteArray): Boolean =
+        b004EventCodeHash.isNotEmpty() && info.eventCodeHash.contentEquals(b004EventCodeHash)
+
     private fun canonicalDisplayNameBytes(displayName: String): ByteArray {
         requireEventInfo(Normalizer.normalize(displayName, Normalizer.Form.NFC) == displayName, BarnardEventInfoError.INVALID_DISPLAY_NAME)
-        val bytes = displayName.toByteArray(StandardCharsets.UTF_8)
+        val bytes = try {
+            val encoded = StandardCharsets.UTF_8.newEncoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .encode(CharBuffer.wrap(displayName))
+            ByteArray(encoded.remaining()).also(encoded::get)
+        } catch (_: Exception) {
+            throw BarnardEventInfoException(BarnardEventInfoError.INVALID_DISPLAY_NAME)
+        }
         requireEventInfo(bytes.size in 1..MAXIMUM_DISPLAY_NAME_BYTES, BarnardEventInfoError.INVALID_DISPLAY_NAME)
         requireEventInfo(displayName.codePoints().allMatch { it > 0x1f && it != 0x7f }, BarnardEventInfoError.INVALID_DISPLAY_NAME)
         return bytes

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -1,0 +1,173 @@
+package org.levarac.barnard
+
+import org.levarac.barnard.BarnardCrypto.toHex
+
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
+import java.text.Normalizer
+
+/** B005's unauthenticated, event-scoped discovery hint. */
+public class BarnardEventInfo(
+    public val eventDisplayName: String,
+    eventCodeHash: ByteArray,
+) {
+    public val eventCodeHash: ByteArray = eventCodeHash.copyOf()
+}
+
+/** Local serving state only; neither flag is present in B005 bytes. */
+public data class BarnardEventInfoServePolicy(
+    val organizerDesignated: Boolean = false,
+    val eventActiveForDiscovery: Boolean = false,
+) {
+    internal val mayServe: Boolean get() = organizerDesignated && eventActiveForDiscovery
+}
+
+/** Pure B005 serializer/parser. Hash computation is delegated to B004's function. */
+public object BarnardEventInfoCodec {
+    public const val FORMAT_VERSION: Int = 1
+    public const val MAXIMUM_PAYLOAD_BYTES: Int = 512
+    public const val MAXIMUM_DISPLAY_NAME_BYTES: Int = 64
+
+    @JvmStatic
+    public fun payloadIfServing(
+        policy: BarnardEventInfoServePolicy,
+        eventCode: String?,
+        eventDisplayName: String?,
+        b004EventCodeHash: ByteArray,
+    ): ByteArray? {
+        if (!policy.mayServe || eventCode.isNullOrEmpty() || eventDisplayName == null) return null
+        return serialize(eventCode, eventDisplayName, b004EventCodeHash)
+    }
+
+    @JvmStatic
+    public fun serialize(eventCode: String, eventDisplayName: String, b004EventCodeHash: ByteArray): ByteArray {
+        val displayNameBytes = canonicalDisplayNameBytes(eventDisplayName)
+        val eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+        require(eventCodeHash.size == 8 && eventCodeHash.contentEquals(b004EventCodeHash)) {
+            "B005 EventCodeHash must equal B004"
+        }
+        val payload = ByteBuffer.allocate(1 + 3 + displayNameBytes.size + 3 + eventCodeHash.size)
+            .put(FORMAT_VERSION.toByte())
+            .put(0x01)
+            .putShort(displayNameBytes.size.toShort())
+            .put(displayNameBytes)
+            .put(0x02)
+            .putShort(eventCodeHash.size.toShort())
+            .put(eventCodeHash)
+            .array()
+        require(payload.size in 16..MAXIMUM_PAYLOAD_BYTES) { "B005 payload length is invalid" }
+        return payload
+    }
+
+    @JvmStatic
+    public fun parse(payload: ByteArray): BarnardEventInfo {
+        require(payload.size in 16..MAXIMUM_PAYLOAD_BYTES) { "B005 payload length is invalid" }
+        require((payload[0].toInt() and 0xff) == FORMAT_VERSION) { "Unsupported B005 format version" }
+        var offset = 1
+        var previousType = 0
+        var displayName: String? = null
+        var eventCodeHash: ByteArray? = null
+        while (offset < payload.size) {
+            require(offset + 3 <= payload.size) { "Truncated B005 TLV header" }
+            val type = payload[offset].toInt() and 0xff
+            val length = ((payload[offset + 1].toInt() and 0xff) shl 8) or (payload[offset + 2].toInt() and 0xff)
+            offset += 3
+            require(type != 0) { "B005 TLV type zero is invalid" }
+            require(type > previousType) { "B005 TLV types must be strictly ordered" }
+            previousType = type
+            require(length <= payload.size - offset) { "Truncated B005 TLV value" }
+            val value = payload.copyOfRange(offset, offset + length)
+            offset += length
+            when (type) {
+                0x01 -> {
+                    require(displayName == null) { "Duplicate B005 display name" }
+                    displayName = validatedDisplayName(value)
+                }
+                0x02 -> {
+                    require(eventCodeHash == null && value.size == 8) { "Invalid B005 EventCodeHash" }
+                    eventCodeHash = value
+                }
+            }
+        }
+        require(displayName != null) { "B005 display name is required" }
+        require(eventCodeHash != null) { "B005 EventCodeHash is required" }
+        return BarnardEventInfo(displayName, eventCodeHash)
+    }
+
+    private fun canonicalDisplayNameBytes(displayName: String): ByteArray {
+        require(Normalizer.normalize(displayName, Normalizer.Form.NFC) == displayName) { "B005 display name must be NFC" }
+        val bytes = displayName.toByteArray(StandardCharsets.UTF_8)
+        require(bytes.size in 1..MAXIMUM_DISPLAY_NAME_BYTES) { "B005 display name length is invalid" }
+        require(displayName.codePoints().allMatch { it > 0x1f && it != 0x7f }) { "B005 display name contains a control" }
+        return bytes
+    }
+
+    private fun validatedDisplayName(bytes: ByteArray): String {
+        val displayName = try {
+            StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+                .toString()
+        } catch (_: Exception) {
+            throw IllegalArgumentException("B005 display name is not valid UTF-8")
+        }
+        canonicalDisplayNameBytes(displayName)
+        return displayName
+    }
+}
+
+public data class BarnardEventInfoDiscoveryObservation(
+    val additionalNamesOmitted: Boolean,
+    val additionalEventsOmitted: Boolean,
+)
+
+/** Bounded, observer-local state for one five-minute B005 discovery session. */
+public class BarnardEventInfoDiscoverySession(startedAtMs: Long) {
+    private var startedAtMs = startedAtMs
+    private val namesByHash = mutableMapOf<String, MutableSet<String>>()
+    public var additionalNamesOmitted: Boolean = false
+        private set
+    public var additionalEventsOmitted: Boolean = false
+        private set
+    public val retainedHashCount: Int get() = namesByHash.size
+
+    public fun observe(info: BarnardEventInfo, nowMs: Long): BarnardEventInfoDiscoveryObservation {
+        if (nowMs - startedAtMs >= 300_000L) {
+            startedAtMs = nowMs
+            namesByHash.clear()
+            additionalNamesOmitted = false
+            additionalEventsOmitted = false
+        }
+        val hash = info.eventCodeHash.toHex()
+        val name = info.eventDisplayName
+        val names = namesByHash[hash]
+        when {
+            names != null && name !in names && names.size >= 4 -> additionalNamesOmitted = true
+            names != null -> names += name
+            namesByHash.size >= 32 -> additionalEventsOmitted = true
+            else -> namesByHash[hash] = mutableSetOf(name)
+        }
+        return BarnardEventInfoDiscoveryObservation(additionalNamesOmitted, additionalEventsOmitted)
+    }
+}
+
+/** Two B005 transport attempts per peer/session, with a fixed 30-second retry delay. */
+public class BarnardEventInfoRetryBudget {
+    private val attempts = mutableMapOf<String, Int>()
+    private val retryAfterMs = mutableMapOf<String, Long>()
+    private val semanticUnavailable = mutableSetOf<String>()
+
+    public fun canStart(peer: String, nowMs: Long): Boolean =
+        peer !in semanticUnavailable && (attempts[peer] ?: 0) < 2 && nowMs >= (retryAfterMs[peer] ?: 0L)
+
+    public fun recordRecoverableFailure(peer: String, nowMs: Long): Long? {
+        val count = (attempts[peer] ?: 0) + 1
+        attempts[peer] = count
+        if (count >= 2) return null
+        return (nowMs + 30_000L).also { retryAfterMs[peer] = it }
+    }
+
+    public fun recordSemanticUnavailable(peer: String) { semanticUnavailable += peer }
+}

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -1,0 +1,96 @@
+package org.levarac.barnard
+
+import org.levarac.barnard.BarnardCrypto.toHex
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class BarnardEventInfoTest {
+    @Test
+    fun goldenVectorsSerializeAndParseByteForByte() {
+        val vectors = listOf(
+            arrayOf("CORE-SPLIT-80", "Barnard Core Split", "0b9f14789f13968f", "010100124261726e61726420436f72652053706c69740200080b9f14789f13968f"),
+            arrayOf("東京-2026", "東京 2026", "34dc60f26d21cb94", "0101000be69db1e4baac203230323602000834dc60f26d21cb94"),
+        )
+        for ((eventCode, displayName, expectedHash, expectedPayload) in vectors) {
+            val b004 = BarnardCrypto.computeEventCodeHash(eventCode)
+            assertEquals(expectedHash, b004.toHex())
+            val payload = BarnardEventInfoCodec.serialize(eventCode, displayName, b004)
+            assertEquals(expectedPayload, payload.toHex())
+            val parsed = BarnardEventInfoCodec.parse(payload)
+            assertEquals(displayName, parsed.eventDisplayName)
+            assertArrayEquals(b004, parsed.eventCodeHash)
+        }
+    }
+
+    @Test
+    fun parserSkipsWellFormedUnknownTlvButRejectsMalformedCorpus() {
+        val validWithUnknown = "010100124261726e61726420436f72652053706c69740200080b9f14789f13968f100001ff".hexBytes()
+        assertEquals("Barnard Core Split", BarnardEventInfoCodec.parse(validWithUnknown).eventDisplayName)
+
+        val malformed = listOf(
+            "",
+            "020100124261726e61726420436f72652053706c69740200080b9f14789f13968f",
+            "010100124261726e61726420436f72652053706c69740200080b9f14789f1396",
+            "010200080b9f14789f13968f0100124261726e61726420436f72652053706c6974",
+            "01010001410200080b9f14789f13968f020000",
+            "01010001ff0200080b9f14789f13968f",
+            "0101000241010200080b9f14789f13968f",
+            "0101000341cc8a0200080b9f14789f13968f",
+        )
+        malformed.forEach { hex ->
+            assertThrows("expected malformed B005 to fail: $hex", IllegalArgumentException::class.java) {
+                BarnardEventInfoCodec.parse(hex.hexBytes())
+            }
+        }
+    }
+
+    @Test
+    fun serializerRejectsB004MismatchAndDisabledPolicy() {
+        val b004 = BarnardCrypto.computeEventCodeHash("CORE-SPLIT-80")
+        assertThrows(IllegalArgumentException::class.java) {
+            BarnardEventInfoCodec.serialize("CORE-SPLIT-80", "Barnard Core Split", ByteArray(8))
+        }
+        assertNull(BarnardEventInfoCodec.payloadIfServing(
+            BarnardEventInfoServePolicy(),
+            "CORE-SPLIT-80",
+            "Barnard Core Split",
+            b004,
+        ))
+    }
+
+    @Test
+    fun discoveryRetentionCapsNamesHashesAndResetsAtFiveMinutes() {
+        val session = BarnardEventInfoDiscoverySession(0L)
+        repeat(32) { index ->
+            session.observe(BarnardEventInfo("Event $index", ByteArray(8) { index.toByte() }), 1L)
+        }
+        assertEquals(32, session.retainedHashCount)
+        assertEquals(true, session.observe(BarnardEventInfo("Overflow", ByteArray(8) { 0xff.toByte() }), 2L).additionalEventsOmitted)
+
+        val names = BarnardEventInfoDiscoverySession(0L)
+        val hash = ByteArray(8) { 0x42 }
+        repeat(4) { index -> names.observe(BarnardEventInfo("Name $index", hash), 1L) }
+        assertEquals(true, names.observe(BarnardEventInfo("Name 4", hash), 2L).additionalNamesOmitted)
+        names.observe(BarnardEventInfo("Fresh", hash), 300_000L)
+        assertEquals(1, names.retainedHashCount)
+    }
+
+    @Test
+    fun retryBudgetAllowsOnlyTwoTransportAttemptsWithThirtySecondBackoff() {
+        val retries = BarnardEventInfoRetryBudget()
+        val peer = "AA:BB"
+        assertEquals(true, retries.canStart(peer, 0L))
+        assertEquals(30_000L, retries.recordRecoverableFailure(peer, 0L))
+        assertEquals(false, retries.canStart(peer, 29_999L))
+        assertEquals(true, retries.canStart(peer, 30_000L))
+        assertEquals(null, retries.recordRecoverableFailure(peer, 30_000L))
+        assertEquals(false, retries.canStart(peer, 60_000L))
+        retries.recordSemanticUnavailable(peer)
+        assertEquals(false, retries.canStart(peer, 999_000L))
+    }
+}
+
+private fun String.hexBytes(): ByteArray = chunked(2).map { it.toInt(16).toByte() }.toByteArray()

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -106,6 +106,9 @@ class BarnardEventInfoTest {
         retries.recordSemanticUnavailable("CC:DD")
         retries.clearAll()
         assertEquals(true, retries.canStart(peer, 0L))
+
+        retries.recordSemanticUnavailable(peer, 0L)
+        assertEquals(true, retries.canStart(peer, 300_000L))
     }
 
     @Test

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -99,6 +99,13 @@ class BarnardEventInfoTest {
         assertEquals(false, retries.canStart(peer, 60_000L))
         retries.recordSemanticUnavailable(peer)
         assertEquals(false, retries.canStart(peer, 999_000L))
+
+        retries.clear(peer)
+        assertEquals(true, retries.canStart(peer, 0L))
+        retries.recordRecoverableFailure(peer, 0L)
+        retries.recordSemanticUnavailable("CC:DD")
+        retries.clearAll()
+        assertEquals(true, retries.canStart(peer, 0L))
     }
 
     @Test
@@ -108,6 +115,9 @@ class BarnardEventInfoTest {
             BarnardEventInfoCodec.validateEventDisplayName("a".repeat(65))
         }
         BarnardEventInfoCodec.validateEventDisplayName("a")
+        assertThrows(IllegalArgumentException::class.java) {
+            BarnardEventInfoCodec.validateEventDisplayName("\ud800")
+        }
 
         BarnardEventInfoCodec.parse(b005Payload(16))
         assertThrows(IllegalArgumentException::class.java) {
@@ -117,6 +127,13 @@ class BarnardEventInfoTest {
         assertThrows(IllegalArgumentException::class.java) {
             BarnardEventInfoCodec.parse(ByteArray(513))
         }
+    }
+
+    @Test
+    fun b005HintMustMatchThePeripheralsB004Value() {
+        val info = BarnardEventInfoCodec.parse(b005Payload(16))
+        assertEquals(true, BarnardEventInfoCodec.matchesB004(info, ByteArray(8) { 0x42 }))
+        assertEquals(false, BarnardEventInfoCodec.matchesB004(info, ByteArray(8) { 0x43 }))
     }
 
     @Test

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -100,6 +100,47 @@ class BarnardEventInfoTest {
         retries.recordSemanticUnavailable(peer)
         assertEquals(false, retries.canStart(peer, 999_000L))
     }
+
+    @Test
+    fun codecAcceptsExactBoundsAndRejectsAdjacentValues() {
+        BarnardEventInfoCodec.validateEventDisplayName("a".repeat(64))
+        assertThrows(IllegalArgumentException::class.java) {
+            BarnardEventInfoCodec.validateEventDisplayName("a".repeat(65))
+        }
+        BarnardEventInfoCodec.validateEventDisplayName("a")
+
+        BarnardEventInfoCodec.parse(b005Payload(16))
+        assertThrows(IllegalArgumentException::class.java) {
+            BarnardEventInfoCodec.parse(ByteArray(15))
+        }
+        BarnardEventInfoCodec.parse(b005Payload(512))
+        assertThrows(IllegalArgumentException::class.java) {
+            BarnardEventInfoCodec.parse(ByteArray(513))
+        }
+    }
+
+    @Test
+    fun eventInfoUsesValueEqualityAndTypedParseReasons() {
+        assertEquals(
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }),
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }),
+        )
+        val failure = assertThrows(BarnardEventInfoException::class.java) {
+            BarnardEventInfoCodec.parse(ByteArray(15))
+        }
+        assertEquals(BarnardEventInfoError.INVALID_PAYLOAD_LENGTH, failure.reason)
+    }
+}
+
+private fun b005Payload(totalLength: Int): ByteArray {
+    val payload = mutableListOf(1, 0x01, 0x00, 0x01, 0x61, 0x02, 0x00, 0x08)
+    payload += List(8) { 0x42 }
+    val extensionLength = totalLength - payload.size - 3
+    if (extensionLength > 0) {
+        payload += listOf(0x10, (extensionLength ushr 8) and 0xff, extensionLength and 0xff)
+        payload += List(extensionLength) { 0 }
+    }
+    return payload.map(Int::toByte).toByteArray()
 }
 
 private fun String.hexBytes(): ByteArray = chunked(2).map { it.toInt(16).toByte() }.toByteArray()

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -3,6 +3,7 @@ package org.levarac.barnard
 import org.levarac.barnard.BarnardCrypto.toHex
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Test
@@ -59,6 +60,12 @@ class BarnardEventInfoTest {
             "Barnard Core Split",
             b004,
         ))
+        assertNotNull(BarnardEventInfoCodec.payloadIfServing(
+            BarnardEventInfoServePolicy(organizerDesignated = true, eventActiveForDiscovery = true),
+            "CORE-SPLIT-80",
+            "Barnard Core Split",
+            b004,
+        ))
     }
 
     @Test
@@ -76,6 +83,8 @@ class BarnardEventInfoTest {
         assertEquals(true, names.observe(BarnardEventInfo("Name 4", hash), 2L).additionalNamesOmitted)
         names.observe(BarnardEventInfo("Fresh", hash), 300_000L)
         assertEquals(1, names.retainedHashCount)
+        assertEquals(false, names.additionalNamesOmitted)
+        assertEquals(false, names.additionalEventsOmitted)
     }
 
     @Test

--- a/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
@@ -1523,6 +1523,15 @@ extension BarnardEngine: CBPeripheralDelegate {
     case eventInfoCharacteristicUUID:
       do {
         let hint = try BarnardEventInfoCodec.parse(value)
+        guard BarnardEventInfoCodec.matchesB004(
+          hint,
+          b004EventCodeHash: peripheralReadValues[id]?.eventCodeHash ?? Data()
+        ) else {
+          eventInfoRetryBudget.recordSemanticUnavailable(id)
+          emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString, "reason": "b004_mismatch"])
+          finishConnection(peripheral)
+          return
+        }
         var data: [String: Any] = [
           "id": id.uuidString,
           "eventCodeHash": hint.eventCodeHash.hexString,

--- a/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
@@ -116,12 +116,20 @@ public struct BarnardConstraintEvent {
   public let message: String?
 }
 
+public struct BarnardEventInfoHintEvent {
+  public let peripheralId: UUID
+  public let eventInfo: BarnardEventInfo
+  public let additionalNamesOmitted: Bool
+  public let additionalEventsOmitted: Bool
+}
+
 public enum BarnardEvent {
   case state(BarnardState)
   case constraint(BarnardConstraintEvent)
   case error(BarnardErrorEvent)
   case detection(BarnardDetectionEvent)
   case rssiUpdate(BarnardRssiUpdateEvent)
+  case eventInfoHint(BarnardEventInfoHintEvent)
 }
 
 public struct BarnardDebugEvent {
@@ -199,11 +207,11 @@ public final class BarnardEngine: NSObject {
   private var eventInfoDisplayName: String?
   private struct EventInfoSnapshot {
     var value: Data
-    var eventDisplayName: String?
-    var eventCodeHash: Data
     var lastRequest: Date
   }
   private var eventInfoSnapshots: [UUID: EventInfoSnapshot] = [:]
+  private let eventInfoRetryBudget = BarnardEventInfoRetryBudget()
+  private var eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(startedAt: Date().timeIntervalSince1970)
   private var shouldStartScanWhenReady = false
   private var shouldStartAdvertiseWhenReady = false
   private var allowDuplicates = true
@@ -535,6 +543,10 @@ public final class BarnardEngine: NSObject {
   }
 
   public func startScan(allowDuplicates: Bool = true) {
+    if !isScanning {
+      eventInfoRetryBudget.clearAll()
+      eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(startedAt: Date().timeIntervalSince1970)
+    }
     self.allowDuplicates = allowDuplicates
     startScanInternal()
   }
@@ -682,6 +694,8 @@ public final class BarnardEngine: NSObject {
     peripheralCharacteristics.removeAll()
     peripheralReadValues.removeAll()
     b004ReadRetries.removeAll()
+    eventInfoRetryBudget.clearAll()
+    eventInfoDiscoverySession = BarnardEventInfoDiscoverySession(startedAt: Date().timeIntervalSince1970)
     lastDiscoveryNameById.removeAll()
     knownPeers.removeAll()
 
@@ -974,11 +988,6 @@ public final class BarnardEngine: NSObject {
     }
     peripheralCharacteristics[id] = charMap
 
-    // B005 is intentionally independent of the B004 same-event gate.
-    if let eventInfo = charMap[eventInfoCharacteristicUUID] {
-      peripheral.readValue(for: eventInfo)
-      return
-    }
     readEventCodeHash(for: peripheral)
   }
 
@@ -1005,7 +1014,7 @@ public final class BarnardEngine: NSObject {
       let rpidCh = charMap[rpidCharacteristicUUID]
     else {
       markGattResolutionFailed(id, reason: "b002_missing", recoverable: true)
-      finishConnection(peripheral)
+      readEventInfoAfterResolution(for: peripheral)
       return
     }
     peripheralReadValues[id]?.rpidReadStartedAt = Date()
@@ -1072,7 +1081,36 @@ public final class BarnardEngine: NSObject {
       }
     }
 
+    readEventInfoAfterResolution(for: peripheral)
+  }
+
+  private func readEventInfoAfterResolution(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let eventInfo = peripheralCharacteristics[id]?[eventInfoCharacteristicUUID] else {
+      eventInfoRetryBudget.recordSemanticUnavailable(id)
+      emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString, "reason": "missing"])
+      finishConnection(peripheral)
+      return
+    }
+    guard eventInfoRetryBudget.canStart(id, now: Date().timeIntervalSince1970) else {
+      finishConnection(peripheral)
+      return
+    }
+    peripheral.readValue(for: eventInfo)
+  }
+
+  private func retryEventInfoRead(for peripheral: CBPeripheral, error: Error) {
+    let id = peripheral.identifier
+    let now = Date().timeIntervalSince1970
+    let deadline = eventInfoRetryBudget.recordRecoverableFailure(id, now: now)
+    emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString, "error": error.localizedDescription])
     finishConnection(peripheral)
+    guard let deadline else { return }
+    DispatchQueue.main.asyncAfter(deadline: .now() + max(0, deadline - now)) { [weak self, weak peripheral] in
+      guard let self, let peripheral, self.isScanning else { return }
+      self.lastConnectAttemptAt.removeValue(forKey: id)
+      self.enqueueConnect(peripheral)
+    }
   }
 
   private func finishConnection(_ peripheral: CBPeripheral) {
@@ -1121,6 +1159,16 @@ public final class BarnardEngine: NSObject {
 
   private func emitError(code: String, message: String, recoverable: Bool? = nil) {
     onEvent?(.error(BarnardErrorEvent(code: code, message: message, recoverable: recoverable)))
+  }
+
+  private func emitEventInfoHint(peripheralId: UUID, eventInfo: BarnardEventInfo) {
+    let observation = eventInfoDiscoverySession.observe(eventInfo, now: Date().timeIntervalSince1970)
+    onEvent?(.eventInfoHint(BarnardEventInfoHintEvent(
+      peripheralId: peripheralId,
+      eventInfo: eventInfo,
+      additionalNamesOmitted: observation.additionalNamesOmitted,
+      additionalEventsOmitted: observation.additionalEventsOmitted
+    )))
   }
 
   /// Emit v2 detection event. Byte fields are lowercase hex.
@@ -1413,8 +1461,13 @@ extension BarnardEngine: CBPeripheralDelegate {
     // B002 read failure (drop the detection — no RPID, nothing to emit).
     if let error = error {
       if characteristic.uuid == eventInfoCharacteristicUUID {
-        emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString])
-        readEventCodeHash(for: peripheral)
+        if let attError = error as? CBATTError, attError.code == .readNotPermitted {
+          eventInfoRetryBudget.recordSemanticUnavailable(id)
+          emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString, "reason": "read_not_permitted"])
+          finishConnection(peripheral)
+        } else {
+          retryEventInfoRead(for: peripheral, error: error)
+        }
         return
       }
       if characteristic.uuid == displayIdCharacteristicUUID {
@@ -1478,10 +1531,13 @@ extension BarnardEngine: CBPeripheralDelegate {
         data["displayName"] = hint.eventDisplayName
         #endif
         emitDebug(level: "info", name: "gatt_event_info_hint", data: data)
+        eventInfoRetryBudget.clear(id)
+        emitEventInfoHint(peripheralId: id, eventInfo: hint)
       } catch {
+        eventInfoRetryBudget.recordSemanticUnavailable(id)
         emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString])
       }
-      readEventCodeHash(for: peripheral)
+      finishConnection(peripheral)
     case eventCodeHashCharacteristicUUID:
       peripheralReadValues[id]?.eventCodeHash = value
       let matches = eventCodeHashMatches(value)
@@ -1502,7 +1558,7 @@ extension BarnardEngine: CBPeripheralDelegate {
           "id": id.uuidString,
           "bytes": value.count,
         ])
-        finishConnection(peripheral)
+        readEventInfoAfterResolution(for: peripheral)
         return
       }
       readRpidCharacteristic(for: peripheral)
@@ -1629,8 +1685,6 @@ extension BarnardEngine: CBPeripheralManagerDelegate {
         }
         eventInfoSnapshots[id] = EventInfoSnapshot(
           value: value,
-          eventDisplayName: eventInfoDisplayName,
-          eventCodeHash: rpid.getEventCodeHash(),
           lastRequest: now
         )
       } catch {
@@ -1639,13 +1693,6 @@ extension BarnardEngine: CBPeripheralManagerDelegate {
       }
     }
     guard var snapshot = eventInfoSnapshots[id] else {
-      peripheral.respond(to: request, withResult: .invalidOffset)
-      return
-    }
-    guard snapshot.eventDisplayName == eventInfoDisplayName,
-      snapshot.eventCodeHash == rpid.getEventCodeHash()
-    else {
-      eventInfoSnapshots.removeValue(forKey: id)
       peripheral.respond(to: request, withResult: .invalidOffset)
       return
     }

--- a/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
@@ -148,6 +148,7 @@ public final class BarnardEngine: NSObject {
   private let rpidCharacteristicUUID = CBUUID(string: "0000B002-0000-1000-8000-00805F9B34FB")
   private let displayIdCharacteristicUUID = CBUUID(string: "0000B003-0000-1000-8000-00805F9B34FB")
   private let eventCodeHashCharacteristicUUID = CBUUID(string: "0000B004-0000-1000-8000-00805F9B34FB")
+  private let eventInfoCharacteristicUUID = CBUUID(string: "0000B005-0000-1000-8000-00805F9B34FB")
   private let localName = "BNRD"
   private let unavailableRssi = 127
 
@@ -188,11 +189,16 @@ public final class BarnardEngine: NSObject {
   private var rpidCharacteristic: CBMutableCharacteristic?
   private var displayIdCharacteristic: CBMutableCharacteristic?
   private var eventCodeHashCharacteristic: CBMutableCharacteristic?
+  private var eventInfoCharacteristic: CBMutableCharacteristic?
 
   // MARK: - State
 
   private var isScanning = false
   private var isAdvertising = false
+  private var eventInfoServePolicy = BarnardEventInfoServePolicy()
+  private var eventInfoDisplayName: String?
+  private struct EventInfoSnapshot { var value: Data; var lastRequest: Date }
+  private var eventInfoSnapshots: [UUID: EventInfoSnapshot] = [:]
   private var shouldStartScanWhenReady = false
   private var shouldStartAdvertiseWhenReady = false
   private var allowDuplicates = true
@@ -445,6 +451,20 @@ public final class BarnardEngine: NSObject {
       "eninSeconds": self.eninSeconds,
       "beaconChain": beaconChainInfo().chainId,
     ])
+  }
+
+  /// Sets B005's host-local serving state. Both booleans default to false and
+  /// are never placed on wire.
+  public func configureEventInfoServing(
+    organizerDesignated: Bool = false,
+    eventActiveForDiscovery: Bool = false,
+    eventDisplayName: String? = nil
+  ) {
+    eventInfoServePolicy = BarnardEventInfoServePolicy(
+      organizerDesignated: organizerDesignated,
+      eventActiveForDiscovery: eventActiveForDiscovery
+    )
+    eventInfoDisplayName = eventDisplayName
   }
 
   public func getCurrentEventCode() -> String? {
@@ -727,6 +747,7 @@ public final class BarnardEngine: NSObject {
     rpidCharacteristic = nil
     displayIdCharacteristic = nil
     eventCodeHashCharacteristic = nil
+    eventInfoCharacteristic = nil
 
     buildAndAddGattService()
 
@@ -759,17 +780,24 @@ public final class BarnardEngine: NSObject {
       value: nil,
       permissions: [.readable]
     )
+    let eventInfoCh = CBMutableCharacteristic(
+      type: eventInfoCharacteristicUUID,
+      properties: [.read],
+      value: nil,
+      permissions: [.readable]
+    )
 
     let svc = CBMutableService(type: discoveryServiceUUID, primary: true)
-    svc.characteristics = [rpidCh, displayIdCh, eventCodeHashCh]
+    svc.characteristics = [rpidCh, displayIdCh, eventCodeHashCh, eventInfoCh]
     manager.add(svc)
 
     rpidCharacteristic = rpidCh
     displayIdCharacteristic = displayIdCh
     eventCodeHashCharacteristic = eventCodeHashCh
+    eventInfoCharacteristic = eventInfoCh
 
     emitDebug(level: "info", name: "gatt_service_added", data: [
-      "characteristics": ["RPID", "displayId", "EventCodeHash"],
+      "characteristics": ["RPID", "displayId", "EventCodeHash", "eventInfo"],
     ])
   }
 
@@ -939,8 +967,17 @@ public final class BarnardEngine: NSObject {
     }
     peripheralCharacteristics[id] = charMap
 
-    // Step 1: EventCodeHash. B004 gates B002/B003 exchange.
-    guard let eventCodeHashCh = charMap[eventCodeHashCharacteristicUUID] else {
+    // B005 is intentionally independent of the B004 same-event gate.
+    if let eventInfo = charMap[eventInfoCharacteristicUUID] {
+      peripheral.readValue(for: eventInfo)
+      return
+    }
+    readEventCodeHash(for: peripheral)
+  }
+
+  private func readEventCodeHash(for peripheral: CBPeripheral) {
+    let id = peripheral.identifier
+    guard let eventCodeHashCh = peripheralCharacteristics[id]?[eventCodeHashCharacteristicUUID] else {
       markGattResolutionFailed(id, reason: "b004_missing", recoverable: true)
       emitDebug(level: "warn", name: "gatt_b004_missing", data: [
         "id": id.uuidString,
@@ -1165,6 +1202,8 @@ public final class BarnardEngine: NSObject {
       return "B003_displayId"
     case eventCodeHashCharacteristicUUID:
       return "B004_eventCodeHash"
+    case eventInfoCharacteristicUUID:
+      return "B005_eventInfo"
     default:
       return uuid.uuidString
     }
@@ -1340,7 +1379,7 @@ extension BarnardEngine: CBPeripheralDelegate {
       return
     }
     peripheral.discoverCharacteristics(
-      [rpidCharacteristicUUID, displayIdCharacteristicUUID, eventCodeHashCharacteristicUUID],
+      [rpidCharacteristicUUID, displayIdCharacteristicUUID, eventCodeHashCharacteristicUUID, eventInfoCharacteristicUUID],
       for: svc
     )
   }
@@ -1366,6 +1405,11 @@ extension BarnardEngine: CBPeripheralDelegate {
     // Distinguish B003 read failure (still emit detection with null) from
     // B002 read failure (drop the detection — no RPID, nothing to emit).
     if let error = error {
+      if characteristic.uuid == eventInfoCharacteristicUUID {
+        emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString])
+        readEventCodeHash(for: peripheral)
+        return
+      }
       if characteristic.uuid == displayIdCharacteristicUUID {
         emitDebug(level: "warn", name: "gatt_b003_read_failed", data: [
           "id": id.uuidString,
@@ -1416,6 +1460,18 @@ extension BarnardEngine: CBPeripheralDelegate {
     let value = characteristic.value ?? Data()
 
     switch characteristic.uuid {
+    case eventInfoCharacteristicUUID:
+      do {
+        let hint = try BarnardEventInfoCodec.parse(value)
+        emitDebug(level: "info", name: "gatt_event_info_hint", data: [
+          "id": id.uuidString,
+          "displayName": hint.eventDisplayName,
+          "eventCodeHash": hint.eventCodeHash.hexString,
+        ])
+      } catch {
+        emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString])
+      }
+      readEventCodeHash(for: peripheral)
     case eventCodeHashCharacteristicUUID:
       peripheralReadValues[id]?.eventCodeHash = value
       let matches = eventCodeHashMatches(value)
@@ -1538,9 +1594,51 @@ extension BarnardEngine: CBPeripheralManagerDelegate {
         debugName: "gatt_respond_event_code_hash",
         debugData: ["isEmpty": hash.isEmpty]
       )
+    case eventInfoCharacteristicUUID:
+      respondEventInfoRead(peripheral, request: request)
 
     default:
       peripheral.respond(to: request, withResult: .attributeNotFound)
+    }
+  }
+
+  private func respondEventInfoRead(_ peripheral: CBPeripheralManager, request: CBATTRequest) {
+    let id = request.central.identifier
+    let now = Date()
+    eventInfoSnapshots = eventInfoSnapshots.filter { now.timeIntervalSince($0.value.lastRequest) <= 30 }
+    if request.offset == 0 {
+      do {
+        guard let value = try BarnardEventInfoCodec.payloadIfServing(
+          policy: eventInfoServePolicy,
+          eventCode: rpid.eventCode,
+          eventDisplayName: eventInfoDisplayName,
+          b004EventCodeHash: rpid.getEventCodeHash()
+        ) else {
+          peripheral.respond(to: request, withResult: .readNotPermitted)
+          return
+        }
+        eventInfoSnapshots[id] = EventInfoSnapshot(value: value, lastRequest: now)
+      } catch {
+        peripheral.respond(to: request, withResult: .readNotPermitted)
+        return
+      }
+    }
+    guard var snapshot = eventInfoSnapshots[id] else {
+      peripheral.respond(to: request, withResult: .invalidOffset)
+      return
+    }
+    guard request.offset <= snapshot.value.count else {
+      eventInfoSnapshots.removeValue(forKey: id)
+      peripheral.respond(to: request, withResult: .invalidOffset)
+      return
+    }
+    request.value = snapshot.value.subdata(in: request.offset..<snapshot.value.count)
+    peripheral.respond(to: request, withResult: .success)
+    if request.offset == snapshot.value.count {
+      eventInfoSnapshots.removeValue(forKey: id)
+    } else {
+      snapshot.lastRequest = now
+      eventInfoSnapshots[id] = snapshot
     }
   }
 

--- a/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
@@ -197,7 +197,12 @@ public final class BarnardEngine: NSObject {
   private var isAdvertising = false
   private var eventInfoServePolicy = BarnardEventInfoServePolicy()
   private var eventInfoDisplayName: String?
-  private struct EventInfoSnapshot { var value: Data; var lastRequest: Date }
+  private struct EventInfoSnapshot {
+    var value: Data
+    var eventDisplayName: String?
+    var eventCodeHash: Data
+    var lastRequest: Date
+  }
   private var eventInfoSnapshots: [UUID: EventInfoSnapshot] = [:]
   private var shouldStartScanWhenReady = false
   private var shouldStartAdvertiseWhenReady = false
@@ -459,7 +464,8 @@ public final class BarnardEngine: NSObject {
     organizerDesignated: Bool = false,
     eventActiveForDiscovery: Bool = false,
     eventDisplayName: String? = nil
-  ) {
+  ) throws {
+    if let eventDisplayName { try BarnardEventInfoCodec.validateEventDisplayName(eventDisplayName) }
     eventInfoServePolicy = BarnardEventInfoServePolicy(
       organizerDesignated: organizerDesignated,
       eventActiveForDiscovery: eventActiveForDiscovery
@@ -608,6 +614,7 @@ public final class BarnardEngine: NSObject {
     }
     peripheralManager?.stopAdvertising()
     isAdvertising = false
+    eventInfoSnapshots.removeAll()
     startAdvertiseInternal()
     emitDebug(level: "info", name: "advertise_restart_on_foreground", data: nil)
   }
@@ -1463,11 +1470,14 @@ extension BarnardEngine: CBPeripheralDelegate {
     case eventInfoCharacteristicUUID:
       do {
         let hint = try BarnardEventInfoCodec.parse(value)
-        emitDebug(level: "info", name: "gatt_event_info_hint", data: [
+        var data: [String: Any] = [
           "id": id.uuidString,
-          "displayName": hint.eventDisplayName,
           "eventCodeHash": hint.eventCodeHash.hexString,
-        ])
+        ]
+        #if DEBUG
+        data["displayName"] = hint.eventDisplayName
+        #endif
+        emitDebug(level: "info", name: "gatt_event_info_hint", data: data)
       } catch {
         emitDebug(level: "info", name: "gatt_event_info_unavailable", data: ["id": id.uuidString])
       }
@@ -1617,13 +1627,25 @@ extension BarnardEngine: CBPeripheralManagerDelegate {
           peripheral.respond(to: request, withResult: .readNotPermitted)
           return
         }
-        eventInfoSnapshots[id] = EventInfoSnapshot(value: value, lastRequest: now)
+        eventInfoSnapshots[id] = EventInfoSnapshot(
+          value: value,
+          eventDisplayName: eventInfoDisplayName,
+          eventCodeHash: rpid.getEventCodeHash(),
+          lastRequest: now
+        )
       } catch {
         peripheral.respond(to: request, withResult: .readNotPermitted)
         return
       }
     }
     guard var snapshot = eventInfoSnapshots[id] else {
+      peripheral.respond(to: request, withResult: .invalidOffset)
+      return
+    }
+    guard snapshot.eventDisplayName == eventInfoDisplayName,
+      snapshot.eventCodeHash == rpid.getEventCodeHash()
+    else {
+      eventInfoSnapshots.removeValue(forKey: id)
       peripheral.respond(to: request, withResult: .invalidOffset)
       return
     }

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -7,10 +7,13 @@ import Foundation
 public struct BarnardEventInfo: Equatable {
   public let eventDisplayName: String
   public let eventCodeHash: Data
+  /// Reserved for the optional `0x10` census extension. v1 leaves it absent.
+  public let census: Data?
 
-  public init(eventDisplayName: String, eventCodeHash: Data) {
+  public init(eventDisplayName: String, eventCodeHash: Data, census: Data? = nil) {
     self.eventDisplayName = eventDisplayName
     self.eventCodeHash = eventCodeHash
+    self.census = census
   }
 }
 

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -141,6 +141,12 @@ public enum BarnardEventInfoCodec {
     return BarnardEventInfo(eventDisplayName: displayName, eventCodeHash: eventCodeHash)
   }
 
+  /// A B005 hint is trustworthy only as an unauthenticated hint when it is
+  /// internally consistent with the same Peripheral's B004 response.
+  public static func matchesB004(_ info: BarnardEventInfo, b004EventCodeHash: Data) -> Bool {
+    !b004EventCodeHash.isEmpty && info.eventCodeHash == b004EventCodeHash
+  }
+
   private static func appendLength(_ length: Int, to payload: inout Data) {
     payload.append(UInt8((length >> 8) & 0xff))
     payload.append(UInt8(length & 0xff))

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -1,0 +1,228 @@
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+
+/// The unauthenticated, event-scoped hint carried by B005. It contains no
+/// device, organizer, or other persistent identifier.
+public struct BarnardEventInfo: Equatable {
+  public let eventDisplayName: String
+  public let eventCodeHash: Data
+
+  public init(eventDisplayName: String, eventCodeHash: Data) {
+    self.eventDisplayName = eventDisplayName
+    self.eventCodeHash = eventCodeHash
+  }
+}
+
+/// Local-only authorization state for serving B005. Neither flag is encoded
+/// in the characteristic value and both deliberately default to `false`.
+public struct BarnardEventInfoServePolicy: Equatable {
+  public var organizerDesignated: Bool
+  public var eventActiveForDiscovery: Bool
+
+  public init(organizerDesignated: Bool = false, eventActiveForDiscovery: Bool = false) {
+    self.organizerDesignated = organizerDesignated
+    self.eventActiveForDiscovery = eventActiveForDiscovery
+  }
+
+  var mayServe: Bool { organizerDesignated && eventActiveForDiscovery }
+}
+
+public enum BarnardEventInfoError: Error, Equatable {
+  case invalidPayloadLength
+  case unsupportedFormatVersion
+  case truncatedTlv
+  case zeroTlvType
+  case unorderedTlvTypes
+  case missingDisplayName
+  case missingEventCodeHash
+  case invalidDisplayName
+  case invalidEventCodeHash
+  case eventCodeHashMismatch
+}
+
+/// B005's pure canonical encoder and strict parser. The encoder intentionally
+/// delegates its hash derivation to the existing B004 implementation.
+public enum BarnardEventInfoCodec {
+  public static let formatVersion: UInt8 = 1
+  public static let maximumPayloadBytes = 512
+  public static let maximumDisplayNameBytes = 64
+
+  public static func payloadIfServing(
+    policy: BarnardEventInfoServePolicy,
+    eventCode: String?,
+    eventDisplayName: String?,
+    b004EventCodeHash: Data
+  ) throws -> Data? {
+    guard policy.mayServe,
+      let eventCode,
+      !eventCode.isEmpty,
+      let eventDisplayName
+    else { return nil }
+    return try serialize(
+      eventCode: eventCode,
+      eventDisplayName: eventDisplayName,
+      b004EventCodeHash: b004EventCodeHash
+    )
+  }
+
+  public static func serialize(
+    eventCode: String,
+    eventDisplayName: String,
+    b004EventCodeHash: Data
+  ) throws -> Data {
+    let displayNameBytes = try canonicalDisplayNameBytes(eventDisplayName)
+    let eventCodeHash = BarnardCrypto.computeEventCodeHash(eventCode)
+    guard eventCodeHash.count == 8, eventCodeHash == b004EventCodeHash else {
+      throw BarnardEventInfoError.eventCodeHashMismatch
+    }
+
+    var payload = Data([formatVersion, 0x01])
+    appendLength(displayNameBytes.count, to: &payload)
+    payload.append(displayNameBytes)
+    payload.append(0x02)
+    appendLength(eventCodeHash.count, to: &payload)
+    payload.append(eventCodeHash)
+    guard (16...maximumPayloadBytes).contains(payload.count) else {
+      throw BarnardEventInfoError.invalidPayloadLength
+    }
+    return payload
+  }
+
+  public static func parse(_ payload: Data) throws -> BarnardEventInfo {
+    guard (16...maximumPayloadBytes).contains(payload.count) else {
+      throw BarnardEventInfoError.invalidPayloadLength
+    }
+    guard payload.first == formatVersion else {
+      throw BarnardEventInfoError.unsupportedFormatVersion
+    }
+
+    var index = 1
+    var previousType = 0
+    var displayName: String?
+    var eventCodeHash: Data?
+    while index < payload.count {
+      guard index + 3 <= payload.count else { throw BarnardEventInfoError.truncatedTlv }
+      let type = Int(payload[index])
+      let length = (Int(payload[index + 1]) << 8) | Int(payload[index + 2])
+      index += 3
+      guard type != 0 else { throw BarnardEventInfoError.zeroTlvType }
+      guard type > previousType else { throw BarnardEventInfoError.unorderedTlvTypes }
+      previousType = type
+      guard length <= payload.count - index else { throw BarnardEventInfoError.truncatedTlv }
+      let value = payload.subdata(in: index..<(index + length))
+      index += length
+
+      switch type {
+      case 0x01:
+        guard displayName == nil else { throw BarnardEventInfoError.unorderedTlvTypes }
+        displayName = try validatedDisplayName(value)
+      case 0x02:
+        guard eventCodeHash == nil, value.count == 8 else {
+          throw BarnardEventInfoError.invalidEventCodeHash
+        }
+        eventCodeHash = value
+      default:
+        continue // Structurally valid extensions are intentionally ignorable.
+      }
+    }
+
+    guard index == payload.count else { throw BarnardEventInfoError.truncatedTlv }
+    guard let displayName else { throw BarnardEventInfoError.missingDisplayName }
+    guard let eventCodeHash else { throw BarnardEventInfoError.missingEventCodeHash }
+    return BarnardEventInfo(eventDisplayName: displayName, eventCodeHash: eventCodeHash)
+  }
+
+  private static func appendLength(_ length: Int, to payload: inout Data) {
+    payload.append(UInt8((length >> 8) & 0xff))
+    payload.append(UInt8(length & 0xff))
+  }
+
+  private static func canonicalDisplayNameBytes(_ displayName: String) throws -> Data {
+    let bytes = Data(displayName.utf8)
+    // Swift `String ==` uses canonical equivalence, so compare UTF-8 bytes to
+    // detect a decomposed spelling rather than accepting it as NFC.
+    guard bytes == Data(displayName.precomposedStringWithCanonicalMapping.utf8) else {
+      throw BarnardEventInfoError.invalidDisplayName
+    }
+    guard (1...maximumDisplayNameBytes).contains(bytes.count), containsOnlyPermittedScalars(displayName) else {
+      throw BarnardEventInfoError.invalidDisplayName
+    }
+    return bytes
+  }
+
+  private static func validatedDisplayName(_ bytes: Data) throws -> String {
+    guard let displayName = String(data: bytes, encoding: .utf8) else {
+      throw BarnardEventInfoError.invalidDisplayName
+    }
+    _ = try canonicalDisplayNameBytes(displayName)
+    return displayName
+  }
+
+  private static func containsOnlyPermittedScalars(_ value: String) -> Bool {
+    value.unicodeScalars.allSatisfy { scalar in
+      scalar.value > 0x1f && scalar.value != 0x7f
+    }
+  }
+}
+
+public struct BarnardEventInfoDiscoveryObservation: Equatable {
+  public let additionalNamesOmitted: Bool
+  public let additionalEventsOmitted: Bool
+}
+
+/// Bounded, observer-local retention for one five-minute discovery session.
+public final class BarnardEventInfoDiscoverySession {
+  private var startedAt: TimeInterval
+  private var namesByHash: [Data: Set<Data>] = [:]
+  public private(set) var additionalNamesOmitted = false
+  public private(set) var additionalEventsOmitted = false
+  public var retainedHashCount: Int { namesByHash.count }
+
+  public init(startedAt: TimeInterval) { self.startedAt = startedAt }
+
+  @discardableResult
+  public func observe(_ info: BarnardEventInfo, now: TimeInterval) -> BarnardEventInfoDiscoveryObservation {
+    if now - startedAt >= 300 {
+      startedAt = now
+      namesByHash.removeAll()
+      additionalNamesOmitted = false
+      additionalEventsOmitted = false
+    }
+    let name = Data(info.eventDisplayName.utf8)
+    if var names = namesByHash[info.eventCodeHash] {
+      if !names.contains(name) && names.count >= 4 { additionalNamesOmitted = true }
+      else { names.insert(name); namesByHash[info.eventCodeHash] = names }
+    } else if namesByHash.count >= 32 {
+      additionalEventsOmitted = true
+    } else {
+      namesByHash[info.eventCodeHash] = [name]
+    }
+    return BarnardEventInfoDiscoveryObservation(
+      additionalNamesOmitted: additionalNamesOmitted,
+      additionalEventsOmitted: additionalEventsOmitted
+    )
+  }
+}
+
+/// B005's bounded connection/read retry policy. Semantic unavailability is
+/// terminal for the session; transport failures get one retry after 30s.
+public final class BarnardEventInfoRetryBudget {
+  private var attempts: [UUID: Int] = [:]
+  private var retryAfter: [UUID: TimeInterval] = [:]
+  private var semanticUnavailable: Set<UUID> = []
+
+  public init() {}
+  public func canStart(_ peer: UUID, now: TimeInterval) -> Bool {
+    !semanticUnavailable.contains(peer) && (attempts[peer] ?? 0) < 2 && now >= (retryAfter[peer] ?? 0)
+  }
+  @discardableResult public func recordRecoverableFailure(_ peer: UUID, now: TimeInterval) -> TimeInterval? {
+    let next = (attempts[peer] ?? 0) + 1
+    attempts[peer] = next
+    guard next < 2 else { return nil }
+    let deadline = now + 30
+    retryAfter[peer] = deadline
+    return deadline
+  }
+  public func recordSemanticUnavailable(_ peer: UUID) { semanticUnavailable.insert(peer) }
+}

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -89,7 +89,12 @@ public enum BarnardEventInfoCodec {
     return payload
   }
 
-  public static func parse(_ payload: Data) throws -> BarnardEventInfo {
+  public static func validateEventDisplayName(_ eventDisplayName: String) throws {
+    _ = try canonicalDisplayNameBytes(eventDisplayName)
+  }
+
+  public static func parse(_ input: Data) throws -> BarnardEventInfo {
+    let payload = Data(input)
     guard (16...maximumPayloadBytes).contains(payload.count) else {
       throw BarnardEventInfoError.invalidPayloadLength
     }
@@ -225,4 +230,14 @@ public final class BarnardEventInfoRetryBudget {
     return deadline
   }
   public func recordSemanticUnavailable(_ peer: UUID) { semanticUnavailable.insert(peer) }
+  public func clear(_ peer: UUID) {
+    attempts.removeValue(forKey: peer)
+    retryAfter.removeValue(forKey: peer)
+    semanticUnavailable.remove(peer)
+  }
+  public func clearAll() {
+    attempts.removeAll()
+    retryAfter.removeAll()
+    semanticUnavailable.removeAll()
+  }
 }

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -222,6 +222,7 @@ public final class BarnardEventInfoDiscoverySession {
 /// B005's bounded connection/read retry policy. Semantic unavailability is
 /// terminal for the session; transport failures get one retry after 30s.
 public final class BarnardEventInfoRetryBudget {
+  private let lock = NSLock()
   private var attempts: [UUID: Int] = [:]
   private var retryAfter: [UUID: TimeInterval] = [:]
   private var semanticUnavailable: Set<UUID> = []
@@ -229,41 +230,57 @@ public final class BarnardEventInfoRetryBudget {
 
   public init() {}
   public func canStart(_ peer: UUID, now: TimeInterval) -> Bool {
-    prune(now: now)
-    lastSeen[peer] = now
-    return !semanticUnavailable.contains(peer) && (attempts[peer] ?? 0) < 2 && now >= (retryAfter[peer] ?? 0)
+    synchronized {
+      prune(now: now)
+      lastSeen[peer] = now
+      return !semanticUnavailable.contains(peer) && (attempts[peer] ?? 0) < 2 && now >= (retryAfter[peer] ?? 0)
+    }
   }
   @discardableResult public func recordRecoverableFailure(_ peer: UUID, now: TimeInterval) -> TimeInterval? {
-    prune(now: now)
-    lastSeen[peer] = now
-    let next = (attempts[peer] ?? 0) + 1
-    attempts[peer] = next
-    guard next < 2 else { return nil }
-    let deadline = now + 30
-    retryAfter[peer] = deadline
-    return deadline
+    synchronized {
+      prune(now: now)
+      lastSeen[peer] = now
+      let next = (attempts[peer] ?? 0) + 1
+      attempts[peer] = next
+      guard next < 2 else { return nil }
+      let deadline = now + 30
+      retryAfter[peer] = deadline
+      return deadline
+    }
   }
   public func recordSemanticUnavailable(_ peer: UUID, now: TimeInterval = Date().timeIntervalSince1970) {
-    prune(now: now)
-    lastSeen[peer] = now
-    semanticUnavailable.insert(peer)
+    synchronized {
+      prune(now: now)
+      lastSeen[peer] = now
+      semanticUnavailable.insert(peer)
+    }
   }
   public func clear(_ peer: UUID) {
+    synchronized { remove(peer) }
+  }
+  public func clearAll() {
+    synchronized {
+      attempts.removeAll()
+      retryAfter.removeAll()
+      semanticUnavailable.removeAll()
+      lastSeen.removeAll()
+    }
+  }
+  private func synchronized<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
+  private func remove(_ peer: UUID) {
     attempts.removeValue(forKey: peer)
     retryAfter.removeValue(forKey: peer)
     semanticUnavailable.remove(peer)
     lastSeen.removeValue(forKey: peer)
   }
-  public func clearAll() {
-    attempts.removeAll()
-    retryAfter.removeAll()
-    semanticUnavailable.removeAll()
-    lastSeen.removeAll()
-  }
   private func prune(now: TimeInterval) {
     let stalePeers = lastSeen.compactMap { peer, seenAt in
       now >= seenAt && now - seenAt >= 300 ? peer : nil
     }
-    stalePeers.forEach(clear)
+    stalePeers.forEach(remove)
   }
 }

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -225,12 +225,17 @@ public final class BarnardEventInfoRetryBudget {
   private var attempts: [UUID: Int] = [:]
   private var retryAfter: [UUID: TimeInterval] = [:]
   private var semanticUnavailable: Set<UUID> = []
+  private var lastSeen: [UUID: TimeInterval] = [:]
 
   public init() {}
   public func canStart(_ peer: UUID, now: TimeInterval) -> Bool {
-    !semanticUnavailable.contains(peer) && (attempts[peer] ?? 0) < 2 && now >= (retryAfter[peer] ?? 0)
+    prune(now: now)
+    lastSeen[peer] = now
+    return !semanticUnavailable.contains(peer) && (attempts[peer] ?? 0) < 2 && now >= (retryAfter[peer] ?? 0)
   }
   @discardableResult public func recordRecoverableFailure(_ peer: UUID, now: TimeInterval) -> TimeInterval? {
+    prune(now: now)
+    lastSeen[peer] = now
     let next = (attempts[peer] ?? 0) + 1
     attempts[peer] = next
     guard next < 2 else { return nil }
@@ -238,15 +243,27 @@ public final class BarnardEventInfoRetryBudget {
     retryAfter[peer] = deadline
     return deadline
   }
-  public func recordSemanticUnavailable(_ peer: UUID) { semanticUnavailable.insert(peer) }
+  public func recordSemanticUnavailable(_ peer: UUID, now: TimeInterval = Date().timeIntervalSince1970) {
+    prune(now: now)
+    lastSeen[peer] = now
+    semanticUnavailable.insert(peer)
+  }
   public func clear(_ peer: UUID) {
     attempts.removeValue(forKey: peer)
     retryAfter.removeValue(forKey: peer)
     semanticUnavailable.remove(peer)
+    lastSeen.removeValue(forKey: peer)
   }
   public func clearAll() {
     attempts.removeAll()
     retryAfter.removeAll()
     semanticUnavailable.removeAll()
+    lastSeen.removeAll()
+  }
+  private func prune(now: TimeInterval) {
+    let stalePeers = lastSeen.compactMap { peer, seenAt in
+      now >= seenAt && now - seenAt >= 300 ? peer : nil
+    }
+    stalePeers.forEach(clear)
   }
 }

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -109,6 +109,9 @@ final class BarnardEventInfoTests: XCTestCase {
     retries.recordSemanticUnavailable(UUID())
     retries.clearAll()
     XCTAssertTrue(retries.canStart(peer, now: 0))
+
+    retries.recordSemanticUnavailable(peer, now: 0)
+    XCTAssertTrue(retries.canStart(peer, now: 300))
   }
 
   func testCodecAcceptsExactBoundsAndRejectsAdjacentValues() throws {

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -102,6 +102,13 @@ final class BarnardEventInfoTests: XCTestCase {
     XCTAssertFalse(retries.canStart(peer, now: 60))
     retries.recordSemanticUnavailable(peer)
     XCTAssertFalse(retries.canStart(peer, now: 999))
+
+    retries.clear(peer)
+    XCTAssertTrue(retries.canStart(peer, now: 0))
+    _ = retries.recordRecoverableFailure(peer, now: 0)
+    retries.recordSemanticUnavailable(UUID())
+    retries.clearAll()
+    XCTAssertTrue(retries.canStart(peer, now: 0))
   }
 
   func testCodecAcceptsExactBoundsAndRejectsAdjacentValues() throws {
@@ -113,6 +120,12 @@ final class BarnardEventInfoTests: XCTestCase {
     XCTAssertThrowsError(try BarnardEventInfoCodec.parse(Data(repeating: 0, count: 15)))
     XCTAssertNoThrow(try BarnardEventInfoCodec.parse(b005Payload(totalLength: 512)))
     XCTAssertThrowsError(try BarnardEventInfoCodec.parse(Data(repeating: 0, count: 513)))
+  }
+
+  func testB005HintMustMatchThePeripheralsB004Value() throws {
+    let info = try BarnardEventInfoCodec.parse(b005Payload(totalLength: 16))
+    XCTAssertTrue(BarnardEventInfoCodec.matchesB004(info, b004EventCodeHash: Data(repeating: 0x42, count: 8)))
+    XCTAssertFalse(BarnardEventInfoCodec.matchesB004(info, b004EventCodeHash: Data(repeating: 0x43, count: 8)))
   }
 
   private func b005Payload(totalLength: Int) -> Data {

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -103,6 +103,30 @@ final class BarnardEventInfoTests: XCTestCase {
     retries.recordSemanticUnavailable(peer)
     XCTAssertFalse(retries.canStart(peer, now: 999))
   }
+
+  func testCodecAcceptsExactBoundsAndRejectsAdjacentValues() throws {
+    XCTAssertNoThrow(try BarnardEventInfoCodec.validateEventDisplayName(String(repeating: "a", count: 64)))
+    XCTAssertThrowsError(try BarnardEventInfoCodec.validateEventDisplayName(String(repeating: "a", count: 65)))
+    XCTAssertNoThrow(try BarnardEventInfoCodec.validateEventDisplayName("a"))
+
+    XCTAssertNoThrow(try BarnardEventInfoCodec.parse(b005Payload(totalLength: 16)))
+    XCTAssertThrowsError(try BarnardEventInfoCodec.parse(Data(repeating: 0, count: 15)))
+    XCTAssertNoThrow(try BarnardEventInfoCodec.parse(b005Payload(totalLength: 512)))
+    XCTAssertThrowsError(try BarnardEventInfoCodec.parse(Data(repeating: 0, count: 513)))
+  }
+
+  private func b005Payload(totalLength: Int) -> Data {
+    var payload = Data([1, 0x01, 0x00, 0x01, 0x61, 0x02, 0x00, 0x08])
+    payload.append(Data(repeating: 0x42, count: 8))
+    let extensionLength = totalLength - payload.count - 3
+    if extensionLength > 0 {
+      payload.append(0x10)
+      payload.append(UInt8((extensionLength >> 8) & 0xff))
+      payload.append(UInt8(extensionLength & 0xff))
+      payload.append(Data(repeating: 0, count: extensionLength))
+    }
+    return payload
+  }
 }
 
 private extension Data {

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -36,7 +36,7 @@ final class BarnardEventInfoTests: XCTestCase {
       "020100124261726e61726420436f72652053706c69740200080b9f14789f13968f", // version
       "010100124261726e61726420436f72652053706c69740200080b9f14789f1396", // truncation
       "010200080b9f14789f13968f0100124261726e61726420436f72652053706c6974", // ordering
-      "01010001410200080b9f14789f13968f020000", // duplicate
+      "01010001410200080b9f14789f13968f020000", // unordered repeat of type 0x02
       "01010001ff0200080b9f14789f13968f", // invalid UTF-8
       "0101000241010200080b9f14789f13968f", // control character
       "0101000341cc8a0200080b9f14789f13968f", // non-NFC A + ring
@@ -63,6 +63,12 @@ final class BarnardEventInfoTests: XCTestCase {
       eventDisplayName: "Barnard Core Split",
       b004EventCodeHash: b004
     ))
+    XCTAssertNotNil(try BarnardEventInfoCodec.payloadIfServing(
+      policy: BarnardEventInfoServePolicy(organizerDesignated: true, eventActiveForDiscovery: true),
+      eventCode: "CORE-SPLIT-80",
+      eventDisplayName: "Barnard Core Split",
+      b004EventCodeHash: b004
+    ))
   }
 
   func testDiscoveryRetentionCapsNamesHashesAndResetsAtFiveMinutes() {
@@ -81,6 +87,8 @@ final class BarnardEventInfoTests: XCTestCase {
     XCTAssertTrue(names.observe(BarnardEventInfo(eventDisplayName: "Name 4", eventCodeHash: hash), now: 2).additionalNamesOmitted)
     _ = names.observe(BarnardEventInfo(eventDisplayName: "Fresh", eventCodeHash: hash), now: 300)
     XCTAssertEqual(names.retainedHashCount, 1)
+    XCTAssertFalse(names.additionalNamesOmitted)
+    XCTAssertFalse(names.additionalEventsOmitted)
   }
 
   func testRetryBudgetAllowsOnlyTwoTransportAttemptsWithThirtySecondBackoff() {

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -1,0 +1,114 @@
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+import XCTest
+@testable import Barnard
+
+final class BarnardEventInfoTests: XCTestCase {
+  func testGoldenVectorsSerializeAndParseByteForByte() throws {
+    let vectors: [(String, String, String, String)] = [
+      ("CORE-SPLIT-80", "Barnard Core Split", "0b9f14789f13968f", "010100124261726e61726420436f72652053706c69740200080b9f14789f13968f"),
+      ("東京-2026", "東京 2026", "34dc60f26d21cb94", "0101000be69db1e4baac203230323602000834dc60f26d21cb94"),
+    ]
+
+    for (eventCode, displayName, expectedHash, expectedPayload) in vectors {
+      let b004 = BarnardCrypto.computeEventCodeHash(eventCode)
+      XCTAssertEqual(b004.hexString, expectedHash)
+      let payload = try BarnardEventInfoCodec.serialize(
+        eventCode: eventCode,
+        eventDisplayName: displayName,
+        b004EventCodeHash: b004
+      )
+      XCTAssertEqual(payload.hexString, expectedPayload)
+      XCTAssertEqual(try BarnardEventInfoCodec.parse(payload), BarnardEventInfo(
+        eventDisplayName: displayName,
+        eventCodeHash: b004
+      ))
+    }
+  }
+
+  func testParserSkipsWellFormedUnknownTlvButRejectsMalformedCorpus() throws {
+    let validWithUnknown = Data(hex: "010100124261726e61726420436f72652053706c69740200080b9f14789f13968f100001ff")!
+    XCTAssertEqual(try BarnardEventInfoCodec.parse(validWithUnknown).eventDisplayName, "Barnard Core Split")
+
+    let malformed = [
+      "", // below minimum length
+      "020100124261726e61726420436f72652053706c69740200080b9f14789f13968f", // version
+      "010100124261726e61726420436f72652053706c69740200080b9f14789f1396", // truncation
+      "010200080b9f14789f13968f0100124261726e61726420436f72652053706c6974", // ordering
+      "01010001410200080b9f14789f13968f020000", // duplicate
+      "01010001ff0200080b9f14789f13968f", // invalid UTF-8
+      "0101000241010200080b9f14789f13968f", // control character
+      "0101000341cc8a0200080b9f14789f13968f", // non-NFC A + ring
+    ]
+    for hex in malformed {
+      guard let payload = Data(hex: hex) else {
+        XCTFail("malformed fixture must remain byte-decodable: \(hex)")
+        continue
+      }
+      XCTAssertThrowsError(try BarnardEventInfoCodec.parse(payload), "expected malformed B005 to fail: \(hex)")
+    }
+  }
+
+  func testSerializerRejectsB004MismatchAndDisabledPolicy() throws {
+    let b004 = BarnardCrypto.computeEventCodeHash("CORE-SPLIT-80")
+    XCTAssertThrowsError(try BarnardEventInfoCodec.serialize(
+      eventCode: "CORE-SPLIT-80",
+      eventDisplayName: "Barnard Core Split",
+      b004EventCodeHash: Data(repeating: 0, count: 8)
+    ))
+    XCTAssertNil(try BarnardEventInfoCodec.payloadIfServing(
+      policy: BarnardEventInfoServePolicy(),
+      eventCode: "CORE-SPLIT-80",
+      eventDisplayName: "Barnard Core Split",
+      b004EventCodeHash: b004
+    ))
+  }
+
+  func testDiscoveryRetentionCapsNamesHashesAndResetsAtFiveMinutes() {
+    let session = BarnardEventInfoDiscoverySession(startedAt: 0)
+    for index in 0..<32 {
+      _ = session.observe(BarnardEventInfo(eventDisplayName: "Event \(index)", eventCodeHash: Data(repeating: UInt8(index), count: 8)), now: 1)
+    }
+    XCTAssertEqual(session.retainedHashCount, 32)
+    XCTAssertTrue(session.observe(BarnardEventInfo(eventDisplayName: "Overflow", eventCodeHash: Data(repeating: 0xff, count: 8)), now: 2).additionalEventsOmitted)
+
+    let names = BarnardEventInfoDiscoverySession(startedAt: 0)
+    let hash = Data(repeating: 0x42, count: 8)
+    for index in 0..<4 {
+      _ = names.observe(BarnardEventInfo(eventDisplayName: "Name \(index)", eventCodeHash: hash), now: 1)
+    }
+    XCTAssertTrue(names.observe(BarnardEventInfo(eventDisplayName: "Name 4", eventCodeHash: hash), now: 2).additionalNamesOmitted)
+    _ = names.observe(BarnardEventInfo(eventDisplayName: "Fresh", eventCodeHash: hash), now: 300)
+    XCTAssertEqual(names.retainedHashCount, 1)
+  }
+
+  func testRetryBudgetAllowsOnlyTwoTransportAttemptsWithThirtySecondBackoff() {
+    let retries = BarnardEventInfoRetryBudget()
+    let peer = UUID()
+    XCTAssertTrue(retries.canStart(peer, now: 0))
+    XCTAssertEqual(retries.recordRecoverableFailure(peer, now: 0), 30)
+    XCTAssertFalse(retries.canStart(peer, now: 29))
+    XCTAssertTrue(retries.canStart(peer, now: 30))
+    XCTAssertEqual(retries.recordRecoverableFailure(peer, now: 30), nil)
+    XCTAssertFalse(retries.canStart(peer, now: 60))
+    retries.recordSemanticUnavailable(peer)
+    XCTAssertFalse(retries.canStart(peer, now: 999))
+  }
+}
+
+private extension Data {
+  init?(hex: String) {
+    guard hex.count.isMultiple(of: 2) else { return nil }
+    var bytes = [UInt8]()
+    bytes.reserveCapacity(hex.count / 2)
+    var index = hex.startIndex
+    while index < hex.endIndex {
+      let next = hex.index(index, offsetBy: 2)
+      guard let byte = UInt8(hex[index..<next], radix: 16) else { return nil }
+      bytes.append(byte)
+      index = next
+    }
+    self.init(bytes)
+  }
+}


### PR DESCRIPTION
## Summary
- Add the read-only B005 Event Info GATT characteristic to the Swift and Android discovery services.
- Keep B005 as an optional final GATT read after B004/B002/B003 resolution, with two-attempt, 30-second bounded retry behavior.
- Emit a typed, untrusted B005 hint only when its hash matches the same Peripheral B004 response; retain names and hashes only within the specified session caps.
- Add immutable long-read snapshots, Android callback synchronization, strict parser parity, and no device-unique persistent identifiers on-wire.

## Contract
Implements `specs/113-event-info-discovery` for Issue #115. B005 has no notify/indicate path and contains no device-unique persistent identifier.

## Validation
- Android: `./gradlew testDebugUnitTest` with an isolated Robolectric home: 73 tests passed.
- Swift B005: `xcodebuild … -only-testing:BarnardTests/BarnardEventInfoTests test`: 7 tests passed.
- Swift full suite: deferred to this PR GitHub CI because the local environment previously stalled in the existing secp256k1 signing round-trip.

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional event information discovery over Bluetooth on Android and iOS.
  * Apps can configure event display names and control when information is shared.
  * Event metadata supports validation, privacy-conscious retention, partial reads, and bounded retries.
  * Discovery emits event information hints while preserving existing resolution when data is unavailable.

* **Bug Fixes**
  * Improved handling of malformed data, invalid offsets, connection changes, expiration, policy restrictions, and temporary failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->