### PR TITLE
ci: raise swift-package job timeout to 60 minutes

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -36,7 +36,7 @@ jobs:
     # toolchain is installed in this job (barnard#56 acceptance criterion:
     # "CI validates each first-class SDK surface independently").
     runs-on: macos-15
-    timeout-minutes: 50
+    timeout-minutes: 60
     defaults:
       run:
         working-directory: packages/swift/barnard


### PR DESCRIPTION
## Summary

The `swift-package` CI job (`native-sdk.yml`) has been running with near-zero time margin. Several individual tests already take 2-13 minutes each under an unoptimized (`-Onone`) debug build of the BigInteger-based EC math in `BarnardSigning`/`BarnardCoreOwnerKey`, and the suite has been observed to hit the previous 50-minute limit and get cancelled mid-run — not from a test failure, but from the job simply running out of time. This has happened on `main` itself at least once, and is currently blocking #135 the same way (all individual tests in that run passed; the job was cancelled by the timeout after the suite grew by ~200s).

## Change

Raises `timeout-minutes` from 50 to 60 for the `swift-package` job.

## Follow-up (not addressed here)

- Optimize the debug test build, or split the suite, to restore real margin rather than just raising the ceiling again later.

## Test plan

- [ ] CI green on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the native SDK build workflow timeout to improve reliability for longer-running builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->