### PR TITLE
fix(event-info): address B005 audit follow-ups

### DIFF
--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -832,7 +832,7 @@ public class BarnardEngine(private val appContext: Context) {
         }
         val hint = BarnardEventInfoHintEvent(
             peripheralId = address,
-            eventInfo = if (observation.shouldEmitGenericHint) null else eventInfo,
+            eventInfo = eventInfoForDiscoveryHint(eventInfo, observation.shouldEmitGenericHint),
             additionalNamesOmitted = observation.additionalNamesOmitted,
             additionalEventsOmitted = observation.additionalEventsOmitted,
         )

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngine.kt
@@ -40,6 +40,9 @@ import java.util.concurrent.ConcurrentHashMap
 
 private const val TAG = "BarnardEngine"
 
+internal fun shouldDiscardEventInfoSnapshotAfterResponse(status: Int, responseSent: Boolean): Boolean =
+    status == BluetoothGatt.GATT_SUCCESS && !responseSent
+
 internal fun isRuntimePermissionRequestBlocked(
     sdkInt: Int,
     hasPermission: Boolean,
@@ -829,7 +832,7 @@ public class BarnardEngine(private val appContext: Context) {
         }
         val hint = BarnardEventInfoHintEvent(
             peripheralId = address,
-            eventInfo = eventInfo,
+            eventInfo = if (observation.shouldEmitGenericHint) null else eventInfo,
             additionalNamesOmitted = observation.additionalNamesOmitted,
             additionalEventsOmitted = observation.additionalEventsOmitted,
         )
@@ -1513,7 +1516,7 @@ public class BarnardEngine(private val appContext: Context) {
                             "address" to address,
                             "eventCodeHash" to hint.eventCodeHash.toHex(),
                         ) + if (isDebugBuild()) mapOf("displayName" to hint.eventDisplayName) else emptyMap())
-                        eventInfoRetryBudget.clear(address)
+                        eventInfoRetryBudget.recordSuccessfulAttempt(address, System.currentTimeMillis())
                         emitEventInfoHint(address, hint)
                     } catch (_: IllegalArgumentException) {
                         eventInfoRetryBudget.recordSemanticUnavailable(address)
@@ -1782,6 +1785,13 @@ public class BarnardEngine(private val appContext: Context) {
             if (offset == snapshot.value.size) eventInfoSnapshots.remove(key) else snapshot.lastRequestAtMs = now
             Outcome(BluetoothGatt.GATT_SUCCESS, slice)
         }
-        server.sendResponse(device, requestId, outcome.status, offset, outcome.value)
+        val responseSent = server.sendResponse(device, requestId, outcome.status, offset, outcome.value)
+        if (shouldDiscardEventInfoSnapshotAfterResponse(outcome.status, responseSent)) {
+            val address = device.address ?: ""
+            val key = "$address:${eventInfoConnectionEpochs[address] ?: 0L}"
+            synchronized(eventInfoStateLock) {
+                eventInfoSnapshots.remove(key)
+            }
+        }
     }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngineTypes.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngineTypes.kt
@@ -144,10 +144,14 @@ public data class BarnardConstraintEvent(
     val requiredAction: String?,
 )
 
