### PR TITLE
fix(ios): serialize device secret creation

### DIFF
--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -1,5 +1,7 @@
 // Use of this source code is governed by a BSD-style license.
 
+import Dispatch
+
 public protocol BarnardCoreRandomSource {
   func randomBytes(count: Int) -> [UInt8]
 }
@@ -45,6 +47,12 @@ public struct BarnardCoreBeaconChain {
 }
 
 public enum BarnardCoreKeyManager {
+  // Keep this target's platform imports minimal by using the Dispatch
+  // semaphore primitive already available on its supported platforms. The
+  // lock covers the complete read-check-generate-write transaction: a caller
+  // that arrives after a cold caller must observe the value that was stored.
+  private static let loadOrCreateLock = DispatchSemaphore(value: 1)
+
   public static func loadOrCreate(
     key: String,
     minimumByteCount: Int,
@@ -52,6 +60,9 @@ public enum BarnardCoreKeyManager {
     storage: any BarnardCoreKeyStorage,
     randomSource: any BarnardCoreRandomSource
   ) -> [UInt8] {
+    loadOrCreateLock.wait()
+    defer { loadOrCreateLock.signal() }
+
     if let existing = storage.bytes(forKey: key), existing.count >= minimumByteCount {
       return existing
     }

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -66,6 +66,13 @@ public enum BarnardCoreKeyManager {
     return queue
   }()
 
+  /// Loads a stored value or atomically creates and stores one.
+  ///
+  /// The storage and random-source callbacks execute inside the transaction.
+  /// A callback that synchronously re-enters this method on the same execution
+  /// context is supported. The behavior of same-key recursive creation is
+  /// undefined, and callbacks must not synchronously wait for another thread
+  /// to call this method.
   public static func loadOrCreate(
     key: String,
     minimumByteCount: Int,

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -47,11 +47,24 @@ public struct BarnardCoreBeaconChain {
 }
 
 public enum BarnardCoreKeyManager {
-  // Keep this target's platform imports minimal by using the Dispatch
-  // semaphore primitive already available on its supported platforms. The
-  // lock covers the complete read-check-generate-write transaction: a caller
-  // that arrives after a cold caller must observe the value that was stored.
-  private static let loadOrCreateLock = DispatchSemaphore(value: 1)
+  // Keep this target's platform imports minimal by using Dispatch, which is
+  // already available on its supported platforms. The serial queue covers
+  // the complete read-check-generate-write transaction: a caller that arrives
+  // after a cold caller must observe the value that was stored.
+  //
+  // The queue-specific check deliberately makes the critical section
+  // re-entrant for synchronous callbacks executing on this queue from injected
+  // storage or random sources. That avoids deadlocking host implementations
+  // that call back into loadOrCreate. Such callbacks must not recursively
+  // request the same key: re-entry is safe, but same-key recursive creation
+  // remains undefined. A callback that synchronously waits for another thread
+  // to call loadOrCreate can still deadlock and is not supported.
+  private static let loadOrCreateQueueKey = DispatchSpecificKey<Void>()
+  private static let loadOrCreateQueue: DispatchQueue = {
+    let queue = DispatchQueue(label: "org.levarac.barnard.core-key-manager")
+    queue.setSpecific(key: loadOrCreateQueueKey, value: ())
+    return queue
+  }()
 
   public static func loadOrCreate(
     key: String,
@@ -60,15 +73,21 @@ public enum BarnardCoreKeyManager {
     storage: any BarnardCoreKeyStorage,
     randomSource: any BarnardCoreRandomSource
   ) -> [UInt8] {
-    loadOrCreateLock.wait()
-    defer { loadOrCreateLock.signal() }
-
-    if let existing = storage.bytes(forKey: key), existing.count >= minimumByteCount {
-      return existing
+    withLoadOrCreateCriticalSection {
+      if let existing = storage.bytes(forKey: key), existing.count >= minimumByteCount {
+        return existing
+      }
+      let generated = randomSource.randomBytes(count: generatedByteCount)
+      storage.setBytes(generated, forKey: key)
+      return generated
     }
-    let generated = randomSource.randomBytes(count: generatedByteCount)
-    storage.setBytes(generated, forKey: key)
-    return generated
+  }
+
+  private static func withLoadOrCreateCriticalSection<T>(_ body: () -> T) -> T {
+    if DispatchQueue.getSpecific(key: loadOrCreateQueueKey) != nil {
+      return body()
+    }
+    return loadOrCreateQueue.sync(execute: body)
   }
 }
 

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -57,8 +57,10 @@ public enum BarnardCoreKeyManager {
   // storage or random sources. That avoids deadlocking host implementations
   // that call back into loadOrCreate. Such callbacks must not recursively
   // request the same key: re-entry is safe, but same-key recursive creation
-  // remains undefined. A callback that synchronously waits for another thread
-  // to call loadOrCreate can still deadlock and is not supported.
+  // remains undefined; the inner caller may retain a secret that an outer call
+  // overwrites, so the returned and stored values can diverge. A callback that
+  // synchronously waits for another thread to call loadOrCreate can still
+  // deadlock and is not supported.
   private static let loadOrCreateQueueKey = DispatchSpecificKey<Void>()
   private static let loadOrCreateQueue: DispatchQueue = {
     let queue = DispatchQueue(label: "org.levarac.barnard.core-key-manager")

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardCore/BarnardCoreCrypto.swift
@@ -72,9 +72,10 @@ public enum BarnardCoreKeyManager {
   ///
   /// The storage and random-source callbacks execute inside the transaction.
   /// A callback that synchronously re-enters this method on the same execution
-  /// context is supported. The behavior of same-key recursive creation is
-  /// undefined, and callbacks must not synchronously wait for another thread
-  /// to call this method.
+  /// context is supported. Same-key recursive creation is undefined: the inner
+  /// caller may retain a secret that an outer call overwrites, so the returned
+  /// and stored values can diverge. Callbacks must not synchronously wait for
+  /// another thread to call this method.
   public static func loadOrCreate(
     key: String,
     minimumByteCount: Int,

--- a/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardIdentityController.swift
+++ b/packages/dart/barnard/ios/barnard/Sources/barnard/BarnardIdentityController.swift
@@ -14,6 +14,17 @@ import Foundation
 /// method channel — only the public key and signatures do.
 final class BarnardIdentityController: NSObject, FlutterPlugin {
   private let deviceSecretKey = "barnard.rpidSeed"
+  private let keyStorage: any BarnardCoreKeyStorage
+  private let randomSource: any BarnardCoreRandomSource
+
+  init(
+    keyStorage: any BarnardCoreKeyStorage = BarnardUserDefaultsKeyStorage(),
+    randomSource: any BarnardCoreRandomSource = BarnardSystemRandomSource()
+  ) {
+    self.keyStorage = keyStorage
+    self.randomSource = randomSource
+    super.init()
+  }
 
   static func register(with _: FlutterPluginRegistrar) {
     // Registered directly by BarnardPlugin.register(with:); this
@@ -120,12 +131,12 @@ final class BarnardIdentityController: NSObject, FlutterPlugin {
   // BarnardClient.exportCurrentTek, which is the TEK, not the raw secret).
 
   private func getOrCreateDeviceSecret() -> Data {
-    let defaults = UserDefaults.standard
-    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
-      return existing
-    }
-    let newSecret = BarnardCrypto.generateRandomBytes(32)
-    defaults.set(newSecret, forKey: deviceSecretKey)
-    return newSecret
+    Data(BarnardCoreKeyManager.loadOrCreate(
+      key: deviceSecretKey,
+      minimumByteCount: 32,
+      generatedByteCount: 32,
+      storage: keyStorage,
+      randomSource: randomSource
+    ))
   }
 }

--- a/packages/react-native/barnard/ios/BarnardDeviceSecret.swift
+++ b/packages/react-native/barnard/ios/BarnardDeviceSecret.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Shared in-process DeviceSecret creation for the React Native iOS package.
+///
+/// Both the sensing client and signing identity use this key. Keep the full
+/// read-check-generate-write transaction under one lock so separate native
+/// module instances cannot create competing secrets during a cold start.
+enum BarnardDeviceSecretStore {
+  private static let lock = NSLock()
+  private static let key = "barnard.rpidSeed"
+
+  static func loadOrCreate() -> Data {
+    lock.lock()
+    defer { lock.unlock() }
+
+    let defaults = UserDefaults.standard
+    if let existing = defaults.data(forKey: key), existing.count >= 32 {
+      return existing
+    }
+    let generated = BarnardCrypto.generateRandomBytes(32)
+    defaults.set(generated, forKey: key)
+    return generated
+  }
+}

--- a/packages/react-native/barnard/ios/BarnardIdentity.swift
+++ b/packages/react-native/barnard/ios/BarnardIdentity.swift
@@ -13,8 +13,6 @@ import React
 /// signatures do.
 @objc(BarnardIdentity)
 class BarnardIdentity: NSObject {
-  private let deviceSecretKey = "barnard.rpidSeed"
-
   @objc static func requiresMainQueueSetup() -> Bool { false }
 
   @objc(signingPublicKey:resolve:reject:)
@@ -102,12 +100,6 @@ class BarnardIdentity: NSObject {
   // Same storage key as BarnardRpidGenerator.getOrCreateDeviceSecret — see
   // that class for the rationale (shared DeviceSecret, never exposed).
   private func getOrCreateDeviceSecret() -> Data {
-    let defaults = UserDefaults.standard
-    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
-      return existing
-    }
-    let newSecret = BarnardCrypto.generateRandomBytes(32)
-    defaults.set(newSecret, forKey: deviceSecretKey)
-    return newSecret
+    BarnardDeviceSecretStore.loadOrCreate()
   }
 }

--- a/packages/react-native/barnard/ios/BarnardRpidGenerator.swift
+++ b/packages/react-native/barnard/ios/BarnardRpidGenerator.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 final class BarnardRpidGenerator {
-  private let deviceSecretKey = "barnard.rpidSeed"
   private let eventCodeKey = "barnard.eventCode"
 
   private(set) var eventCode: String? {
@@ -90,15 +89,7 @@ final class BarnardRpidGenerator {
   }
 
   private func getOrCreateDeviceSecret() -> Data {
-    let defaults = UserDefaults.standard
-
-    if let existing = defaults.data(forKey: deviceSecretKey), existing.count >= 32 {
-      return existing
-    }
-
-    let newSecret = BarnardCrypto.generateRandomBytes(32)
-    defaults.set(newSecret, forKey: deviceSecretKey)
-    return newSecret
+    BarnardDeviceSecretStore.loadOrCreate()
   }
 
   func getDeviceSecret() -> Data {

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -1,5 +1,7 @@
 // Use of this source code is governed by a BSD-style license.
 
+import Dispatch
+
 public protocol BarnardCoreRandomSource {
   func randomBytes(count: Int) -> [UInt8]
 }
@@ -45,6 +47,12 @@ public struct BarnardCoreBeaconChain {
 }
 
 public enum BarnardCoreKeyManager {
+  // Keep this target's platform imports minimal by using the Dispatch
+  // semaphore primitive already available on its supported platforms. The
+  // lock covers the complete read-check-generate-write transaction: a caller
+  // that arrives after a cold caller must observe the value that was stored.
+  private static let loadOrCreateLock = DispatchSemaphore(value: 1)
+
   public static func loadOrCreate(
     key: String,
     minimumByteCount: Int,
@@ -52,6 +60,9 @@ public enum BarnardCoreKeyManager {
     storage: any BarnardCoreKeyStorage,
     randomSource: any BarnardCoreRandomSource
   ) -> [UInt8] {
+    loadOrCreateLock.wait()
+    defer { loadOrCreateLock.signal() }
+
     if let existing = storage.bytes(forKey: key), existing.count >= minimumByteCount {
       return existing
     }

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -66,6 +66,13 @@ public enum BarnardCoreKeyManager {
     return queue
   }()
 
+  /// Loads a stored value or atomically creates and stores one.
+  ///
+  /// The storage and random-source callbacks execute inside the transaction.
+  /// A callback that synchronously re-enters this method on the same execution
+  /// context is supported. The behavior of same-key recursive creation is
+  /// undefined, and callbacks must not synchronously wait for another thread
+  /// to call this method.
   public static func loadOrCreate(
     key: String,
     minimumByteCount: Int,

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -47,11 +47,24 @@ public struct BarnardCoreBeaconChain {
 }
 
 public enum BarnardCoreKeyManager {
-  // Keep this target's platform imports minimal by using the Dispatch
-  // semaphore primitive already available on its supported platforms. The
-  // lock covers the complete read-check-generate-write transaction: a caller
-  // that arrives after a cold caller must observe the value that was stored.
-  private static let loadOrCreateLock = DispatchSemaphore(value: 1)
+  // Keep this target's platform imports minimal by using Dispatch, which is
+  // already available on its supported platforms. The serial queue covers
+  // the complete read-check-generate-write transaction: a caller that arrives
+  // after a cold caller must observe the value that was stored.
+  //
+  // The queue-specific check deliberately makes the critical section
+  // re-entrant for synchronous callbacks executing on this queue from injected
+  // storage or random sources. That avoids deadlocking host implementations
+  // that call back into loadOrCreate. Such callbacks must not recursively
+  // request the same key: re-entry is safe, but same-key recursive creation
+  // remains undefined. A callback that synchronously waits for another thread
+  // to call loadOrCreate can still deadlock and is not supported.
+  private static let loadOrCreateQueueKey = DispatchSpecificKey<Void>()
+  private static let loadOrCreateQueue: DispatchQueue = {
+    let queue = DispatchQueue(label: "org.levarac.barnard.core-key-manager")
+    queue.setSpecific(key: loadOrCreateQueueKey, value: ())
+    return queue
+  }()
 
   public static func loadOrCreate(
     key: String,
@@ -60,15 +73,21 @@ public enum BarnardCoreKeyManager {
     storage: any BarnardCoreKeyStorage,
     randomSource: any BarnardCoreRandomSource
   ) -> [UInt8] {
-    loadOrCreateLock.wait()
-    defer { loadOrCreateLock.signal() }
-
-    if let existing = storage.bytes(forKey: key), existing.count >= minimumByteCount {
-      return existing
+    withLoadOrCreateCriticalSection {
+      if let existing = storage.bytes(forKey: key), existing.count >= minimumByteCount {
+        return existing
+      }
+      let generated = randomSource.randomBytes(count: generatedByteCount)
+      storage.setBytes(generated, forKey: key)
+      return generated
     }
-    let generated = randomSource.randomBytes(count: generatedByteCount)
-    storage.setBytes(generated, forKey: key)
-    return generated
+  }
+
+  private static func withLoadOrCreateCriticalSection<T>(_ body: () -> T) -> T {
+    if DispatchQueue.getSpecific(key: loadOrCreateQueueKey) != nil {
+      return body()
+    }
+    return loadOrCreateQueue.sync(execute: body)
   }
 }
 

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -57,8 +57,10 @@ public enum BarnardCoreKeyManager {
   // storage or random sources. That avoids deadlocking host implementations
   // that call back into loadOrCreate. Such callbacks must not recursively
   // request the same key: re-entry is safe, but same-key recursive creation
-  // remains undefined. A callback that synchronously waits for another thread
-  // to call loadOrCreate can still deadlock and is not supported.
+  // remains undefined; the inner caller may retain a secret that an outer call
+  // overwrites, so the returned and stored values can diverge. A callback that
+  // synchronously waits for another thread to call loadOrCreate can still
+  // deadlock and is not supported.
   private static let loadOrCreateQueueKey = DispatchSpecificKey<Void>()
   private static let loadOrCreateQueue: DispatchQueue = {
     let queue = DispatchQueue(label: "org.levarac.barnard.core-key-manager")

--- a/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
+++ b/packages/swift/barnard/Sources/BarnardCore/BarnardCoreCrypto.swift
@@ -72,9 +72,10 @@ public enum BarnardCoreKeyManager {
   ///
   /// The storage and random-source callbacks execute inside the transaction.
   /// A callback that synchronously re-enters this method on the same execution
-  /// context is supported. The behavior of same-key recursive creation is
-  /// undefined, and callbacks must not synchronously wait for another thread
-  /// to call this method.
+  /// context is supported. Same-key recursive creation is undefined: the inner
+  /// caller may retain a secret that an outer call overwrites, so the returned
+  /// and stored values can diverge. Callbacks must not synchronously wait for
+  /// another thread to call this method.
   public static func loadOrCreate(
     key: String,
     minimumByteCount: Int,

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
@@ -1,5 +1,7 @@
 // Use of this source code is governed by a BSD-style license.
 
+import Dispatch
+import Foundation
 import XCTest
 @testable import BarnardCore
 
@@ -47,6 +49,43 @@ final class BarnardCoreTests: XCTestCase {
 
     XCTAssertEqual(first, [UInt8](repeating: 0x5a, count: 32))
     XCTAssertEqual(second, first)
+  }
+
+  func testConcurrentColdLoadsAgreeWithStoredSecret() {
+    let attempts = 8
+    let secrets = [
+      [UInt8](repeating: 0x11, count: 32),
+      [UInt8](repeating: 0x22, count: 32),
+    ]
+
+    for attempt in 0..<attempts {
+      let storage = DelayedKeyStorage(readDelay: 0.05)
+      let results = ConcurrentByteValues()
+
+      DispatchQueue.concurrentPerform(iterations: 2) { index in
+        let loaded = BarnardCoreKeyManager.loadOrCreate(
+          key: "device-secret-\(attempt)",
+          minimumByteCount: 32,
+          generatedByteCount: 32,
+          storage: storage,
+          randomSource: FixedRandomSource(bytes: secrets[index])
+        )
+        results.append(loaded)
+      }
+
+      let loadedValues = results.snapshot
+      XCTAssertEqual(loadedValues.count, 2)
+      XCTAssertEqual(
+        loadedValues[0],
+        loadedValues[1],
+        "concurrent cold loads must return the same device secret (attempt \(attempt))"
+      )
+      XCTAssertEqual(
+        loadedValues[0],
+        storage.storedBytes(forKey: "device-secret-\(attempt)"),
+        "concurrent cold loads must return the value that was persisted (attempt \(attempt))"
+      )
+    }
   }
 
   func testInjectedClockProducesExpectedPayload() {
@@ -100,6 +139,52 @@ private final class MemoryKeyStorage: BarnardCoreKeyStorage {
 
   func setBytes(_ bytes: [UInt8], forKey key: String) {
     values[key] = bytes
+  }
+}
+
+private final class DelayedKeyStorage: BarnardCoreKeyStorage {
+  private let lock = NSLock()
+  private let readDelay: TimeInterval
+  private var values: [String: [UInt8]] = [:]
+
+  init(readDelay: TimeInterval) {
+    self.readDelay = readDelay
+  }
+
+  func bytes(forKey key: String) -> [UInt8]? {
+    Thread.sleep(forTimeInterval: readDelay)
+    lock.lock()
+    defer { lock.unlock() }
+    return values[key]
+  }
+
+  func setBytes(_ bytes: [UInt8], forKey key: String) {
+    lock.lock()
+    values[key] = bytes
+    lock.unlock()
+  }
+
+  func storedBytes(forKey key: String) -> [UInt8]? {
+    lock.lock()
+    defer { lock.unlock() }
+    return values[key]
+  }
+}
+
+private final class ConcurrentByteValues {
+  private let lock = NSLock()
+  private var values: [[UInt8]] = []
+
+  func append(_ value: [UInt8]) {
+    lock.lock()
+    values.append(value)
+    lock.unlock()
+  }
+
+  var snapshot: [[UInt8]] {
+    lock.lock()
+    defer { lock.unlock() }
+    return values
   }
 }
 

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
@@ -52,40 +52,65 @@ final class BarnardCoreTests: XCTestCase {
   }
 
   func testConcurrentColdLoadsAgreeWithStoredSecret() {
-    let attempts = 8
     let secrets = [
       [UInt8](repeating: 0x11, count: 32),
       [UInt8](repeating: 0x22, count: 32),
     ]
+    let key = "device-secret-rendezvous"
+    let storage = RendezvousKeyStorage(readTimeout: 1.0)
+    let results = ConcurrentByteValues()
 
-    for attempt in 0..<attempts {
-      let storage = DelayedKeyStorage(readDelay: 0.05)
-      let results = ConcurrentByteValues()
-
-      DispatchQueue.concurrentPerform(iterations: 2) { index in
-        let loaded = BarnardCoreKeyManager.loadOrCreate(
-          key: "device-secret-\(attempt)",
-          minimumByteCount: 32,
-          generatedByteCount: 32,
-          storage: storage,
-          randomSource: FixedRandomSource(bytes: secrets[index])
-        )
-        results.append(loaded)
-      }
-
-      let loadedValues = results.snapshot
-      XCTAssertEqual(loadedValues.count, 2)
-      XCTAssertEqual(
-        loadedValues[0],
-        loadedValues[1],
-        "concurrent cold loads must return the same device secret (attempt \(attempt))"
+    // The storage blocks the first read until the second read has arrived.
+    // The timeout is intentional: a correct implementation serializes the
+    // calls, so the second read cannot rendezvous until the first transaction
+    // has completed. An unfixed implementation reaches both reads together,
+    // making the race deterministic without relying on sleeps or repetition.
+    DispatchQueue.concurrentPerform(iterations: 2) { index in
+      let loaded = BarnardCoreKeyManager.loadOrCreate(
+        key: key,
+        minimumByteCount: 32,
+        generatedByteCount: 32,
+        storage: storage,
+        randomSource: FixedRandomSource(bytes: secrets[index])
       )
-      XCTAssertEqual(
-        loadedValues[0],
-        storage.storedBytes(forKey: "device-secret-\(attempt)"),
-        "concurrent cold loads must return the value that was persisted (attempt \(attempt))"
-      )
+      results.append(loaded)
     }
+
+    let loadedValues = results.snapshot
+    XCTAssertEqual(loadedValues.count, 2)
+    XCTAssertEqual(
+      loadedValues[0],
+      loadedValues[1],
+      "concurrent cold loads must return the same device secret"
+    )
+    XCTAssertEqual(
+      loadedValues[0],
+      storage.storedBytes(forKey: key),
+      "concurrent cold loads must return the value that was persisted"
+    )
+  }
+
+  func testReentrantStorageCallbackDoesNotDeadlock() {
+    let storage = ReentrantKeyStorage()
+    let completed = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global().async {
+      _ = BarnardCoreKeyManager.loadOrCreate(
+        key: "outer-device-secret",
+        minimumByteCount: 32,
+        generatedByteCount: 32,
+        storage: storage,
+        randomSource: FixedRandomSource(bytes: [UInt8](repeating: 0x11, count: 32))
+      )
+      completed.signal()
+    }
+
+    XCTAssertEqual(
+      completed.wait(timeout: .now() + 1),
+      .success,
+      "storage callbacks may synchronously re-enter loadOrCreate"
+    )
+    XCTAssertEqual(storage.nestedCallCount, 1)
   }
 
   func testInjectedClockProducesExpectedPayload() {
@@ -142,32 +167,64 @@ private final class MemoryKeyStorage: BarnardCoreKeyStorage {
   }
 }
 
-private final class DelayedKeyStorage: BarnardCoreKeyStorage {
-  private let lock = NSLock()
-  private let readDelay: TimeInterval
+private final class RendezvousKeyStorage: BarnardCoreKeyStorage {
+  private let condition = NSCondition()
+  private let readTimeout: TimeInterval
+  private var readCount = 0
   private var values: [String: [UInt8]] = [:]
 
-  init(readDelay: TimeInterval) {
-    self.readDelay = readDelay
+  init(readTimeout: TimeInterval) {
+    self.readTimeout = readTimeout
   }
 
   func bytes(forKey key: String) -> [UInt8]? {
-    Thread.sleep(forTimeInterval: readDelay)
-    lock.lock()
-    defer { lock.unlock() }
+    condition.lock()
+    readCount += 1
+    if readCount == 2 {
+      condition.broadcast()
+    } else {
+      let deadline = Date(timeIntervalSinceNow: readTimeout)
+      while readCount < 2 && condition.wait(until: deadline) {}
+    }
+    let value = values[key]
+    condition.unlock()
+    return value
+  }
+
+  func setBytes(_ bytes: [UInt8], forKey key: String) {
+    condition.lock()
+    values[key] = bytes
+    condition.unlock()
+  }
+
+  func storedBytes(forKey key: String) -> [UInt8]? {
+    condition.lock()
+    let value = values[key]
+    condition.unlock()
+    return value
+  }
+}
+
+private final class ReentrantKeyStorage: BarnardCoreKeyStorage {
+  private var values: [String: [UInt8]] = [:]
+  private(set) var nestedCallCount = 0
+
+  func bytes(forKey key: String) -> [UInt8]? {
+    if nestedCallCount == 0 {
+      nestedCallCount = 1
+      _ = BarnardCoreKeyManager.loadOrCreate(
+        key: "nested-device-secret",
+        minimumByteCount: 32,
+        generatedByteCount: 32,
+        storage: self,
+        randomSource: FixedRandomSource(bytes: [UInt8](repeating: 0x22, count: 32))
+      )
+    }
     return values[key]
   }
 
   func setBytes(_ bytes: [UInt8], forKey key: String) {
-    lock.lock()
     values[key] = bytes
-    lock.unlock()
-  }
-
-  func storedBytes(forKey key: String) -> [UInt8]? {
-    lock.lock()
-    defer { lock.unlock() }
-    return values[key]
   }
 }
 

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
@@ -65,15 +65,25 @@ final class BarnardCoreTests: XCTestCase {
     // calls, so the second read cannot rendezvous until the first transaction
     // has completed. An unfixed implementation reaches both reads together,
     // making the race deterministic without relying on sleeps or repetition.
-    DispatchQueue.concurrentPerform(iterations: 2) { index in
-      let loaded = BarnardCoreKeyManager.loadOrCreate(
-        key: key,
-        minimumByteCount: 32,
-        generatedByteCount: 32,
-        storage: storage,
-        randomSource: FixedRandomSource(bytes: secrets[index])
-      )
-      results.append(loaded)
+    let completed = DispatchGroup()
+    for index in secrets.indices {
+      completed.enter()
+      DispatchQueue.global().async {
+        defer { completed.leave() }
+        let loaded = BarnardCoreKeyManager.loadOrCreate(
+          key: key,
+          minimumByteCount: 32,
+          generatedByteCount: 32,
+          storage: storage,
+          randomSource: FixedRandomSource(bytes: secrets[index])
+        )
+        results.append(loaded)
+      }
+    }
+
+    guard completed.wait(timeout: .now() + 3) == .success else {
+      XCTFail("concurrent cold loads did not complete before the timeout")
+      return
     }
 
     let loadedValues = results.snapshot
@@ -92,9 +102,11 @@ final class BarnardCoreTests: XCTestCase {
 
   func testReentrantStorageCallbackDoesNotDeadlock() {
     let storage = ReentrantKeyStorage()
-    let completed = DispatchSemaphore(value: 0)
+    let completed = DispatchGroup()
+    completed.enter()
 
     DispatchQueue.global().async {
+      defer { completed.leave() }
       _ = BarnardCoreKeyManager.loadOrCreate(
         key: "outer-device-secret",
         minimumByteCount: 32,
@@ -102,14 +114,12 @@ final class BarnardCoreTests: XCTestCase {
         storage: storage,
         randomSource: FixedRandomSource(bytes: [UInt8](repeating: 0x11, count: 32))
       )
-      completed.signal()
     }
 
-    XCTAssertEqual(
-      completed.wait(timeout: .now() + 1),
-      .success,
-      "storage callbacks may synchronously re-enter loadOrCreate"
-    )
+    guard completed.wait(timeout: .now() + 3) == .success else {
+      XCTFail("re-entrant storage callback did not complete before the timeout")
+      return
+    }
     XCTAssertEqual(storage.nestedCallCount, 1)
   }
 

--- a/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
+++ b/packages/swift/barnard/Tests/BarnardCoreTests/BarnardCoreTests.swift
@@ -181,6 +181,7 @@ private final class RendezvousKeyStorage: BarnardCoreKeyStorage {
   private let condition = NSCondition()
   private let readTimeout: TimeInterval
   private var readCount = 0
+  private var rendezvousSnapshot: [UInt8]?
   private var values: [String: [UInt8]] = [:]
 
   init(readTimeout: TimeInterval) {
@@ -191,12 +192,16 @@ private final class RendezvousKeyStorage: BarnardCoreKeyStorage {
     condition.lock()
     readCount += 1
     if readCount == 2 {
+      // Capture the pre-write state while holding the barrier lock. Returning
+      // this shared snapshot to both readers keeps the unfixed race from
+      // passing merely because one reader re-acquires the lock after a write.
+      rendezvousSnapshot = values[key]
       condition.broadcast()
     } else {
       let deadline = Date(timeIntervalSinceNow: readTimeout)
       while readCount < 2 && condition.wait(until: deadline) {}
     }
-    let value = values[key]
+    let value = readCount >= 2 ? rendezvousSnapshot : values[key]
     condition.unlock()
     return value
   }


### PR DESCRIPTION
> **DRAFT — opened early to run `swift-android` against the `Dispatch` availability question.** The review gate is still in progress; do not merge or mark this PR ready for review yet.

## Why this is an early Draft

This change uses `Dispatch` inside `BarnardCore`, whose stdlib-only constraint forbids Foundation. No one has established that `Dispatch` is available on the Android Swift toolchain. The local cross-compile attempt was inconclusive because this machine has an Xcode-beta Swift 6.4 / Android SDK 6.3.3 mismatch. The `.github/workflows/native-sdk.yml` purity guard is a denylist that does not include `Dispatch`, so it would not catch this gap. This Draft is intentionally open now so `swift-android` can settle that question before another review gate.

## Defect and fix

Issue #125 is a silent cold-install race in `loadOrCreate`: concurrent callers can both observe an absent device secret, generate different values, and let one caller continue with bytes that storage no longer contains.

The fix:

- Serializes the complete read-check-generate-write transaction on a private `DispatchQueue`.
- Uses a queue-specific re-entry check so synchronous callback re-entry on the same execution context does not deadlock.
- Documents the unsupported cross-thread synchronous-wait callback contract and the returned-versus-stored divergence consequence of same-key recursive creation.
- Adds outer `DispatchGroup` timeout joins to both concurrency regression tests, so a hang before or after the inner storage wait fails the test rather than blocking CI.
- Makes the rendezvous deterministic by capturing the pre-write storage snapshot under the barrier lock before broadcasting it to both readers.

No on-wire payload shape changed, and no device-unique persistent identifier was added.

## Evidence

- The old test baseline, measured by the review seat against genuinely unfixed code, missed the defect 8/67 times.
- The new test was measured against the `d05420a` committed `BarnardCoreCrypto.swift` blob. Its blob SHA-1 is `d2c5157bd550e1d8a744b1f083747c8eadb6004b`; the SHA-256 content hash is `31b43f26c5cc123629da8b2d48b7c00862f9dfbb319932722dfb00a7cdf0e6f6`. The source was verified to contain no `Dispatch`, lock, or queue. Across 67 repetitions, 67 detected the race and 0 passed falsely: misses `0/67`.
- Fixed targeted tests passed 2/2 on iPhone 17 Pro / iOS 26.5 Simulator.
- Exact-head full suite at `0d597d6`: 81 passed, 0 failed, 0 skipped. Result bundle: `/private/tmp/barnard-full-0d597d6.xcresult`.
- `scripts/check-swift-mirror.sh` passes; canonical and Dart Swift mirrors remain byte-identical.

## Filesystem sweep and scope

The call-site sweep was built from the filesystem rather than the mirror manifest. It found and covered:

- The Dart iOS site the manifest did not expose.
- Two additional React Native iOS sites, both covered by their shared `NSLock`-protected store.
- Six Android sites, deliberately deferred to #129 and unchanged here.

## Recorded non-blocking items

- Android/Linux toolchain compatibility for `Dispatch` is unresolved until CI runs `swift-android`.
- A separate process sharing an App Group UserDefaults suite is outside this in-process queue's protection.
- A timeout failure can leave the deliberately hanging worker running; the bounded join still fails the test and does not block CI.

Closes #125
Refs #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-secret creation and storage to prevent inconsistent results during simultaneous access.
  * Added safeguards so reentrant storage operations complete without deadlocking.
  * Standardized secret retrieval across supported integrations.

* **Tests**
  * Added coverage for concurrent secret loading, persistence, and reentrant storage callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->