### PR TITLE
feat(android): owner key のプリミティブを BarnardIdentity から呼べるようにする (#133 追随)

### DIFF
--- a/examples/android-native/app/build.gradle.kts
+++ b/examples/android-native/app/build.gradle.kts
@@ -32,6 +32,16 @@ android {
             isMinifyEnabled = false
         }
     }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+        unitTests.all {
+            it.testLogging {
+                events("passed", "skipped", "failed", "standardOut", "standardError")
+                showStandardStreams = true
+            }
+        }
+    }
 }
 
 dependencies {
@@ -46,4 +56,12 @@ dependencies {
     // directly; UIAutomator/Espresso would only add a brittle UI layer.
     androidTestImplementation("androidx.test:runner:1.7.0")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
+
+    // JVM unit tests (barnard#133): prove BarnardIdentity's owner-key
+    // wrappers are reachable from a separate Gradle build, where Kotlin's
+    // `internal` is genuinely unreachable (unlike a same-module test, which
+    // Kotlin's Gradle plugin wires as a friend-path).
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("org.robolectric:robolectric:4.11.1")
 }

--- a/examples/android-native/app/src/test/kotlin/org/levarac/barnard/example/BarnardIdentityOwnerKeyPublicApiTest.kt
+++ b/examples/android-native/app/src/test/kotlin/org/levarac/barnard/example/BarnardIdentityOwnerKeyPublicApiTest.kt
@@ -1,0 +1,141 @@
+// Use of this source code is governed by a BSD-style license.
+
+package org.levarac.barnard.example
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.levarac.barnard.BarnardIdentity
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Reachability proof for the owner-key wrappers added to [BarnardIdentity]
+ * (barnard#133 follow-up). This module consumes `packages/android/barnard`
+ * as an external Gradle module dependency (see
+ * `examples/android-native/settings.gradle.kts`), a genuine build boundary
+ * where Kotlin's `internal` visibility is actually enforced — unlike a
+ * same-module test, which the Kotlin Gradle plugin wires as a friend-path
+ * of `src/main/kotlin`. This test would fail to *compile* if these six
+ * operations were reachable only via `internal object BarnardSigning`.
+ *
+ * Byte-exact conformance for these primitives is proven separately by
+ * `BarnardOwnerKeyConformanceVectorTest` in `packages/android/barnard`,
+ * against `test-vectors/owner-key-v1.txt`. This test reuses a few of those
+ * same fixed vector values, but only to keep inputs realistic — it is not a
+ * substitute for that conformance suite.
+ *
+ * `@Config(sdk = [34])`: this app module's `defaultConfig.targetSdk = 36`
+ * (pre-existing, unrelated to this task) exceeds Robolectric 4.11.1's max
+ * supported SDK (34, per `DefaultSdkPicker`); pin the simulated framework
+ * SDK for just this test class rather than touch shared module config.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class BarnardIdentityOwnerKeyPublicApiTest {
+    private fun newContext(): Context = ApplicationProvider.getApplicationContext()
+
+    private fun hex(value: String): ByteArray =
+        ByteArray(value.length / 2) { i -> value.substring(i * 2, i * 2 + 2).toInt(16).toByte() }
+
+    // test-vectors/owner-key-v1.txt: owner_zero_*
+    private val accountSecret = hex("0000000000000000000000000000000000000000000000000000000000000000")
+    private val expectedOwnerZeroPrivateKey = "46cbfd04992339fab4937354a6f24c115a238f4bd133a8c43b18162ab986bf27"
+    private val expectedOwnerZeroPublicKey = "03351e5165d083f53425fc4a51e7228d53e88eb2899bcb6a83368a8aafaa1de5f4"
+
+    // test-vectors/owner-key-v1.txt: binding_*
+    private val bindingDomain = "beid.levarac.org"
+    private val bindingWalletAddress = hex("14791697260e4c9a71f18484c9f997b308e59325")
+    private val bindingOwnerPublicKey = hex("03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67")
+    private val bindingChainId = 1uL
+    private val bindingNonce = hex("000102030405060708090a0b0c0d0e0f")
+    private val bindingIssuedAt = "2026-07-30T09:00:00Z"
+
+    // test-vectors/owner-key-v1.txt: selfproof_*
+    private val selfProofEventIdHash = hex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+    private val selfProofEventSigningPublicKey = hex("02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5")
+    private val selfProofEninStart = 12uL
+    private val selfProofEninEnd = 34uL
+    private val selfProofOwnerPrivateKey = "0000000000000000000000000000000000000000000000000000000000000001"
+    private val selfProofOwnerPublicKey = hex("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+
+    // test-vectors/owner-key-v1.txt: walletack_*
+    private val walletAckWalletAddress = hex("202122232425262728292a2b2c2d2e2f30313233")
+    private val walletAckWalletSignature = hex(
+        "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f80",
+    )
+    private val walletAckOwnerPrivateKey = "0000000000000000000000000000000000000000000000000000000000000001"
+
+    @Test
+    fun deriveOwnerKeyPairIsReachableAndMatchesVector() {
+        val identity = BarnardIdentity(newContext())
+        val keyPair = identity.deriveOwnerKeyPair(accountSecret)
+        assertEquals(expectedOwnerZeroPrivateKey, keyPair.privateKey)
+        assertEquals(expectedOwnerZeroPublicKey, keyPair.publicKeyCompressed)
+    }
+
+    @Test
+    fun buildAccountBindingTextIsReachable() {
+        val identity = BarnardIdentity(newContext())
+        val text = identity.buildAccountBindingText(
+            domain = bindingDomain,
+            walletAddress = bindingWalletAddress,
+            ownerPublicKey = bindingOwnerPublicKey,
+            chainId = bindingChainId,
+            nonce = bindingNonce,
+            issuedAt = bindingIssuedAt,
+        )
+        assertNotNull(text)
+    }
+
+    @Test
+    fun buildSelfProofMessageIsReachable() {
+        val identity = BarnardIdentity(newContext())
+        val message = identity.buildSelfProofMessage(
+            eventIdHash = selfProofEventIdHash,
+            eventSigningPublicKey = selfProofEventSigningPublicKey,
+            eninStart = selfProofEninStart,
+            eninEnd = selfProofEninEnd,
+            ownerPublicKey = selfProofOwnerPublicKey,
+        )
+        assertNotNull(message)
+    }
+
+    @Test
+    fun signSelfProofIsReachable() {
+        val identity = BarnardIdentity(newContext())
+        val sig = identity.signSelfProof(
+            ownerPrivateKey = selfProofOwnerPrivateKey,
+            eventIdHash = selfProofEventIdHash,
+            eventSigningPublicKey = selfProofEventSigningPublicKey,
+            eninStart = selfProofEninStart,
+            eninEnd = selfProofEninEnd,
+            ownerPublicKey = selfProofOwnerPublicKey,
+        )
+        assertNotNull(sig)
+    }
+
+    @Test
+    fun buildWalletAcknowledgementMessageIsReachable() {
+        val identity = BarnardIdentity(newContext())
+        val message = identity.buildWalletAcknowledgementMessage(
+            walletAddress = walletAckWalletAddress,
+            walletSignature = walletAckWalletSignature,
+        )
+        assertNotNull(message)
+    }
+
+    @Test
+    fun signWalletAcknowledgementIsReachable() {
+        val identity = BarnardIdentity(newContext())
+        val sig = identity.signWalletAcknowledgement(
+            ownerPrivateKey = walletAckOwnerPrivateKey,
+            walletAddress = walletAckWalletAddress,
+            walletSignature = walletAckWalletSignature,
+        )
+        assertNotNull(sig)
+    }
+}

--- a/examples/android-native/app/src/test/kotlin/org/levarac/barnard/example/BarnardIdentityOwnerKeyPublicApiTest.kt
+++ b/examples/android-native/app/src/test/kotlin/org/levarac/barnard/example/BarnardIdentityOwnerKeyPublicApiTest.kt
@@ -4,8 +4,9 @@ package org.levarac.barnard.example
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.levarac.barnard.BarnardIdentity
@@ -53,6 +54,19 @@ class BarnardIdentityOwnerKeyPublicApiTest {
     private val bindingChainId = 1uL
     private val bindingNonce = hex("000102030405060708090a0b0c0d0e0f")
     private val bindingIssuedAt = "2026-07-30T09:00:00Z"
+    private val expectedBindingText = """
+        beid.levarac.org wants to bind this wallet to a Levarac owner key.
+
+        This signature authorizes no transaction and moves no assets.
+
+        Domain-Tag: barnard-account-binding:v1
+        Wallet: 0x14791697260e4c9a71f18484c9f997b308e59325
+        Owner-Key: 0x03879beac8b548009124867a99a358aeb34ff42f957f868bbc83339568b16d9c67
+        Chain-ID: eip155:1
+        Scope: global
+        Nonce: 0x000102030405060708090a0b0c0d0e0f
+        Issued-At: 2026-07-30T09:00:00Z
+    """.trimIndent()
 
     // test-vectors/owner-key-v1.txt: selfproof_*
     private val selfProofEventIdHash = hex("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
@@ -61,6 +75,12 @@ class BarnardIdentityOwnerKeyPublicApiTest {
     private val selfProofEninEnd = 34uL
     private val selfProofOwnerPrivateKey = "0000000000000000000000000000000000000000000000000000000000000001"
     private val selfProofOwnerPublicKey = hex("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+    private val expectedSelfProofMessage = hex("6261726e6172642d73656c662d70726f6f663a7631000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5000000000000000c00000000000000220279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798")
+    private val expectedSelfProofSignature = Triple(
+        "61a5c17538920d8129030611976278ef32cd938b6ddff2c878a35f37a6b453ba",
+        "28260168d623191d83fc9dfc160e984b8452573a1a0450226859f188cf23e6b1",
+        1,
+    )
 
     // test-vectors/owner-key-v1.txt: walletack_*
     private val walletAckWalletAddress = hex("202122232425262728292a2b2c2d2e2f30313233")
@@ -68,6 +88,12 @@ class BarnardIdentityOwnerKeyPublicApiTest {
         "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f80",
     )
     private val walletAckOwnerPrivateKey = "0000000000000000000000000000000000000000000000000000000000000001"
+    private val expectedWalletAckMessage = hex("6261726e6172642d77616c6c65742d61636b3a7631202122232425262728292a2b2c2d2e2f303132336dccac7549efb1d8c9e30f9c4d387b5b435456376a60633decd23a7373336a93")
+    private val expectedWalletAckSignature = Triple(
+        "ff288f4744a3977c74c6b2743992115a460deb46ff6ad92e57ffc70257d017a9",
+        "76e7b55c7505aab7e832a289fdf032825722ca745f9bf299d50418e6e3aaca67",
+        0,
+    )
 
     @Test
     fun deriveOwnerKeyPairIsReachableAndMatchesVector() {
@@ -78,7 +104,7 @@ class BarnardIdentityOwnerKeyPublicApiTest {
     }
 
     @Test
-    fun buildAccountBindingTextIsReachable() {
+    fun buildAccountBindingTextIsReachableAndMatchesVector() {
         val identity = BarnardIdentity(newContext())
         val text = identity.buildAccountBindingText(
             domain = bindingDomain,
@@ -88,11 +114,11 @@ class BarnardIdentityOwnerKeyPublicApiTest {
             nonce = bindingNonce,
             issuedAt = bindingIssuedAt,
         )
-        assertNotNull(text)
+        assertEquals(expectedBindingText, text)
     }
 
     @Test
-    fun buildSelfProofMessageIsReachable() {
+    fun buildSelfProofMessageIsReachableAndMatchesVector() {
         val identity = BarnardIdentity(newContext())
         val message = identity.buildSelfProofMessage(
             eventIdHash = selfProofEventIdHash,
@@ -101,11 +127,11 @@ class BarnardIdentityOwnerKeyPublicApiTest {
             eninEnd = selfProofEninEnd,
             ownerPublicKey = selfProofOwnerPublicKey,
         )
-        assertNotNull(message)
+        assertArrayEquals(expectedSelfProofMessage, message)
     }
 
     @Test
-    fun signSelfProofIsReachable() {
+    fun signSelfProofIsReachableAndMatchesVector() {
         val identity = BarnardIdentity(newContext())
         val sig = identity.signSelfProof(
             ownerPrivateKey = selfProofOwnerPrivateKey,
@@ -115,27 +141,61 @@ class BarnardIdentityOwnerKeyPublicApiTest {
             eninEnd = selfProofEninEnd,
             ownerPublicKey = selfProofOwnerPublicKey,
         )
-        assertNotNull(sig)
+        assertEquals(expectedSelfProofSignature.first, sig?.r)
+        assertEquals(expectedSelfProofSignature.second, sig?.s)
+        assertEquals(expectedSelfProofSignature.third, sig?.v)
     }
 
     @Test
-    fun buildWalletAcknowledgementMessageIsReachable() {
+    fun buildWalletAcknowledgementMessageIsReachableAndMatchesVector() {
         val identity = BarnardIdentity(newContext())
         val message = identity.buildWalletAcknowledgementMessage(
             walletAddress = walletAckWalletAddress,
             walletSignature = walletAckWalletSignature,
         )
-        assertNotNull(message)
+        assertArrayEquals(expectedWalletAckMessage, message)
     }
 
     @Test
-    fun signWalletAcknowledgementIsReachable() {
+    fun signWalletAcknowledgementIsReachableAndMatchesVector() {
         val identity = BarnardIdentity(newContext())
         val sig = identity.signWalletAcknowledgement(
             ownerPrivateKey = walletAckOwnerPrivateKey,
             walletAddress = walletAckWalletAddress,
             walletSignature = walletAckWalletSignature,
         )
-        assertNotNull(sig)
+        assertEquals(expectedWalletAckSignature.first, sig?.r)
+        assertEquals(expectedWalletAckSignature.second, sig?.s)
+        assertEquals(expectedWalletAckSignature.third, sig?.v)
+    }
+
+    @Test
+    fun signingWrappersRejectNonCanonicalOwnerPrivateKeysWithoutThrowing() {
+        val identity = BarnardIdentity(newContext())
+        val invalidPrivateKeys = listOf(
+            "1",
+            expectedOwnerZeroPrivateKey.uppercase(),
+            "g".repeat(64),
+        )
+
+        invalidPrivateKeys.forEach { ownerPrivateKey ->
+            assertNull(
+                identity.signSelfProof(
+                    ownerPrivateKey = ownerPrivateKey,
+                    eventIdHash = selfProofEventIdHash,
+                    eventSigningPublicKey = selfProofEventSigningPublicKey,
+                    eninStart = selfProofEninStart,
+                    eninEnd = selfProofEninEnd,
+                    ownerPublicKey = selfProofOwnerPublicKey,
+                ),
+            )
+            assertNull(
+                identity.signWalletAcknowledgement(
+                    ownerPrivateKey = ownerPrivateKey,
+                    walletAddress = walletAckWalletAddress,
+                    walletSignature = walletAckWalletSignature,
+                ),
+            )
+        }
     }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardIdentity.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardIdentity.kt
@@ -162,7 +162,7 @@ public class BarnardIdentity(private val appContext: Context) {
         ownerPublicKey: ByteArray,
     ): BarnardRecoverableSignature? {
         val sig = BarnardSigning.signSelfProof(
-            hexToBigInteger(ownerPrivateKey),
+            parseOwnerPrivateKey(ownerPrivateKey) ?: return null,
             eventIdHash,
             eventSigningPublicKey,
             eninStart,
@@ -193,7 +193,11 @@ public class BarnardIdentity(private val appContext: Context) {
         walletAddress: ByteArray,
         walletSignature: ByteArray,
     ): BarnardRecoverableSignature? {
-        val sig = BarnardSigning.signWalletAcknowledgement(hexToBigInteger(ownerPrivateKey), walletAddress, walletSignature)
+        val sig = BarnardSigning.signWalletAcknowledgement(
+            parseOwnerPrivateKey(ownerPrivateKey) ?: return null,
+            walletAddress,
+            walletSignature,
+        )
             ?: return null
         return BarnardRecoverableSignature(r = sig.r.toHex(), s = sig.s.toHex(), v = sig.v)
     }
@@ -237,5 +241,8 @@ public class BarnardIdentity(private val appContext: Context) {
         return fixed.toHex()
     }
 
-    private fun hexToBigInteger(hex: String): BigInteger = BigInteger(hex, 16)
+    private fun parseOwnerPrivateKey(hex: String): BigInteger? {
+        if (!Regex("[0-9a-f]{64}").matches(hex)) return null
+        return BigInteger(hex, 16)
+    }
 }

--- a/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardIdentity.kt
+++ b/packages/android/barnard/src/main/kotlin/org/levarac/barnard/BarnardIdentity.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.util.Base64
 import org.levarac.barnard.BarnardCrypto.toHex
+import java.math.BigInteger
 import java.security.MessageDigest
 
 /** Recoverable secp256k1 signature `(r, s, v)`, Kotlin-first mirror of [BarnardSigning.RecoverableSignature]. */
@@ -20,6 +21,12 @@ public data class BarnardRpidOwnershipProof(
     val rpi: String,
     val signingPublicKey: String,
     val signature: BarnardRecoverableSignature,
+)
+
+/** The long-lived owner keypair (barnard#133 / barnard#92), Kotlin-first mirror of [BarnardSigning.SigningKeyPair]. */
+public data class BarnardOwnerKeyPair(
+    val privateKey: String,
+    val publicKeyCompressed: String,
 )
 
 /**
@@ -85,6 +92,112 @@ public class BarnardIdentity(private val appContext: Context) {
         return BarnardRecoverableSignature(r = sig.r.toHex(), s = sig.s.toHex(), v = sig.v)
     }
 
+    // MARK: - Owner key: account binding, self-proof, wallet acknowledgement (barnard#133 / barnard#92)
+    //
+    // Unlike signingPublicKey/sign/proveRpidOwnership/proveKeyBinding above,
+    // these six do not use appContext or the device secret — the owner key
+    // is rooted in an externally supplied account secret, not the device.
+    // They live on this same public wrapper anyway: Android's BarnardSigning
+    // is a single internal object (not split into a public "Core" + a
+    // public "Identity" layer like Swift's BarnardCore/BarnardIdentity), so
+    // this is the pragmatic Android equivalent of Swift's surface.
+
+    /**
+     * Derives the long-lived owner keypair from a 32-byte [accountSecret]
+     * (barnard#133 / barnard#92). See [BarnardSigning.deriveOwnerKeyPair].
+     */
+    public fun deriveOwnerKeyPair(accountSecret: ByteArray): BarnardOwnerKeyPair {
+        val keyPair = BarnardSigning.deriveOwnerKeyPair(accountSecret)
+        return BarnardOwnerKeyPair(
+            privateKey = fixedHex32(keyPair.privateKey),
+            publicKeyCompressed = keyPair.publicKeyCompressed.toHex(),
+        )
+    }
+
+    /**
+     * Canonical, EIP-4361-shaped text for an external wallet SDK to sign
+     * with `personal_sign`, binding [walletAddress] to [ownerPublicKey]
+     * (barnard#133 / barnard#92). Returns `null` on any guard failure. See
+     * [BarnardSigning.buildAccountBindingText].
+     */
+    public fun buildAccountBindingText(
+        domain: String,
+        walletAddress: ByteArray,
+        ownerPublicKey: ByteArray,
+        chainId: ULong,
+        nonce: ByteArray,
+        issuedAt: String,
+    ): String? {
+        return BarnardSigning.buildAccountBindingText(domain, walletAddress, ownerPublicKey, chainId, nonce, issuedAt)
+    }
+
+    /**
+     * Canonical self-proof claim message binding [eventSigningPublicKey] to
+     * [ownerPublicKey] for the ENIN range `[eninStart, eninEnd]`
+     * (barnard#133 / barnard#92). Returns `null` on any guard failure. See
+     * [BarnardSigning.buildSelfProofMessage].
+     */
+    public fun buildSelfProofMessage(
+        eventIdHash: ByteArray,
+        eventSigningPublicKey: ByteArray,
+        eninStart: ULong,
+        eninEnd: ULong,
+        ownerPublicKey: ByteArray,
+    ): ByteArray? {
+        return BarnardSigning.buildSelfProofMessage(eventIdHash, eventSigningPublicKey, eninStart, eninEnd, ownerPublicKey)
+    }
+
+    /**
+     * Signs the self-proof claim per [buildSelfProofMessage] with
+     * [ownerPrivateKey] (lowercase hex), after confirming it actually
+     * derives [ownerPublicKey] (barnard#133 / barnard#92). Returns `null` on
+     * any guard failure. See [BarnardSigning.signSelfProof].
+     */
+    public fun signSelfProof(
+        ownerPrivateKey: String,
+        eventIdHash: ByteArray,
+        eventSigningPublicKey: ByteArray,
+        eninStart: ULong,
+        eninEnd: ULong,
+        ownerPublicKey: ByteArray,
+    ): BarnardRecoverableSignature? {
+        val sig = BarnardSigning.signSelfProof(
+            hexToBigInteger(ownerPrivateKey),
+            eventIdHash,
+            eventSigningPublicKey,
+            eninStart,
+            eninEnd,
+            ownerPublicKey,
+        ) ?: return null
+        return BarnardRecoverableSignature(r = sig.r.toHex(), s = sig.s.toHex(), v = sig.v)
+    }
+
+    /**
+     * Canonical wallet-acknowledgement claim message counter-signing one
+     * exact [walletSignature] over [walletAddress] (barnard#133 /
+     * barnard#92). Returns `null` on any guard failure. See
+     * [BarnardSigning.buildWalletAcknowledgementMessage].
+     */
+    public fun buildWalletAcknowledgementMessage(walletAddress: ByteArray, walletSignature: ByteArray): ByteArray? {
+        return BarnardSigning.buildWalletAcknowledgementMessage(walletAddress, walletSignature)
+    }
+
+    /**
+     * Signs the wallet-acknowledgement claim per
+     * [buildWalletAcknowledgementMessage] with [ownerPrivateKey] (lowercase
+     * hex, barnard#133 / barnard#92). Returns `null` on any guard failure.
+     * See [BarnardSigning.signWalletAcknowledgement].
+     */
+    public fun signWalletAcknowledgement(
+        ownerPrivateKey: String,
+        walletAddress: ByteArray,
+        walletSignature: ByteArray,
+    ): BarnardRecoverableSignature? {
+        val sig = BarnardSigning.signWalletAcknowledgement(hexToBigInteger(ownerPrivateKey), walletAddress, walletSignature)
+            ?: return null
+        return BarnardRecoverableSignature(r = sig.r.toHex(), s = sig.s.toHex(), v = sig.v)
+    }
+
     // MARK: - DeviceSecret Management
     //
     // Same storage key as BarnardEngine.getOrCreateDeviceSecret — the
@@ -103,4 +216,26 @@ public class BarnardIdentity(private val appContext: Context) {
         prefs.edit().putString(key, Base64.encodeToString(bytes, Base64.NO_WRAP)).apply()
         return bytes
     }
+
+    // MARK: - Owner-key hex <-> BigInteger conversion (barnard#133 / barnard#92)
+    //
+    // BarnardSigning keeps private keys as BigInteger internally and its own
+    // fixed-width encoder (toFixedBytes(value, 32)) is private to that file
+    // by design. These are a small local duplicate scoped to the hex string
+    // boundary this public wrapper needs, so BarnardSigning.kt does not need
+    // any visibility change.
+
+    /** Fixed-width 32-byte big-endian lowercase hex, matching the convention `BarnardSigning`'s own `toFixedBytes(value, 32)` uses internally. */
+    private fun fixedHex32(value: BigInteger): String {
+        val raw = value.toByteArray()
+        val trimmed = if (raw.size > 32 && raw[0] == 0.toByte()) raw.copyOfRange(raw.size - 32, raw.size) else raw
+        val fixed = when {
+            trimmed.size == 32 -> trimmed
+            trimmed.size < 32 -> ByteArray(32 - trimmed.size) + trimmed
+            else -> trimmed.copyOfRange(trimmed.size - 32, trimmed.size)
+        }
+        return fixed.toHex()
+    }
+
+    private fun hexToBigInteger(hex: String): BigInteger = BigInteger(hex, 16)
 }


### PR DESCRIPTION
Refs #133。**PR #135 の追随であり、同じ issue がまだ解けていなかったことへの修正**です。

## v0.4.0 では #133 は解けていませんでした

#135(こちらが出した PR)は 4 群のプリミティブを実装しましたが、**`internal object BarnardSigning` の中に置き、公開ラッパー `BarnardIdentity` を拡張しませんでした**。結果、消費者からは呼べません。

`thegreeting/beid` 側が実プロジェクトでコンパイルして確認しています:

```
Cannot access 'object BarnardSigning : Any': it is internal in file.
```

**「コードがリリースに入っている」と「消費者が使える」は別の主張**で、#133 が求めていたのは後者でした。**#135 のレビューは前者しか見ていませんでした。** こちらの落ち度です。

実装の置き場所としての判断(既存の `internal object` に足す。別ファイルにすると同一 Kotlin モジュール内に 2 つ目の secp256k1 実装が生まれる)は正しかったと考えていますが、**公開面を誰も確認しませんでした**。

## 変更

`BarnardIdentity` に 6 つの public メソッドと `BarnardOwnerKeyPair` を追加:

`deriveOwnerKeyPair` / `buildAccountBindingText` / `buildSelfProofMessage` / `signSelfProof` / `buildWalletAcknowledgementMessage` / `signWalletAcknowledgement`

いずれも `BarnardSigning` への**薄い委譲と hex の変換のみ**です。

**`BarnardSigning.kt` の差分はゼロです。** 実装にも可視性にも触れていません。**可視性のみの変更**です。

鍵と署名は hex `String` で公開境界を渡します。同ファイルの既存の規約(`signingPublicKey(): String`、`BarnardRecoverableSignature.r/s: String`)に合わせました。バイト列の引数は `ByteArray` のままで、こちらも `sign()` / `proveKeyBinding()` に合わせています。

## 証明はモジュール外から取っています — ここが今回の要点

**同一モジュールのテストではこの不具合を捕まえられません。**

Kotlin の `internal` は同一モジュール内では見えます。#135 が追加した `BarnardOwnerKeyConformanceVectorTest` は**同じモジュール・同じパッケージ**にあり、今日も問題なくコンパイルが通ります。**それがこの不具合を見逃した理由そのものです。**

そこで `examples/android-native` にテストを置きました。ここは `includeBuild` + `dependencySubstitution` で本パッケージを消費する**別の Gradle ビルド**であり、しかも `packages/android/barnard/README.md` が「Installation」として示している経路です。**friend path が無いため `internal` はここから見えません。**

変更前の状態では `:app:compileDebugUnitTestKotlin` が **6 件の `Unresolved reference`** で失敗します(各メソッド名につき 1 件)。

## 検証

- `examples/android-native` — `./gradlew test --rerun-tasks` → **6/6 pass**(debug / release の両 variant)
- `packages/android/barnard` — `./gradlew test --rerun-tasks` → **94 tests / 0 failures**(JUnit XML を直接集計、mtime が当該実行のものであることを確認)
  - `BarnardOwnerKeyConformanceVectorTest` 4/4、`BarnardIdentityTest` 5/5、`BarnardSigningTest` 25/25 —— **いずれも無変更で pass**
- `assembleDebug` / `assembleRelease` 成功
- `./scripts/check-android-mirror.sh` → **OK**(`BarnardIdentity.kt` は `mirror-manifest.sh` の対象外)

JDK は Temurin 17(CI の `actions/setup-java@v4` / `temurin` / `"17"` と一致)。

## Swift との対応

Swift は同じ 6 操作を `BarnardCoreSigning` の `public static func` として公開しています。Swift 側の `BarnardIdentity` は owner key を包んでおらず、**2 層構造(公開 Core 層)を持つ点は Android と異なります**が、**関数レベルの公開面は 1 対 1 で一致**します —— 同じ 6 操作、過不足なし。

Android に公開 Core 層を新設するか、この形で揃えるかは barnard 側の設計判断なので、**別の形が望ましければ従います**。

## 付随する変更

`examples/android-native/app/build.gradle.kts` に JVM unit test の設定を足しました(`packages/android/barnard` に既にあるものと同形)。このモジュールは instrumented test しか持っていませんでした。

Robolectric 4.11.1 の対応 SDK 上限(34)が同モジュールの既存 `targetSdk = 36` を下回るため、**新しいテストクラス 1 つだけ**に `@Config(sdk = [34])` を付けています。production コードにも共有ビルド設定にも触れていません。Robolectric を上げるかどうかは別の判断だと考えます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Android support for deriving owner key pairs.
  - Added APIs to build account-binding, self-proof, and wallet-acknowledgement messages.
  - Added signing support for self-proofs and wallet acknowledgements.
  - Invalid owner private keys are safely rejected without throwing errors.

- **Tests**
  - Added JVM tests covering owner-key operations and fixed test vectors.
  - Added validation for external-module API access and invalid key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->