### PR TITLE
docs(release): add known-consumer version checklist

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -58,6 +58,48 @@ For a local fallback, put `mavenCentralUsername`, `mavenCentralPassword`,
 `~/.gradle/gradle.properties`. Then run the manual Maven Central publish command
 from `packages/android/barnard`; it uses the same automatic release behavior.
 
+## Known-consumer version checklist
+
+Barnard has one whole-monorepo version. For a release `vX.Y.Z`, every known
+consumer reference below must resolve to `X.Y.Z`. This checklist is a
+consumer-side release gate: it proves that Beid is configured to consume the
+published Barnard version; it is not evidence that Barnard itself was built or
+published correctly.
+
+Perform these steps in the Beid checkout only after both distribution surfaces
+are available to consumers: Maven `org.levarac:barnard:X.Y.Z` and the
+corresponding reachable Git tag `vX.Y.Z`. Do not change consumer pins or
+resolve Swift Package Manager until both are available:
+
+1. Set the Android dependency in
+   `android/app/build.gradle.kts` to `org.levarac:barnard:X.Y.Z`.
+2. Set the iOS dependency version in `ios/project.yml`. Its `exactVersion`
+   value is the iOS source of truth and must be `X.Y.Z`.
+3. Regenerate `ios/Beid.xcodeproj/project.pbxproj` from `ios/project.yml`.
+   The generated project file is a downstream representation of `project.yml`;
+   do not edit it to establish or override the version.
+4. Resolve Swift Package Manager dependencies, then commit
+   `ios/Beid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`.
+   `Package.resolved` is also downstream: it records the resolver's selected
+   package version and must not be treated as an authority over
+   `ios/project.yml`.
+5. Independently inspect all four references—`android/app/build.gradle.kts`,
+   `ios/project.yml`, `ios/Beid.xcodeproj/project.pbxproj`, and
+   `ios/Beid.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`—and
+   confirm that each records `X.Y.Z` for Barnard. A disagreement is a release
+   blocker: return to `ios/project.yml`, regenerate, and resolve again rather
+   than hand-editing either downstream file.
+6. Capture consumer-side evidence by completing Swift Package Manager
+   resolution and a Beid build that uses the resolved package. Record both
+   results with the release change. This evidence validates the consumer
+   integration only; it does not replace the Barnard package's own build and
+   publication evidence.
+
+As a lightweight safeguard, add a consumer-side mismatch check that extracts
+the Barnard version from these four files and fails when the values differ. It
+should run where Beid changes its Barnard dependency, but this repository does
+not implement or configure that check for Beid.
+
 Revisit whole-monorepo versioning if repository size grows enough to hurt
 consumer fetches or if platforms genuinely need divergent versioning. At that
 point, evaluate a CI-published distribution repository.


### PR DESCRIPTION
## Why

The Beid v0.4.0 dependency bump (thegreeting/beid#296) updated the iOS `.xcodeproj` pbxproj pin and `Package.resolved` to 0.4.0, but did not update `ios/project.yml`'s `exactVersion`, which stayed at 0.3.0. Since `project.yml` is Beid's own xcodegen source of truth (regenerated on every build), every subsequent iOS build silently re-derived the pbxproj back to 0.3.0 — discovered and documented while debugging thegreeting/beid#299.

This is a docs-only fix at the source: a checklist enumerating every known consumer reference that must move together on a Barnard release.

## What

Adds a "Known-consumer version checklist" section to `RELEASING.md`:
- Names all 4 known Beid pins (Android Gradle coordinate, iOS `project.yml`, generated `project.pbxproj`, `Package.resolved`).
- States explicitly that `project.yml` is authoritative and the other iOS files are downstream — never edit them to establish or override the version.
- Requires both the Maven artifact and the matching Git tag to be reachable before a consumer updates.
- Recommends (without implementing) a lightweight consumer-side CI check that fails on a version mismatch across the four files.

No other files changed. Verified by an independent checker in a separate worktree (diff-check clean, docs-only) before this PR.

_Generated by [Claude Code](https://claude.ai/code)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a release checklist for keeping Android, iOS, generated Xcode, and Swift Package Manager references aligned with the released version.
  - Documented required regeneration, dependency resolution, independent consistency checks, and consumer build verification.
  - Identified the authoritative iOS configuration source and clarified that distribution must be available before updating consumer references.
  - Added a recommendation for a future mismatch-detection safeguard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->