-/** Parsed B005 hint retained only for the current discovery session. */
+/**
+ * B005 hint retained only for the current discovery session. Hosts MUST NOT
+ * retain this hint data beyond that session. A generic overflow hint has no
+ * [eventInfo], so its parsed display name and hash cannot escape the session.
+ */
 public data class BarnardEventInfoHintEvent(
     val peripheralId: String,
-    val eventInfo: BarnardEventInfo,
+    val eventInfo: BarnardEventInfo?,
     val additionalNamesOmitted: Boolean,
     val additionalEventsOmitted: Boolean,
 )

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngineTypes.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEngineTypes.kt
@@ -146,12 +146,12 @@ public data class BarnardConstraintEvent(
 
 /**
  * B005 hint retained only for the current discovery session. Hosts MUST NOT
- * retain this hint data beyond that session. A generic overflow hint has no
- * [eventInfo], so its parsed display name and hash cannot escape the session.
+ * retain this hint data beyond that session. A generic overflow hint has an
+ * empty [eventInfo], so no parsed display name or hash can escape the session.
  */
 public data class BarnardEventInfoHintEvent(
     val peripheralId: String,
-    val eventInfo: BarnardEventInfo?,
+    val eventInfo: BarnardEventInfo,
     val additionalNamesOmitted: Boolean,
     val additionalEventsOmitted: Boolean,
 )

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -12,15 +12,20 @@ import java.text.Normalizer
 public class BarnardEventInfo(
     public val eventDisplayName: String,
     eventCodeHash: ByteArray,
+    census: ByteArray? = null,
 ) {
     public val eventCodeHash: ByteArray = eventCodeHash.copyOf()
+    /** Reserved for the optional 0x10 census extension. v1 leaves it absent. */
+    public val census: ByteArray? = census?.copyOf()
 
     override fun equals(other: Any?): Boolean =
         other is BarnardEventInfo &&
             eventDisplayName == other.eventDisplayName &&
-            eventCodeHash.contentEquals(other.eventCodeHash)
+            eventCodeHash.contentEquals(other.eventCodeHash) &&
+            census.contentEquals(other.census)
 
-    override fun hashCode(): Int = 31 * eventDisplayName.hashCode() + eventCodeHash.contentHashCode()
+    override fun hashCode(): Int =
+        31 * (31 * eventDisplayName.hashCode() + eventCodeHash.contentHashCode()) + census.contentHashCode()
 }
 
 /** Kotlin mirror of Swift's [BarnardEventInfoError] reasons. */
@@ -166,6 +171,7 @@ public object BarnardEventInfoCodec {
 public data class BarnardEventInfoDiscoveryObservation(
     val additionalNamesOmitted: Boolean,
     val additionalEventsOmitted: Boolean,
+    val shouldEmitGenericHint: Boolean,
 )
 
 /** Bounded, observer-local state for one five-minute B005 discovery session. */
@@ -189,13 +195,21 @@ public class BarnardEventInfoDiscoverySession(startedAtMs: Long) {
         val hash = info.eventCodeHash.toHex()
         val name = info.eventDisplayName
         val names = namesByHash[hash]
+        var overflowedThisObservation = false
         when {
             names != null && name !in names && names.size >= 4 -> additionalNamesOmitted = true
             names != null -> names += name
-            namesByHash.size >= 32 -> additionalEventsOmitted = true
+            namesByHash.size >= 32 -> {
+                additionalEventsOmitted = true
+                overflowedThisObservation = true
+            }
             else -> namesByHash[hash] = mutableSetOf(name)
         }
-        return BarnardEventInfoDiscoveryObservation(additionalNamesOmitted, additionalEventsOmitted)
+        return BarnardEventInfoDiscoveryObservation(
+            additionalNamesOmitted,
+            additionalEventsOmitted,
+            overflowedThisObservation,
+        )
     }
 }
 
@@ -221,6 +235,15 @@ public class BarnardEventInfoRetryBudget {
         attempts[peer] = count
         if (count >= 2) return null
         return (nowMs + 30_000L).also { retryAfterMs[peer] = it }
+    }
+
+    /** A successful B005 read still consumes one of the two session attempts. */
+    @Synchronized
+    public fun recordSuccessfulAttempt(peer: String, nowMs: Long) {
+        prune(nowMs)
+        lastSeenMs[peer] = nowMs
+        attempts[peer] = (attempts[peer] ?: 0) + 1
+        retryAfterMs.remove(peer)
     }
 
     @Synchronized

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -174,6 +174,12 @@ public data class BarnardEventInfoDiscoveryObservation(
     val shouldEmitGenericHint: Boolean,
 )
 
+/** Replaces an overflowed B005 hint with a marker that has no parsed data. */
+internal fun eventInfoForDiscoveryHint(
+    eventInfo: BarnardEventInfo,
+    shouldEmitGenericHint: Boolean,
+): BarnardEventInfo = if (shouldEmitGenericHint) BarnardEventInfo("", ByteArray(0)) else eventInfo
+
 /** Bounded, observer-local state for one five-minute B005 discovery session. */
 public class BarnardEventInfoDiscoverySession(startedAtMs: Long) {
     private var startedAtMs = startedAtMs

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardEventInfo.kt
@@ -14,18 +14,25 @@ public class BarnardEventInfo(
     eventCodeHash: ByteArray,
     census: ByteArray? = null,
 ) {
-    public val eventCodeHash: ByteArray = eventCodeHash.copyOf()
-    /** Reserved for the optional 0x10 census extension. v1 leaves it absent. */
-    public val census: ByteArray? = census?.copyOf()
+    private val eventCodeHashBytes: ByteArray = eventCodeHash.copyOf()
+    private val censusBytes: ByteArray? = census?.copyOf()
+
+    /** Returns a defensive copy; mutating it cannot affect equality or hashing. */
+    public val eventCodeHash: ByteArray
+        get() = eventCodeHashBytes.copyOf()
+
+    /** Reserved for the optional 0x10 census extension. v1 leaves it absent. Returns a defensive copy. */
+    public val census: ByteArray?
+        get() = censusBytes?.copyOf()
 
     override fun equals(other: Any?): Boolean =
         other is BarnardEventInfo &&
             eventDisplayName == other.eventDisplayName &&
-            eventCodeHash.contentEquals(other.eventCodeHash) &&
-            census.contentEquals(other.census)
+            eventCodeHashBytes.contentEquals(other.eventCodeHashBytes) &&
+            censusBytes.contentEquals(other.censusBytes)
 
     override fun hashCode(): Int =
-        31 * (31 * eventDisplayName.hashCode() + eventCodeHash.contentHashCode()) + census.contentHashCode()
+        31 * (31 * eventDisplayName.hashCode() + eventCodeHashBytes.contentHashCode()) + censusBytes.contentHashCode()
 }
 
 /** Kotlin mirror of Swift's [BarnardEventInfoError] reasons. */

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -1,14 +1,23 @@
 package org.levarac.barnard
 
+import android.bluetooth.BluetoothGatt
 import org.levarac.barnard.BarnardCrypto.toHex
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class BarnardEventInfoTest {
+    @Test
+    fun failedSuccessfulB005ResponseDiscardsItsSnapshot() {
+        assertEquals(true, shouldDiscardEventInfoSnapshotAfterResponse(BluetoothGatt.GATT_SUCCESS, responseSent = false))
+        assertEquals(false, shouldDiscardEventInfoSnapshotAfterResponse(BluetoothGatt.GATT_SUCCESS, responseSent = true))
+        assertEquals(false, shouldDiscardEventInfoSnapshotAfterResponse(BluetoothGatt.GATT_READ_NOT_PERMITTED, responseSent = false))
+    }
+
     @Test
     fun goldenVectorsSerializeAndParseByteForByte() {
         val vectors = listOf(
@@ -75,7 +84,10 @@ class BarnardEventInfoTest {
             session.observe(BarnardEventInfo("Event $index", ByteArray(8) { index.toByte() }), 1L)
         }
         assertEquals(32, session.retainedHashCount)
-        assertEquals(true, session.observe(BarnardEventInfo("Overflow", ByteArray(8) { 0xff.toByte() }), 2L).additionalEventsOmitted)
+        val overflow = session.observe(BarnardEventInfo("Overflow", ByteArray(8) { 0xff.toByte() }), 2L)
+        assertEquals(true, overflow.additionalEventsOmitted)
+        assertEquals(true, overflow.shouldEmitGenericHint)
+        assertEquals(32, session.retainedHashCount)
 
         val names = BarnardEventInfoDiscoverySession(0L)
         val hash = ByteArray(8) { 0x42 }
@@ -97,6 +109,14 @@ class BarnardEventInfoTest {
         assertEquals(true, retries.canStart(peer, 30_000L))
         assertEquals(null, retries.recordRecoverableFailure(peer, 30_000L))
         assertEquals(false, retries.canStart(peer, 60_000L))
+
+        retries.clear(peer)
+        assertEquals(true, retries.canStart(peer, 0L))
+        retries.recordSuccessfulAttempt(peer, 0L)
+        assertEquals(true, retries.canStart(peer, 1L))
+        retries.recordSuccessfulAttempt(peer, 1L)
+        assertEquals(false, retries.canStart(peer, 2L))
+
         retries.recordSemanticUnavailable(peer)
         assertEquals(false, retries.canStart(peer, 999_000L))
 
@@ -144,6 +164,10 @@ class BarnardEventInfoTest {
         assertEquals(
             BarnardEventInfo("Event", ByteArray(8) { 0x42 }),
             BarnardEventInfo("Event", ByteArray(8) { 0x42 }),
+        )
+        assertNotEquals(
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }),
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01)),
         )
         val failure = assertThrows(BarnardEventInfoException::class.java) {
             BarnardEventInfoCodec.parse(ByteArray(15))

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -175,6 +175,21 @@ class BarnardEventInfoTest {
             BarnardEventInfo("Event", ByteArray(8) { 0x42 }),
             BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01)),
         )
+        assertEquals(
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01, 0x02)),
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01, 0x02)),
+        )
+        assertNotEquals(
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01, 0x02)),
+            BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01, 0x03)),
+        )
+        // Mutating an accessor's returned array must not affect equality or hashing.
+        val defensive = BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01))
+        val expectedHash = defensive.hashCode()
+        defensive.eventCodeHash[0] = 0x00
+        defensive.census!![0] = 0x7f
+        assertEquals(expectedHash, defensive.hashCode())
+        assertEquals(BarnardEventInfo("Event", ByteArray(8) { 0x42 }, census = byteArrayOf(0x01)), defensive)
         val failure = assertThrows(BarnardEventInfoException::class.java) {
             BarnardEventInfoCodec.parse(ByteArray(15))
         }

