### PR TITLE
perf(swift): memoize the per-event signing key derivation

### DIFF
--- a/packages/swift/barnard/Sources/Barnard/BarnardIdentity.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardIdentity.swift
@@ -29,10 +29,18 @@ public struct BarnardRpidOwnershipProof {
 /// signing identity is rooted in the same secret as the sensing client's
 /// TEK, but the private signing key it derives never leaves this type —
 /// only the public key and signatures do.
+///
+/// Deriving that key costs one secp256k1 scalar multiplication, so an
+/// instance keeps the most recent derivation in memory
+/// (`BarnardSigningKeyCache`). The derived private key is therefore resident
+/// for as long as the instance is alive and its inputs are unchanged, rather
+/// than only for the duration of a call. Hosts that want a narrower window
+/// can release the instance.
 public final class BarnardIdentity {
   private let deviceSecretKey = "barnard.rpidSeed"
   private let keyStorage: any BarnardCoreKeyStorage
   private let randomSource: any BarnardCoreRandomSource
+  private let signingKeyCache = BarnardSigningKeyCache()
 
   public init() {
     keyStorage = BarnardUserDefaultsKeyStorage()
@@ -40,14 +48,13 @@ public final class BarnardIdentity {
   }
 
   public func signingPublicKey(eventCode: String) -> Data {
-    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
-    return keyPair.publicKeyCompressed
+    signingKeyPair(eventCode: eventCode).publicKeyCompressed
   }
 
   /// Signs `SHA256(bytes)` with the per-event signing key derived from
   /// `eventCode`.
   public func sign(eventCode: String, bytes: Data) -> BarnardRecoverableSignature {
-    let keyPair = BarnardSigning.deriveSigningKeyPair(deviceSecret: getOrCreateDeviceSecret(), eventCode: eventCode)
+    let keyPair = signingKeyPair(eventCode: eventCode)
     let messageHash = BarnardCrypto.sha256(bytes)
     let sig = BarnardSigning.signRecoverable(privateKey: keyPair.privateKey, messageHash32: messageHash)
     return BarnardRecoverableSignature(r: sig.r, s: sig.s, v: sig.v)
@@ -82,6 +89,23 @@ public final class BarnardIdentity {
       displayId: displayId
     )
     return BarnardRecoverableSignature(r: sig.r, s: sig.s, v: sig.v)
+  }
+
+  // MARK: - Per-event Signing Key
+
+  /// The signing key pair for `eventCode`, reusing the cached derivation
+  /// when the device secret and event code are unchanged (barnard#124).
+  ///
+  /// The device secret is re-read on every call, and the cache is keyed on
+  /// it: that is what makes a rotated or cleared secret take effect
+  /// immediately. Do not hoist the read out of this method.
+  private func signingKeyPair(eventCode: String) -> BarnardSigning.SigningKeyPair {
+    signingKeyCache.keyPair(
+      deviceSecret: getOrCreateDeviceSecret(),
+      eventCode: eventCode
+    ) { deviceSecret, eventCode in
+      BarnardSigning.deriveSigningKeyPair(deviceSecret: deviceSecret, eventCode: eventCode)
+    }
   }
 
   // MARK: - DeviceSecret Management

--- a/packages/swift/barnard/Sources/Barnard/BarnardSigningKeyCache.swift
+++ b/packages/swift/barnard/Sources/Barnard/BarnardSigningKeyCache.swift
@@ -1,0 +1,113 @@
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+
+/// Single-entry cache for the per-event signing key pair derived from
+/// `(deviceSecret, eventCode)` (barnard#124).
+///
+/// Derivation is deterministic in those two inputs but costs one secp256k1
+/// scalar multiplication, which dominates repeated signing in unoptimized
+/// builds. Caching it is safe only if the cache can never hand back a key
+/// pair derived from different inputs, so this type — not its caller — owns
+/// the cache key:
+///
+/// - The entry is identified by a fingerprint over **both** inputs, computed
+///   here from the arguments actually used for the derivation. That an entry
+///   cannot be addressed by `eventCode` alone is structural: no API exposes
+///   such a lookup. Beyond that, returning a key pair derived from different
+///   inputs would require a SHA-256 collision on the fingerprint — infeasible
+///   under standard assumptions, which is the assumption this cache rests on
+///   rather than an impossibility.
+/// - The fingerprint is a one-way hash. The device secret itself is never
+///   stored by this type.
+/// - The cache retains at most **one entry**, replaced by any lookup with
+///   different inputs, so a rotated or reset device secret misses on its next
+///   use. That bounds what the cache holds, not how many derived private keys
+///   exist: derivation deliberately runs outside the lock, so concurrent cold
+///   misses each hold their own derived key pair for the duration of their
+///   call, and every caller holds the pair it was handed.
+///
+/// Eviction is driven by that next lookup, not by the rotation: what a
+/// rotated secret changes immediately is what the cache *returns*, not what
+/// it still *holds*. The key pair derived from the previous secret stays
+/// resident until a lookup with different inputs overwrites it, or until
+/// `clear()` is called, or for the life of the instance if no further
+/// lookup happens. Both overwrite and `clear()` drop this type's reference;
+/// neither erases key material, and nothing here zeroizes released storage.
+final class BarnardSigningKeyCache {
+  /// Domain separation for the fingerprint. Local to this cache; never
+  /// serialized, stored, or sent on the wire.
+  private static let fingerprintDomainTag = "barnard-signing-key-cache:v1"
+
+  private let lock = NSLock()
+  private var cachedFingerprint: Data?
+  private var cachedKeyPair: BarnardSigning.SigningKeyPair?
+
+  /// Returns the signing key pair for `(deviceSecret, eventCode)`, deriving
+  /// it with `derive` only when the cached entry was built from different
+  /// inputs.
+  ///
+  /// `derive` is called with the lock released: it is the expensive
+  /// operation this cache exists to avoid, and holding a lock across it
+  /// would serialize concurrent signers on it. Two threads racing on a cold
+  /// cache may therefore both derive. That is benign — derivation is a pure
+  /// function of its inputs, so both compute the same key pair, and the
+  /// fingerprint is stored together with the key pair it belongs to, so the
+  /// loser of the race can only cause a redundant miss later, never a hit on
+  /// a mismatched entry.
+  func keyPair(
+    deviceSecret: Data,
+    eventCode: String,
+    derive: (Data, String) -> BarnardSigning.SigningKeyPair
+  ) -> BarnardSigning.SigningKeyPair {
+    let wanted = Self.fingerprint(deviceSecret: deviceSecret, eventCode: eventCode)
+    let hit = synchronized { () -> BarnardSigning.SigningKeyPair? in
+      guard let cachedFingerprint = self.cachedFingerprint, cachedFingerprint == wanted else {
+        return nil
+      }
+      return self.cachedKeyPair
+    }
+    if let hit {
+      return hit
+    }
+
+    let derived = derive(deviceSecret, eventCode)
+    synchronized {
+      self.cachedFingerprint = wanted
+      self.cachedKeyPair = derived
+    }
+    return derived
+  }
+
+  /// Drops this type's reference to the cached key pair ahead of the natural
+  /// eviction on the next lookup with different inputs, so the next lookup
+  /// derives again.
+  ///
+  /// This is not erasure: the storage is not zeroized, and copies already
+  /// returned to callers or being derived concurrently are untouched.
+  func clear() {
+    synchronized {
+      self.cachedFingerprint = nil
+      self.cachedKeyPair = nil
+    }
+  }
+
+  /// One-way identifier for the derivation inputs.
+  ///
+  /// The device secret is length-prefixed so that no other
+  /// `(deviceSecret, eventCode)` pair can produce the same preimage by
+  /// shifting bytes across the boundary.
+  static func fingerprint(deviceSecret: Data, eventCode: String) -> Data {
+    var preimage = Data(fingerprintDomainTag.utf8)
+    preimage.append(contentsOf: withUnsafeBytes(of: UInt32(deviceSecret.count).bigEndian, Array.init))
+    preimage.append(deviceSecret)
+    preimage.append(Data(eventCode.utf8))
+    return BarnardCrypto.sha256(preimage)
+  }
+
+  private func synchronized<T>(_ body: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return body()
+  }
+}

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardSigningKeyCacheTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardSigningKeyCacheTests.swift
@@ -1,0 +1,292 @@
+// Use of this source code is governed by a BSD-style license.
+
+import Foundation
+import XCTest
+@testable import Barnard
+
+/// barnard#124: the per-event signing key pair is cached, so these tests
+/// guard the properties that make caching safe rather than the speedup.
+///
+/// The cache is exercised with a counting stand-in for the real derivation
+/// where the assertion is about cache behavior, and with the real derivation
+/// where the assertion is about key material.
+final class BarnardSigningKeyCacheTests: XCTestCase {
+  private func stubKeyPair(_ marker: UInt8) -> BarnardSigning.SigningKeyPair {
+    BarnardSigning.SigningKeyPair(
+      privateKey: Secp256k1.UInt256(data: Data(repeating: marker, count: 32)),
+      publicKeyCompressed: Data(repeating: marker, count: 33)
+    )
+  }
+
+  func testSameInputsReuseTheDerivation() {
+    let cache = BarnardSigningKeyCache()
+    let secret = Data(repeating: 0x31, count: 32)
+    var derivations = 0
+
+    let first = cache.keyPair(deviceSecret: secret, eventCode: "EVT1") { _, _ in
+      derivations += 1
+      return stubKeyPair(0x01)
+    }
+    let second = cache.keyPair(deviceSecret: secret, eventCode: "EVT1") { _, _ in
+      derivations += 1
+      return stubKeyPair(0x02)
+    }
+
+    XCTAssertEqual(derivations, 1, "second lookup with identical inputs must not derive again")
+    XCTAssertEqual(first.publicKeyCompressed, second.publicKeyCompressed)
+  }
+
+  /// The regression test for the catastrophic form of this bug: a cache
+  /// keyed on `eventCode` alone would sign with another device's identity.
+  func testDifferentDeviceSecretWithSameEventCodeDoesNotReuseTheEntry() {
+    let cache = BarnardSigningKeyCache()
+    var derivations = 0
+    let derive: (Data, String) -> BarnardSigning.SigningKeyPair = { _, _ in
+      derivations += 1
+      return self.stubKeyPair(UInt8(derivations))
+    }
+
+    let first = cache.keyPair(
+      deviceSecret: Data(repeating: 0x41, count: 32),
+      eventCode: "EVT1",
+      derive: derive
+    )
+    let second = cache.keyPair(
+      deviceSecret: Data(repeating: 0x42, count: 32),
+      eventCode: "EVT1",
+      derive: derive
+    )
+
+    XCTAssertEqual(derivations, 2, "a different device secret must miss the cache")
+    XCTAssertNotEqual(first.publicKeyCompressed, second.publicKeyCompressed)
+  }
+
+  /// The same property proved against the real derivation: the key pair
+  /// handed back after the secret changes is the one that secret derives.
+  func testDifferentDeviceSecretYieldsTheKeyPairOfThatSecret() {
+    let cache = BarnardSigningKeyCache()
+    let firstSecret = Data(repeating: 0x43, count: 32)
+    let secondSecret = Data(repeating: 0x44, count: 32)
+    let derive = BarnardSigning.deriveSigningKeyPair(deviceSecret:eventCode:)
+
+    let first = cache.keyPair(deviceSecret: firstSecret, eventCode: "EVT1", derive: derive)
+    let second = cache.keyPair(deviceSecret: secondSecret, eventCode: "EVT1", derive: derive)
+
+    XCTAssertNotEqual(first.publicKeyCompressed, second.publicKeyCompressed)
+    XCTAssertEqual(
+      first.publicKeyCompressed,
+      BarnardSigning.deriveSigningKeyPair(deviceSecret: firstSecret, eventCode: "EVT1")
+        .publicKeyCompressed
+    )
+    XCTAssertEqual(
+      second.publicKeyCompressed,
+      BarnardSigning.deriveSigningKeyPair(deviceSecret: secondSecret, eventCode: "EVT1")
+        .publicKeyCompressed
+    )
+  }
+
+  func testDifferentEventCodeWithSameDeviceSecretDoesNotReuseTheEntry() {
+    let cache = BarnardSigningKeyCache()
+    let secret = Data(repeating: 0x45, count: 32)
+    var derivations = 0
+    let derive: (Data, String) -> BarnardSigning.SigningKeyPair = { _, _ in
+      derivations += 1
+      return self.stubKeyPair(UInt8(derivations))
+    }
+
+    let first = cache.keyPair(deviceSecret: secret, eventCode: "EVT1", derive: derive)
+    let second = cache.keyPair(deviceSecret: secret, eventCode: "EVT2", derive: derive)
+
+    XCTAssertEqual(derivations, 2, "a different event code must miss the cache")
+    XCTAssertNotEqual(first.publicKeyCompressed, second.publicKeyCompressed)
+  }
+
+  /// Only one entry is retained, so at most one derived private key is
+  /// resident and returning to earlier inputs re-derives.
+  func testCacheHoldsASingleEntry() {
+    let cache = BarnardSigningKeyCache()
+    let secret = Data(repeating: 0x46, count: 32)
+    var derivations = 0
+    let derive: (Data, String) -> BarnardSigning.SigningKeyPair = { _, _ in
+      derivations += 1
+      return self.stubKeyPair(UInt8(derivations))
+    }
+
+    _ = cache.keyPair(deviceSecret: secret, eventCode: "EVT1", derive: derive)
+    _ = cache.keyPair(deviceSecret: secret, eventCode: "EVT2", derive: derive)
+    _ = cache.keyPair(deviceSecret: secret, eventCode: "EVT1", derive: derive)
+
+    XCTAssertEqual(derivations, 3)
+  }
+
+  func testClearForcesRederivation() {
+    let cache = BarnardSigningKeyCache()
+    let secret = Data(repeating: 0x47, count: 32)
+    var derivations = 0
+    let derive: (Data, String) -> BarnardSigning.SigningKeyPair = { _, _ in
+      derivations += 1
+      return self.stubKeyPair(UInt8(derivations))
+    }
+
+    _ = cache.keyPair(deviceSecret: secret, eventCode: "EVT1", derive: derive)
+    cache.clear()
+    _ = cache.keyPair(deviceSecret: secret, eventCode: "EVT1", derive: derive)
+
+    XCTAssertEqual(derivations, 2)
+  }
+
+  /// The fingerprint covers both inputs, and covers them unambiguously: a
+  /// byte moved across the secret/event-code boundary changes it.
+  func testFingerprintSeparatesTheInputs() {
+    let a = BarnardSigningKeyCache.fingerprint(
+      deviceSecret: Data([0x01, 0x02]),
+      eventCode: "34"
+    )
+    let b = BarnardSigningKeyCache.fingerprint(
+      deviceSecret: Data([0x01, 0x02, 0x33]),
+      eventCode: "4"
+    )
+    let c = BarnardSigningKeyCache.fingerprint(
+      deviceSecret: Data([0x01, 0x02]),
+      eventCode: "34"
+    )
+
+    XCTAssertNotEqual(a, b)
+    XCTAssertEqual(a, c, "the fingerprint must be stable for identical inputs")
+    XCTAssertEqual(a.count, 32)
+  }
+
+  /// The device secret must not be recoverable from what the cache keeps.
+  func testFingerprintDoesNotContainTheDeviceSecret() {
+    let secret = Data((0..<32).map { UInt8($0 &+ 0x50) })
+    let fingerprint = BarnardSigningKeyCache.fingerprint(deviceSecret: secret, eventCode: "EVT1")
+
+    XCTAssertFalse(
+      fingerprint.range(of: secret) != nil,
+      "the fingerprint must not embed the device secret"
+    )
+    XCTAssertNotEqual(fingerprint, secret)
+  }
+
+  /// A warm cache under concurrent lookups serves one entry consistently and
+  /// does not derive again. (A cold cache may derive more than once by
+  /// design — the lock is not held across the derivation — so the warm case
+  /// is what carries an exact count.)
+  func testConcurrentLookupsOnAWarmCacheAreConsistent() {
+    let cache = BarnardSigningKeyCache()
+    let secret = Data(repeating: 0x48, count: 32)
+    let expected = stubKeyPair(0x99)
+    let derivations = BarnardTestCounter()
+
+    _ = cache.keyPair(deviceSecret: secret, eventCode: "EVT1") { _, _ in
+      derivations.increment()
+      return expected
+    }
+
+    let results = BarnardTestResultBox()
+    DispatchQueue.concurrentPerform(iterations: 64) { _ in
+      let pair = cache.keyPair(deviceSecret: secret, eventCode: "EVT1") { _, _ in
+        derivations.increment()
+        return self.stubKeyPair(0x11)
+      }
+      results.record(pair.publicKeyCompressed)
+    }
+
+    XCTAssertEqual(derivations.value, 1, "a warm cache must not re-derive under concurrent lookups")
+    XCTAssertEqual(results.distinctValues, [expected.publicKeyCompressed])
+  }
+
+  /// Concurrent lookups that contend on the single entry must each get the
+  /// key pair for the inputs they passed.
+  ///
+  /// Every iteration uses a different (deviceSecret, eventCode), and the
+  /// derivation is a pure function of its arguments that yields a distinct
+  /// key pair per input pair, so a lookup that returned another iteration's
+  /// entry — including one assembled from a fingerprint and a key pair read
+  /// at different moments — produces a value this test can tell apart. The
+  /// expected value is computed from the loop index rather than from the
+  /// cache's own fingerprint, so a fault in that fingerprint cannot cancel
+  /// out against the expectation.
+  func testConcurrentLookupsReturnTheKeyPairForTheirOwnInputs() {
+    let cache = BarnardSigningKeyCache()
+    let iterations = 64
+    let mismatches = BarnardTestCounter()
+
+    DispatchQueue.concurrentPerform(iterations: iterations) { index in
+      let secretMarker = UInt8(index)
+      let eventMarker = UInt8(iterations - 1 - index)
+      let deviceSecret = Data(repeating: secretMarker, count: 32)
+      let eventCode = "EVT-\(eventMarker)"
+
+      let pair = cache.keyPair(deviceSecret: deviceSecret, eventCode: eventCode) { secret, code in
+        Self.stubKeyPair(
+          secretMarker: secret.first ?? 0,
+          eventMarker: UInt8(code.dropFirst(4)) ?? 0
+        )
+      }
+
+      let expected = Self.stubKeyPair(secretMarker: secretMarker, eventMarker: eventMarker)
+      if pair.publicKeyCompressed != expected.publicKeyCompressed
+        || pair.privateKey.data != expected.privateKey.data
+      {
+        mismatches.increment()
+      }
+    }
+
+    XCTAssertEqual(
+      mismatches.value,
+      0,
+      "every concurrent lookup must return the key pair derived from its own inputs"
+    )
+  }
+
+  /// Deterministic stand-in for a derivation, distinguishable by both inputs.
+  private static func stubKeyPair(
+    secretMarker: UInt8,
+    eventMarker: UInt8
+  ) -> BarnardSigning.SigningKeyPair {
+    var publicKey = Data([secretMarker, eventMarker])
+    publicKey.append(Data(repeating: secretMarker ^ eventMarker, count: 31))
+    var privateKey = Data([eventMarker, secretMarker])
+    privateKey.append(Data(repeating: secretMarker &+ eventMarker, count: 30))
+    return BarnardSigning.SigningKeyPair(
+      privateKey: Secp256k1.UInt256(data: privateKey),
+      publicKeyCompressed: publicKey
+    )
+  }
+}
+
+/// Minimal thread-safe helpers for the concurrency tests above.
+private final class BarnardTestCounter {
+  private let lock = NSLock()
+  private var count = 0
+
+  func increment() {
+    lock.lock()
+    count += 1
+    lock.unlock()
+  }
+
+  var value: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return count
+  }
+}
+
+private final class BarnardTestResultBox {
+  private let lock = NSLock()
+  private var values: Set<Data> = []
+
+  func record(_ value: Data) {
+    lock.lock()
+    values.insert(value)
+    lock.unlock()
+  }
+
+  var distinctValues: Set<Data> {
+    lock.lock()
+    defer { lock.unlock() }
+    return values
+  }
+}

--- a/packages/swift/barnard/Tests/BarnardTests/BarnardSigningTests.swift
+++ b/packages/swift/barnard/Tests/BarnardTests/BarnardSigningTests.swift
@@ -127,4 +127,44 @@ final class BarnardSigningTests: XCTestCase {
     XCTAssertEqual(proof.signingPublicKey, publicKey)
     XCTAssertEqual(proof.rpi.count, 16)
   }
+
+  /// barnard#124: the signing key pair is cached per instance, so a rotated
+  /// device secret must take effect on the very next call — including for
+  /// the same event code, where a cache keyed on the event code alone would
+  /// keep signing with the old identity.
+  func testBarnardIdentitySignFollowsDeviceSecretRotation() {
+    let defaults = UserDefaults.standard
+    defer { defaults.removeObject(forKey: "barnard.rpidSeed") }
+
+    let firstSecret = Data(repeating: 0x51, count: 32)
+    defaults.set(firstSecret, forKey: "barnard.rpidSeed")
+    let identity = BarnardIdentity()
+
+    let firstPublicKey = identity.signingPublicKey(eventCode: "EVT1")
+    XCTAssertEqual(
+      firstPublicKey,
+      BarnardSigning.deriveSigningKeyPair(deviceSecret: firstSecret, eventCode: "EVT1")
+        .publicKeyCompressed
+    )
+
+    // Same instance, same event code, different device secret.
+    let secondSecret = Data(repeating: 0x52, count: 32)
+    defaults.set(secondSecret, forKey: "barnard.rpidSeed")
+
+    let payload = Data("rotation payload".utf8)
+    let sig = identity.sign(eventCode: "EVT1", bytes: payload)
+    let recovered = BarnardSigning.recoverPublicKey(
+      recId: sig.v,
+      r: Secp256k1.UInt256(data: sig.r),
+      s: Secp256k1.UInt256(data: sig.s),
+      messageHash32: BarnardCrypto.sha256(payload)
+    )
+
+    XCTAssertNotEqual(recovered, firstPublicKey, "the rotated-out key must not sign")
+    XCTAssertEqual(
+      recovered,
+      BarnardSigning.deriveSigningKeyPair(deviceSecret: secondSecret, eventCode: "EVT1")
+        .publicKeyCompressed
+    )
+  }
 }


### PR DESCRIPTION
Closes part 1 of #124.

`BarnardIdentity.sign(eventCode:bytes:)` re-derived the signing key pair on every call. Derivation is deterministic given `(deviceSecret, eventCode)`, so it is now memoized in an internal single-entry cache. A profile of the signing path attributed 23% to `deriveSigningKeyPair` and 77% to `signRecoverable`; this addresses the first.

Scope is **part 1 only**. The secp256k1 backend replacement and the signing API's threading contract are explicitly out of scope — see "Remaining scope" below.

## Design

The cache is keyed on `SHA256(domainTag || byteLength(deviceSecret) || deviceSecret || eventCode)`. The device secret itself is never stored, only that one-way fingerprint.

The single entry point takes both derivation inputs together with the derive closure, and computes the fingerprint from the same arguments it passes to derive. No API exposes a lookup by event code alone, so a lookup cannot return a key pair belonging to different inputs by construction; beyond that, a wrong match would require a SHA-256 collision.

The lock is deliberately **not** held across derivation. Two callers racing on a cold cache may each derive; that is benign because derivation is pure and the fingerprint is written together with the key pair it belongs to, so a losing writer can only cause a later redundant miss.

`getOrCreateDeviceSecret()` is read from storage on **every** call and folded into the fingerprint, so rotation, external clearing, or first-run generation all miss the cache on the next call. There is nothing to invalidate explicitly and nothing that can go stale.

## Effectiveness in the host, verified

The cache is per instance, so it does nothing if a host constructs a new `BarnardIdentity` per call. Verified in the consuming app rather than assumed: there is exactly one construction site, `SensingCoordinator.swift:44` — `private let identity = BarnardIdentity()` — held by a coordinator that is itself a stored property on the app-level coordinator. One instance for the app session, so the cache applies.

## Security trade-off

The derived private key now survives beyond a single call. Stated precisely, because the code comments are the only place a future reader learns what is and is not guaranteed:

- The cache retains at most **one entry**, replaced by any lookup with different inputs. That bounds what the *cache* holds, not how many derived private keys exist — derivation runs outside the lock, so concurrent cold misses each hold their own pair for the duration of their call, and every caller holds the pair it was handed.
- Overwrite and `clear()` drop this type's reference. Neither erases key material, and nothing here zeroizes released storage. Copies already returned to callers, or being derived concurrently, are untouched.
- A wrong-key hit would require breaking SHA-256 collision resistance: infeasible under standard assumptions, which is the assumption this cache rests on rather than an impossibility.

Context for weighing that: the device secret these keys derive from is already stored as plaintext in `UserDefaults` by design — the spec requires storage removed on uninstall and rules out the Keychain — and it is materialised as a fresh unzeroized `Data` on every call. Anyone able to read process memory or the app container could already re-derive every per-event key. This widens a window; it does not create a new class of exposure.

## Behaviour preservation

Signatures for identical inputs are byte-identical. Covered by the rotation test through `BarnardIdentity`, the cache test that pins a returned key pair to the secret it was derived from, and the pre-existing sign-and-recover round trip.

The behaviour vectors also pass unchanged and pin the derivation — but note they call `BarnardSigning.deriveSigningKeyPair` directly and never reach the cache, so they are evidence the *derivation* is unchanged, not evidence about the cache.

## Measurement

Derivation cost measured in-window was **5.5 to 6.0 seconds**, and that is what every repeated sign no longer pays.

Deliberately not quoting a speedup percentage. The machine was under heavy load while measuring (load average swinging between roughly 120 and 250) and the wall-clock spread exceeded the saving, so the timing is supporting evidence only. What actually demonstrates the cache works is the deterministic derivation-count assertions in the unit tests. Re-measure on an idle machine if a number is needed.

## Tests

10 cache tests plus an end-to-end rotation test through `BarnardIdentity`, which writes secret A, takes the public key, writes secret B under the same event code on the same instance, signs, recovers the public key from the signature, and asserts it is B's and not A's.

The cold-cache concurrency test asserts **per-iteration correspondence**: 64 iterations with distinct `(deviceSecret, eventCode)` pairs, expectations derived independently from the loop index rather than from the cache's own fingerprint, each asserting the pair it received is the pair for the inputs it passed. It was mutation-checked — with the cache weakened to ignore the fingerprint, this test fails while the warm-cache test still passes, which is why both are kept.

## Remaining scope, tracked on #124

- The same derive-on-every-call pattern remains in the React Native, Flutter and Kotlin counterparts. Parity is a maintainer decision.
- `proveRpidOwnership` and `proveKeyBinding` still derive internally in `BarnardCore` and are unchanged.

## Notes for reviewers

- `swift test` on a macOS host cannot build this package at all: `BarnardEngine.swift:5` imports UIKit, which the macOS SDK does not provide. A simulator destination is required, which is what CI uses.
- Observation, out of this change's delta: the derivation's own HKDF input is a plain concatenation and is *not* length-prefixed, so this cache's key is stricter than the derivation it guards. The direction is safe — a mismatch can only cost a redundant miss, never a wrong hit.
- Also out of delta and filed separately as #125: device-secret creation is an unsynchronized read-check-generate-write, with a cold-install race. This cache does not widen it.

## Review provenance

- Independent review by a checker that did not write the change: **clean**, no defect found, all five audit areas confirmed against the source.
- Second opinion from a different model family: **needs-changes**, one documentation finding — the original comments claimed a wrong-key hit was structurally impossible and that at most one derived private key was resident at a time. Both were overclaims, and both are corrected above. It also ran the concurrency tests under Thread Sanitizer: clean, no runtime warnings.
- A review arranged by the author does not satisfy the review gate and none is claimed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved repeated signing and public-key retrieval by reusing recently derived signing keys.
  * Concurrent operations can efficiently share cached key results.

* **Security & Reliability**
  * Device secret changes or clearing now immediately invalidate cached signing keys.
  * Signing consistently uses the latest available device secret.

* **Tests**
  * Added coverage for caching, concurrency, key isolation, cache clearing, and secret rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->