### PR TITLE
ci: build the Swift test target with optimizations enabled

### DIFF
--- a/.github/workflows/native-sdk.yml
+++ b/.github/workflows/native-sdk.yml
@@ -67,7 +67,13 @@ jobs:
             exit 1
           fi
       - name: swift test (Barnard compatibility + BarnardCore unit tests)
-        run: xcodebuild -scheme Barnard-Package -destination "id=${{ steps.destination.outputs.udid }}" test
+        # SWIFT_OPTIMIZATION_LEVEL=-O: the default -Onone debug build makes the
+        # BigInteger-based secp256k1 EC math ~9x slower under test, which was
+        # the actual cause of this job running with near-zero timeout margin
+        # (not test harness or Simulator overhead). -O strips bare `assert()`
+        # only (none present in Sources/Tests here; `precondition()` is
+        # unaffected), so numeric-correctness test behavior is unchanged.
+        run: xcodebuild -scheme Barnard-Package -destination "id=${{ steps.destination.outputs.udid }}" SWIFT_OPTIMIZATION_LEVEL=-O test
       - name: Root and inner Swift package manifest drift guard
         working-directory: .
         run: ./scripts/check-swift-package-manifest-mirror.sh


### PR DESCRIPTION
## Summary

Root-causes and fixes the `swift-package` job's near-zero timeout margin (see #136, which raised the timeout as a stopgap). The actual cause is not test harness or Simulator overhead: it's that the test step builds with the default `-Onone` (unoptimized) debug configuration, which makes this package's BigInteger-based secp256k1 EC math roughly 9x slower than an optimized build. Individual EC-heavy tests were taking 2-13 minutes each.

## Change

Adds `SWIFT_OPTIMIZATION_LEVEL=-O` to the `xcodebuild ... test` invocation in the `swift test` step only (the earlier `swift build` package-graph sanity check step is untouched).

## Why this is safe

- `-O` strips bare `assert()` calls but not `precondition()`. There are zero bare `assert(` calls anywhere in this package's `Sources` or `Tests`, so no test behavior changes.
- Debug configuration is otherwise unchanged (`ENABLE_TESTABILITY`/`@testable` still apply).
- Verified the override actually reaches the SPM-generated scheme via `xcodebuild -showBuildSettings`.

## Expected impact

Local benchmarking of this package's EC scalar multiplication showed a 9.4x speedup under `-O` vs `-Onone`, consistent with the per-test durations already visible in CI logs. Expected: test phase ~47min → ~5min, whole job ~8-12min — comfortable headroom against even the pre-#136 50-minute limit.

## Follow-up (not addressed here)

The 60-minute timeout from #136 can likely come back down once this is confirmed green in CI, but generous headroom is harmless, so left as-is.

## Test plan

- [ ] CI green, and confirm the job duration actually drops as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Swift package test build performance by enabling optimized compilation.
  * Preserved assertion and precondition behavior during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->