--- a/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
+++ b/packages/android/barnard/src/test/kotlin/org/levarac/barnard/BarnardEventInfoTest.kt
@@ -88,6 +88,12 @@ class BarnardEventInfoTest {
         assertEquals(true, overflow.additionalEventsOmitted)
         assertEquals(true, overflow.shouldEmitGenericHint)
         assertEquals(32, session.retainedHashCount)
+        val genericHint = eventInfoForDiscoveryHint(
+            BarnardEventInfo("Overflow", ByteArray(8) { 0xff.toByte() }),
+            overflow.shouldEmitGenericHint,
+        )
+        assertEquals("", genericHint.eventDisplayName)
+        assertArrayEquals(ByteArray(0), genericHint.eventCodeHash)
 
         val names = BarnardEventInfoDiscoverySession(0L)
         val hash = ByteArray(8) { 0x42 }

--- a/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
@@ -118,7 +118,8 @@ public struct BarnardConstraintEvent {
 
 public struct BarnardEventInfoHintEvent {
   public let peripheralId: UUID
-  public let eventInfo: BarnardEventInfo
+  /// Nil for an overflow marker. Hosts must not retain hint data past the discovery session.
+  public let eventInfo: BarnardEventInfo?
   public let additionalNamesOmitted: Bool
   public let additionalEventsOmitted: Bool
 }
@@ -590,6 +591,7 @@ public final class BarnardEngine: NSObject {
   public func dispose() {
     stopScanInternal()
     stopAdvertiseInternal()
+    eventInfoSnapshots.removeAll()
   }
 
   public func joinEvent(_ eventCode: String) {
@@ -1165,7 +1167,7 @@ public final class BarnardEngine: NSObject {
     let observation = eventInfoDiscoverySession.observe(eventInfo, now: Date().timeIntervalSince1970)
     onEvent?(.eventInfoHint(BarnardEventInfoHintEvent(
       peripheralId: peripheralId,
-      eventInfo: eventInfo,
+      eventInfo: observation.shouldEmitGenericHint ? nil : eventInfo,
       additionalNamesOmitted: observation.additionalNamesOmitted,
       additionalEventsOmitted: observation.additionalEventsOmitted
     )))
@@ -1540,7 +1542,7 @@ extension BarnardEngine: CBPeripheralDelegate {
         data["displayName"] = hint.eventDisplayName
         #endif
         emitDebug(level: "info", name: "gatt_event_info_hint", data: data)
-        eventInfoRetryBudget.clear(id)
+        eventInfoRetryBudget.recordSuccessfulAttempt(id, now: Date().timeIntervalSince1970)
         emitEventInfoHint(peripheralId: id, eventInfo: hint)
       } catch {
         eventInfoRetryBudget.recordSemanticUnavailable(id)

--- a/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEngine.swift
@@ -118,8 +118,8 @@ public struct BarnardConstraintEvent {
 
 public struct BarnardEventInfoHintEvent {
   public let peripheralId: UUID
-  /// Nil for an overflow marker. Hosts must not retain hint data past the discovery session.
-  public let eventInfo: BarnardEventInfo?
+  /// Empty for an overflow marker. Hosts must not retain hint data past the discovery session.
+  public let eventInfo: BarnardEventInfo
   public let additionalNamesOmitted: Bool
   public let additionalEventsOmitted: Bool
 }
@@ -1167,7 +1167,10 @@ public final class BarnardEngine: NSObject {
     let observation = eventInfoDiscoverySession.observe(eventInfo, now: Date().timeIntervalSince1970)
     onEvent?(.eventInfoHint(BarnardEventInfoHintEvent(
       peripheralId: peripheralId,
-      eventInfo: observation.shouldEmitGenericHint ? nil : eventInfo,
+      eventInfo: eventInfoForDiscoveryHint(
+        eventInfo,
+        shouldEmitGenericHint: observation.shouldEmitGenericHint
+      ),
       additionalNamesOmitted: observation.additionalNamesOmitted,
       additionalEventsOmitted: observation.additionalEventsOmitted
     )))

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -186,6 +186,14 @@ public struct BarnardEventInfoDiscoveryObservation: Equatable {
   public let shouldEmitGenericHint: Bool
 }
 
+/// Replaces an overflowed B005 hint with a marker that has no parsed data.
+func eventInfoForDiscoveryHint(
+  _ eventInfo: BarnardEventInfo,
+  shouldEmitGenericHint: Bool
+) -> BarnardEventInfo {
+  shouldEmitGenericHint ? BarnardEventInfo(eventDisplayName: "", eventCodeHash: Data()) : eventInfo
+}
+
 /// Bounded, observer-local retention for one five-minute discovery session.
 public final class BarnardEventInfoDiscoverySession {
   private var startedAt: TimeInterval

--- a/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardEventInfo.swift
@@ -183,6 +183,7 @@ public enum BarnardEventInfoCodec {
 public struct BarnardEventInfoDiscoveryObservation: Equatable {
   public let additionalNamesOmitted: Bool
   public let additionalEventsOmitted: Bool
+  public let shouldEmitGenericHint: Bool
 }
 
 /// Bounded, observer-local retention for one five-minute discovery session.
@@ -204,17 +205,20 @@ public final class BarnardEventInfoDiscoverySession {
       additionalEventsOmitted = false
     }
     let name = Data(info.eventDisplayName.utf8)
+    var overflowedThisObservation = false
     if var names = namesByHash[info.eventCodeHash] {
       if !names.contains(name) && names.count >= 4 { additionalNamesOmitted = true }
       else { names.insert(name); namesByHash[info.eventCodeHash] = names }
     } else if namesByHash.count >= 32 {
       additionalEventsOmitted = true
+      overflowedThisObservation = true
     } else {
       namesByHash[info.eventCodeHash] = [name]
     }
     return BarnardEventInfoDiscoveryObservation(
       additionalNamesOmitted: additionalNamesOmitted,
-      additionalEventsOmitted: additionalEventsOmitted
+      additionalEventsOmitted: additionalEventsOmitted,
+      shouldEmitGenericHint: overflowedThisObservation
     )
   }
 }
@@ -246,6 +250,15 @@ public final class BarnardEventInfoRetryBudget {
       let deadline = now + 30
       retryAfter[peer] = deadline
       return deadline
+    }
+  }
+  /// A successful B005 read still consumes one of the two session attempts.
+  public func recordSuccessfulAttempt(_ peer: UUID, now: TimeInterval) {
+    synchronized {
+      prune(now: now)
+      lastSeen[peer] = now
+      attempts[peer] = (attempts[peer] ?? 0) + 1
+      retryAfter.removeValue(forKey: peer)
     }
   }
   public func recordSemanticUnavailable(_ peer: UUID, now: TimeInterval = Date().timeIntervalSince1970) {

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -154,6 +154,14 @@ final class BarnardEventInfoTests: XCTestCase {
       BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash),
       BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash, census: Data([0x01]))
     )
+    XCTAssertEqual(
+      BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash, census: Data([0x01, 0x02])),
+      BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash, census: Data([0x01, 0x02]))
+    )
+    XCTAssertNotEqual(
+      BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash, census: Data([0x01, 0x02])),
+      BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash, census: Data([0x01, 0x03]))
+    )
   }
 
   private func b005Payload(totalLength: Int) -> Data {

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -81,6 +81,12 @@ final class BarnardEventInfoTests: XCTestCase {
     XCTAssertTrue(overflow.additionalEventsOmitted)
     XCTAssertTrue(overflow.shouldEmitGenericHint)
     XCTAssertEqual(session.retainedHashCount, 32)
+    let genericHint = eventInfoForDiscoveryHint(
+      BarnardEventInfo(eventDisplayName: "Overflow", eventCodeHash: Data(repeating: 0xff, count: 8)),
+      shouldEmitGenericHint: overflow.shouldEmitGenericHint
+    )
+    XCTAssertEqual(genericHint.eventDisplayName, "")
+    XCTAssertEqual(genericHint.eventCodeHash, Data())
 
     let names = BarnardEventInfoDiscoverySession(startedAt: 0)
     let hash = Data(repeating: 0x42, count: 8)

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardEventInfoTests.swift
@@ -77,7 +77,10 @@ final class BarnardEventInfoTests: XCTestCase {
       _ = session.observe(BarnardEventInfo(eventDisplayName: "Event \(index)", eventCodeHash: Data(repeating: UInt8(index), count: 8)), now: 1)
     }
     XCTAssertEqual(session.retainedHashCount, 32)
-    XCTAssertTrue(session.observe(BarnardEventInfo(eventDisplayName: "Overflow", eventCodeHash: Data(repeating: 0xff, count: 8)), now: 2).additionalEventsOmitted)
+    let overflow = session.observe(BarnardEventInfo(eventDisplayName: "Overflow", eventCodeHash: Data(repeating: 0xff, count: 8)), now: 2)
+    XCTAssertTrue(overflow.additionalEventsOmitted)
+    XCTAssertTrue(overflow.shouldEmitGenericHint)
+    XCTAssertEqual(session.retainedHashCount, 32)
 
     let names = BarnardEventInfoDiscoverySession(startedAt: 0)
     let hash = Data(repeating: 0x42, count: 8)
@@ -100,6 +103,14 @@ final class BarnardEventInfoTests: XCTestCase {
     XCTAssertTrue(retries.canStart(peer, now: 30))
     XCTAssertEqual(retries.recordRecoverableFailure(peer, now: 30), nil)
     XCTAssertFalse(retries.canStart(peer, now: 60))
+
+    retries.clear(peer)
+    XCTAssertTrue(retries.canStart(peer, now: 0))
+    retries.recordSuccessfulAttempt(peer, now: 0)
+    XCTAssertTrue(retries.canStart(peer, now: 1))
+    retries.recordSuccessfulAttempt(peer, now: 1)
+    XCTAssertFalse(retries.canStart(peer, now: 2))
+
     retries.recordSemanticUnavailable(peer)
     XCTAssertFalse(retries.canStart(peer, now: 999))
 
@@ -129,6 +140,14 @@ final class BarnardEventInfoTests: XCTestCase {
     let info = try BarnardEventInfoCodec.parse(b005Payload(totalLength: 16))
     XCTAssertTrue(BarnardEventInfoCodec.matchesB004(info, b004EventCodeHash: Data(repeating: 0x42, count: 8)))
     XCTAssertFalse(BarnardEventInfoCodec.matchesB004(info, b004EventCodeHash: Data(repeating: 0x43, count: 8)))
+  }
+
+  func testEventInfoEqualityIncludesReservedCensus() {
+    let eventCodeHash = Data(repeating: 0x42, count: 8)
+    XCTAssertNotEqual(
+      BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash),
+      BarnardEventInfo(eventDisplayName: "Event", eventCodeHash: eventCodeHash, census: Data([0x01]))
+    )
   }
 
   private func b005Payload(totalLength: Int) -> Data {


### PR DESCRIPTION
## Summary

- discard an Android B005 long-read snapshot when the platform rejects a successful response
- clear Swift B005 snapshots on engine disposal and count successful reads against the per-session retry budget on both platforms
- emit a generic overflow hint for a 33rd event hash, document session-only host retention, and add Kotlin's reserved `census` parity field

## Contract and compatibility

Implements the follow-ups to [the B005 event-info discovery spec](specs/113-event-info-discovery/spec.md). No on-wire payload, schema, or device-unique persistent identifier changes are introduced. The generic overflow marker intentionally carries no parsed event name or hash.

## Validation

- `JAVA_HOME=/Applications/Android Studio.app/Contents/jbr/Contents/Home ./gradlew testDebugUnitTest` (74 tests passed)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swiftc -parse Sources/Barnard/BarnardEventInfo.swift Sources/Barnard/BarnardEngine.swift Tests/BarnardTests/BarnardEventInfoTests.swift` (passed)
- SwiftPM XCTest execution is deferred to CI: the package's iOS `UIKit` target cannot be built as a macOS SwiftPM test target locally.

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event information discovery when event limits are exceeded by providing clear generic hints.
  - Prevented stale event snapshots from being retained after unsuccessful delivery or when discovery ends.
  - Improved retry handling so successful event-information reads correctly consume retry attempts and clear delays.
  - Preserved optional census details when comparing event information.
- **Documentation**
  - Clarified that event-information hints are limited to the current discovery session and should not be retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->